### PR TITLE
Add informative __repr__ to Structure

### DIFF
--- a/chemistry/structure.py
+++ b/chemistry/structure.py
@@ -318,6 +318,28 @@ class Structure(object):
 
     #===================================================
 
+    def __repr__(self):
+        natom = len(self.atoms)
+        nres = len(self.residues)
+        nextra = sum([isinstance(a, ExtraPoint) for a in self.atoms])
+        retstr = ['<%s %d atoms' % (type(self).__name__, natom)]
+        if nextra > 0:
+            retstr.append(' [%d EPs]' % nextra)
+        retstr.append('; %d residues' % nres)
+        nbond = len(self.bonds)
+        retstr.append('; %d bonds' % nbond)
+        if self.box is not None:
+            retstr.append('; PBC')
+        # Just assume that if the first bond has a defined type, so does
+        # everything else... we don't want __repr__ to be super expensive
+        if len(self.bonds) > 0 and self.bonds[0].type is not None:
+            retstr.append('; parametrized>')
+        else:
+            retstr.append('; NOT parametrized>')
+        return ''.join(retstr)
+
+    #===================================================
+
     def add_atom(self, atom, resname, resnum, chain='', inscode=''):
         """
         Adds a new atom to the Structure, adding a new residue to `residues` if


### PR DESCRIPTION
This prints more information about the system, including the number of atoms,
residues, bonds, whether PBC are present, and whether the Structure is
parametrized or not.

For example:

```Python
>>> import chemistry as chem
>>> l = chem.load_file('test/files/trx.prmtop')
>>> k = chem.load_file('test/files/solv.prmtop')
>>> j = chem.load_file('test/files/4lzt.pdb')
>>> i = chem.load_file('test/files/4LZT.cif')
>>> l
<AmberParm 1654 atoms; 108 residues; 1670 bonds; parametrized>
>>> k
<AmberParm 29881 atoms; 9257 residues; 29893 bonds; PBC; parametrized>
>>> j
<Structure 1164 atoms; 274 residues; 0 bonds; PBC; NOT parametrized>
>>> i
<Structure 1164 atoms; 274 residues; 0 bonds; PBC; NOT parametrized>
```