### PR TITLE
Add option to parmout and chamber to write VMD-compatible prmtop files

### DIFF
--- a/ParmedTools/ParmedActions.py
+++ b/ParmedTools/ParmedActions.py
@@ -238,16 +238,22 @@ class parmout(Action):
     """
     Final prmtop written after all actions are complete
     """
-    usage = '<prmtop_name> [<inpcrd_name>] [netcdf]'
+    usage = '<prmtop_name> [<inpcrd_name>] [netcdf] [vmd]'
     supported_subclasses = (AmberParm,)
-
+    
     def init(self, arg_list):
+        print("INITING\n")
         self.filename = arg_list.get_next_string()
         self.rst_name = arg_list.get_next_string(optional=True)
         if arg_list.has_key('netcdf'):
             self.netcdf = True
         else:
             self.netcdf = None
+        if arg_list.has_key('vmd'):
+            print("Found vmd key\n")
+            self.vmd = True
+        else:
+            self.vmd = None
 
     def __str__(self):
         if self.rst_name is not None:
@@ -261,6 +267,9 @@ class parmout(Action):
         if self.rst_name is not None:
             if not Action.overwrite and os.path.exists(self.rst_name):
                 raise FileExists('%s exists; not overwriting.' % self.rst_name)
+        if self.vmd is not None:
+            print("CONVERTING TO VMD COMPAT\n")
+            self.parm.convert_to_vmd_compat()
         self.parm.write_parm(self.filename)
         if self.rst_name is not None:
             self.parm.write_rst7(self.rst_name, netcdf=self.netcdf)
@@ -3583,6 +3592,7 @@ class chamber(Action):
                       before applying it. This might lead to larger prmtop
                       files, but for large parameter sets will dramatically
                       shorten the running time of the chamber action
+        - -vmd        Writes a VMD-compatible prmtop file
 
     If the PDB file has a CRYST1 record, the box information will be set from
     there. Any box info given on the command-line will override the box found in
@@ -3590,7 +3600,7 @@ class chamber(Action):
     """
     usage = ('-top <RTF> -param <PAR> [-str <STR>] -psf <PSF> [-crd <CRD>] '
              '[-nocmap] [-box a,b,c[,alpha,beta,gamma]|bounding] [-radii '
-             '<radiusset>]')
+             '<radiusset>] [-vmd]')
     needs_parm = False
 
     def init(self, arg_list):
@@ -3693,6 +3703,7 @@ class chamber(Action):
             raise InputError('Illegal radius set %s -- must be one of '
                              '%s' % (self.radii, ', '.join(GB_RADII)))
         self.condense = not arg_list.has_key('nocondense')
+        self.vmd_compat = arg_list.has_key('-vmd')
 
     def __str__(self):
         retstr = 'Creating chamber topology file from PSF %s, ' % self.psf
@@ -3717,6 +3728,8 @@ class chamber(Action):
         elif self.box is not None:
             retstr += ' Box info %s.' % (self.box)
         retstr += ' GB Radius set %s.' % self.radii
+        if self.vmd_compat:
+            retstr += ' Writing VMD compatible prmtop'
         return retstr
 
     def execute(self):
@@ -3841,6 +3854,7 @@ class chamber(Action):
             raise ChamberError('Problem assigning parameters to PSF: %s' % e)
         parm = ConvertFromPSF(psf, parmset)
         parm.name = self.psf
+        parm.vmd_compat = self.vmd_compat
         changeRadii(parm, self.radii).execute()
         self.parm_list.add_parm(parm)
         self.parm = parm

--- a/ParmedTools/ParmedActions.py
+++ b/ParmedTools/ParmedActions.py
@@ -242,7 +242,6 @@ class parmout(Action):
     supported_subclasses = (AmberParm,)
     
     def init(self, arg_list):
-        print("INITING\n")
         self.filename = arg_list.get_next_string()
         self.rst_name = arg_list.get_next_string(optional=True)
         if arg_list.has_key('netcdf'):
@@ -250,7 +249,6 @@ class parmout(Action):
         else:
             self.netcdf = None
         if arg_list.has_key('vmd'):
-            print("Found vmd key\n")
             self.vmd = True
         else:
             self.vmd = None
@@ -268,7 +266,6 @@ class parmout(Action):
             if not Action.overwrite and os.path.exists(self.rst_name):
                 raise FileExists('%s exists; not overwriting.' % self.rst_name)
         if self.vmd is not None:
-            print("CONVERTING TO VMD COMPAT\n")
             self.parm.convert_to_vmd_compat()
         self.parm.write_parm(self.filename)
         if self.rst_name is not None:

--- a/chemistry/amber/amberformat.py
+++ b/chemistry/amber/amberformat.py
@@ -359,6 +359,7 @@ class AmberFormat(object):
         self.version = None
         self.charge_flag = 'CHARGE'
         self.name = fname
+        self.vmd_compat = None
 
         if fname is not None:
             self.rdparm(fname)
@@ -794,6 +795,7 @@ class AmberFormat(object):
         """
         if 'TITLE' not in self.flag_list:
             self.add_flag('TITLE', '20a4', num_items=0, after='CTITLE')
+        self.delete_flag('CTITLE')
         self.formats['CHARGE'] = FortranFormat('5E16.8')
         self.formats['ANGLE_EQUIL_VALUE'] = FortranFormat('5E16.8')
         self.formats['LENNARD_JONES_ACOEF'] = FortranFormat('5E16.8')
@@ -834,15 +836,15 @@ class AmberFormat(object):
             for i in xrange(len(self.parm_data[self.charge_flag])):
                 self.parm_data[self.charge_flag][i] *= CHARGE_SCALE
 
-        if self.vmd_compat is not None:
-            self.delete_flag('CTITLE')
-
         # write version to top of prmtop file
         new_prm.write('%s\n' % self.version)
 
         # then write pointers
         self.flag_list.remove('POINTERS')
-        self.flag_list.insert(self.flag_list.index('TITLE')+1, 'POINTERS')
+        if 'TITLE' in self.flag_list:
+          self.flag_list.insert(self.flag_list.index('TITLE')+1, 'POINTERS')
+        else:
+          self.flag_list.insert(self.flag_list.index('CTITLE')+1, 'POINTERS')
 
         # write data to prmtop file, inserting blank line if it's an empty field
         for flag in self.flag_list:

--- a/chemistry/amber/amberformat.py
+++ b/chemistry/amber/amberformat.py
@@ -77,7 +77,6 @@ class FortranFormat(object):
         """
         self.format = format_string
         self.strip_strings = strip_strings # for ease of copying
-
         # Define a function that processes all arguments prior to adding them to
         # the returned list. By default, do nothing, but this allows us to
         # optionally strip whitespace from strings.
@@ -788,6 +787,25 @@ class AmberFormat(object):
 
     #===================================================
 
+    def convert_to_vmd_compat(self):
+        """
+        Converts the flags and internal format fields to a VMD-compatible
+        format.
+        """
+   #     self.add_flag('TITLE', format, data, num_items, comments, after)
+        print("Converting to vmd compat\n")
+        if 'TITLE' not in self.flag_list:
+            self.add_flag('TITLE', '20a4', num_items=0, after='CTITLE')
+        self.formats['CHARGE'] = FortranFormat('5E16.8')
+        self.formats['ANGLE_EQUIL_VALUE'] = FortranFormat('5E16.8')
+        self.formats['LENNARD_JONES_ACOEF'] = FortranFormat('5E16.8')
+        self.formats['LENNARD_JONES_BCOEF'] = FortranFormat('5E16.8')
+        self.formats['LENNARD_JONES_14_ACOEF'] = FortranFormat('5E16.8')
+        self.formats['LENNARD_JONES_14_bCOEF'] = FortranFormat('5E16.8')
+        self.vmd_compat = True
+    
+    #===================================================
+
     def write_parm(self, name):
         """
         Writes the current data in parm_data into a new topology file with
@@ -814,15 +832,24 @@ class AmberFormat(object):
             for i in xrange(len(self.parm_data[self.charge_flag])):
                 self.parm_data[self.charge_flag][i] *= CHARGE_SCALE
 
+        if self.vmd_compat is not None:
+            self.delete_flag('CTITLE')
+
         # write version to top of prmtop file
         new_prm.write('%s\n' % self.version)
+
+        # then write pointers
+        self.flag_list.remove('POINTERS')
+        self.flag_list.insert(self.flag_list.index('TITLE')+1, 'POINTERS')
 
         # write data to prmtop file, inserting blank line if it's an empty field
         for flag in self.flag_list:
             new_prm.write('%%FLAG %s\n' % flag)
             # Insert any comments before the %FORMAT specifier
-            for comment in self.parm_comments[flag]:
-                new_prm.write('%%COMMENT %s\n' % comment)
+            # except VMD hates comments
+            if self.vmd_compat is None:
+              for comment in self.parm_comments[flag]:
+                  new_prm.write('%%COMMENT %s\n' % comment)
             new_prm.write('%%FORMAT(%s)\n' % self.formats[flag])
             if len(self.parm_data[flag]) == 0: # empty field...
                 new_prm.write('\n')

--- a/chemistry/amber/amberformat.py
+++ b/chemistry/amber/amberformat.py
@@ -792,8 +792,6 @@ class AmberFormat(object):
         Converts the flags and internal format fields to a VMD-compatible
         format.
         """
-   #     self.add_flag('TITLE', format, data, num_items, comments, after)
-        print("Converting to vmd compat\n")
         if 'TITLE' not in self.flag_list:
             self.add_flag('TITLE', '20a4', num_items=0, after='CTITLE')
         self.formats['CHARGE'] = FortranFormat('5E16.8')

--- a/chemistry/amber/amberformat.py
+++ b/chemistry/amber/amberformat.py
@@ -800,6 +800,10 @@ class AmberFormat(object):
         self.formats['LENNARD_JONES_BCOEF'] = FortranFormat('5E16.8')
         self.formats['LENNARD_JONES_14_ACOEF'] = FortranFormat('5E16.8')
         self.formats['LENNARD_JONES_14_bCOEF'] = FortranFormat('5E16.8')
+        self.formats['CHARMM_CMAP_PARAMETER_01'] = FortranFormat('8F9.5')
+        self.formats['CHARMM_CMAP_PARAMETER_02'] = FortranFormat('8F9.5')
+        self.formats['CHARMM_CMAP_PARAMETER_03'] = FortranFormat('8F9.5')
+        self.formats['FORCE_FIELD_TYPE'] = FortranFormat('20a4')
         self.vmd_compat = True
     
     #===================================================


### PR DESCRIPTION
VMD has a very strict interpretation of the prmtop format, and ignores the format fields when reading one in. This means that bond data is not successfully parsed from prmtop files that parmed outputs, preventing visualization of the results.

I added an option, -vmd to chamber and parmout that will result in the format fields of the prmtop being what VMD expects. This has the same function as the -vmd flag to standalone chamber.

Example usage:
action = parmout(parm, "test.prmtop test.inpcrd vmd")