### PR TITLE
Simplify setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ packages = ['ParmedTools', 'ParmedTools.gui', 'ParmedTools.simulations']
 # Next the main chemistry packages
 packages += ['chemistry', 'chemistry.amber', 'chemistry.modeller',
              'chemistry.tinker', 'chemistry.unit', 'chemistry.amber.mdin',
-             'chemistry.charmm', 'chemistry.openmm', 'chemistry.formats.pdbx',
-             'chemistry.formats', 'fortranformat']
+             'chemistry.charmm', 'chemistry.formats.pdbx', 'chemistry.formats',
+             'fortranformat']
 
 # Modules
 modules = ['compat24']
@@ -28,31 +28,8 @@ extensions = [Extension('chemistry.amber._rdparm',
 # See if our Python version will support OpenMM. Of the ParmEd-supported
 # Pythons, only 2.4 and 2.5 do not work with OpenMM
 major, minor = sys.version_info[:2]
-supports_omm = major > 2 or minor >= 6
-
-def delete_omm_files():
-    """ Deletes OpenMM modules in chemistry """
-    join = os.path.join
-    files = [join('chemistry', 'amber', 'openmmloader.py'),
-             join('chemistry', 'charmm', 'openmmloader.py'),
-             join('chemistry', 'amber', 'openmmreporters.py'),
-             join('chemistry', 'unit', 'doctests.py')]
-    ret = dict()
-    for f in files:
-        ret[f] = open(f, 'r').read()
-    for f in files:
-        os.unlink(f)
-    return ret
-
-def restore_omm_files(filemap):
-    """
-    Takes the return value of "delete_omm_files" and restores the files to
-    their original greatness :)
-    """
-    # Py3 support not important here, since this code is only executed for
-    # Python 2.5 and older
-    for f, text in filemap.iteritems():
-        open(f, 'w').write(text)
+if major > 2 or minor >= 6:
+    packages.append('chemistry.openmm')
 
 if __name__ == '__main__':
 
@@ -75,33 +52,15 @@ if __name__ == '__main__':
                     if not 'has_key' in x and not 'itertools_imports' in x]
         Mixin2to3.fixer_names = fixers
 
-    if not supports_omm:
-        filemap = delete_omm_files()
-        try:
-            setup(name='ParmEd',
-                  version='SA_1.1.1', # standalone release version
-                  description='Amber parameter file editor',
-                  author='Jason Swails',
-                  author_email='jason.swails -at- gmail.com',
-                  url='http://jswails.wikidot.com/parmed',
-                  license='GPL v2 or later',
-                  packages=packages,
-                  py_modules=modules,
-                  ext_modules=extensions,
-                  cmdclass={'build_py':build_py, 'build_scripts':build_scripts},
-                  scripts=scripts)
-        finally:
-            restore_omm_files(filemap)
-    else:
-        setup(name='ParmEd',
-              version='SA_1.1.1', # standalone release version
-              description='Amber parameter file editor',
-              author='Jason Swails',
-              author_email='jason.swails -at- gmail.com',
-              url='http://jswails.wikidot.com/parmed',
-              license='GPL v2 or later',
-              packages=packages,
-              py_modules=modules,
-              ext_modules=extensions,
-              cmdclass={'build_py':build_py, 'build_scripts':build_scripts},
-              scripts=scripts)
+    setup(name='ParmEd',
+          version='15.0b',
+          description='Amber parameter file editor',
+          author='Jason Swails',
+          author_email='jason.swails -at- gmail.com',
+          url='http://jswails.wikidot.com/parmed',
+          license='GPL v2 or later',
+          packages=packages,
+          py_modules=modules,
+          ext_modules=extensions,
+          cmdclass={'build_py':build_py, 'build_scripts':build_scripts},
+          scripts=scripts)


### PR DESCRIPTION
This fixes builds when the Python version is <= 2.6 by simply omitting the
openmm package in that case (since it has Py24/Py25-incompatible syntax).