### PR TITLE
Fix the Python 3 optimized C++ reader.

### DIFF
--- a/src/CompatibilityMacros.h
+++ b/src/CompatibilityMacros.h
@@ -16,6 +16,7 @@ int PyObject_IS_STRING(PyObject *chk) {
 
 // PyInt -> PyLong
 #   define PyInt_FromLong PyLong_FromLong
+#   define PyInt_AsLong PyLong_AsLong
 
 #else /* Python 2 */
 
@@ -23,4 +24,3 @@ int PyObject_IS_STRING(PyObject *chk) {
 #   define PY_DESTROY_TYPE self->ob_type->tp_free((PyObject *)self)
 
 #endif
-

--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -172,8 +172,13 @@ static struct PyModuleDef moduledef = {
 };
 #endif
 
+#if PY_MAJOR_VERSION >= 3
+PyMODINIT_FUNC
+PyInit__rdparm(void) {
+#else
 PyMODINIT_FUNC
 init_rdparm(void) {
+#endif
     PyObject *m;
 
 #if PY_MAJOR_VERSION >= 3

--- a/test/test_chemistry_amber.py
+++ b/test/test_chemistry_amber.py
@@ -13,6 +13,10 @@ from utils import get_fn, has_numpy
 class TestReadParm(unittest.TestCase):
     """ Tests the various Parm file classes """
     
+    def testOptimizedReader(self):
+        """ Check that the optimized reader imports correctly """
+        from chemistry.amber import _rdparm
+
     def testLoadParm(self):
         """ Test the arbitrary parm loader """
         parm = readparm.LoadParm(get_fn('trx.prmtop'))


### PR DESCRIPTION
This probably explains why Python3 has been so much slower in the tests than
Python 2... This commit also adds a test to make sure that the optimized reader
was built and is importable.