### PR TITLE
Attempt to prevent random Travis failures

### DIFF
--- a/test/test_openmm_amber.py
+++ b/test/test_openmm_amber.py
@@ -89,6 +89,11 @@ def decomposed_energy(context, parm, NRG_UNIT=u.kilocalories_per_mole):
 
 class TestAmberParm(utils.TestCaseRelative):
 
+    def tearDown(self):
+        import gc
+        # Try to force garbage collection
+        gc.collect()
+
     def testEPEnergy(self):
         """ Tests AmberParm handling of extra points in TIP4P water """
         parm = tip4p_system
@@ -737,6 +742,11 @@ class TestAmberParm(utils.TestCaseRelative):
 
 class TestChamberParm(utils.TestCaseRelative):
     
+    def tearDown(self):
+        import gc
+        # Try to force garbage collection
+        gc.collect()
+
     def testGasEnergy(self):
         """ Compare OpenMM and CHAMBER gas phase energies """
         parm = chamber_gas_system

--- a/test/test_openmm_charmm.py
+++ b/test/test_openmm_charmm.py
@@ -69,6 +69,11 @@ if has_openmm:
 
 class TestCharmmFiles(utils.TestCaseRelative):
 
+    def tearDown(self):
+        import gc
+        # Try to force garbage collection
+        gc.collect()
+
     def setUp(self):
         if charmm_solv.box is None:
             charmm_solv.box = [95.387, 80.381, 80.225, 90, 90, 90]

--- a/test/test_openmm_reporters.py
+++ b/test/test_openmm_reporters.py
@@ -34,6 +34,8 @@ class TestStateDataReporter(unittest.TestCase):
             os.makedirs(get_fn('writes'))
 
     def tearDown(self):
+        import gc
+        gc.collect()
         for f in os.listdir(get_fn('writes')):
             os.unlink(get_fn(f, written=True))
 
@@ -180,6 +182,8 @@ class TestTrajRestartReporter(unittest.TestCase):
             os.makedirs(get_fn('writes'))
 
     def tearDown(self):
+        import gc
+        gc.collect()
         for f in os.listdir(get_fn('writes')):
             os.unlink(get_fn(f, written=True))
 


### PR DESCRIPTION
I presume these failures are caused by blowing the memory limits placed on
tests. I think this is caused by rogue System objects and Context objects
sticking around in memory. First stab to get this working is to just call a
gc.collect to try and force the garbage collector to clean up those objects.

If need be, I can del them, but I'd rather not have to.