### PR TITLE
Fix check for same atoms in DihedralParamList.add_param() function

### DIFF
--- a/chemistry/amber/parameters.py
+++ b/chemistry/amber/parameters.py
@@ -310,7 +310,7 @@ class DihedralParamList(ParamList):
                 (oparam[0].dihtype == 'normal' and
                  param.dihtype == 'improper')):
                 continue
-            if oparam.same_atoms((atype1, atype2, atype3, atype4)):
+            if oparam.same_atoms((atype1, atype2, atype3, atype4))[0]:
                 added = True
                 oparam.add_term(param)
                 break


### PR DESCRIPTION
Add subscript 0 to oparam.same_atoms() return value in DihedralParamList.add_param(). We want the first value (same_atoms) in the tuple.

I noticed when dumping an frcmod file from ParmEd that the dihedrals were being written with identical atom type quadruplets (and unique pk, pn, phase terms). Tracked the bug to a subscript that was present in old versions of parameters.py but appeared to have been lost in a revision of the DihedralParamList.add_param() function.
