### PR TITLE
Have CharmmParameterSet parse RESI cards from stream and RTF files

### DIFF
--- a/chemistry/charmm/_charmmfile.py
+++ b/chemistry/charmm/_charmmfile.py
@@ -30,6 +30,12 @@ class CharmmFile(object):
         self.closed = False
         self.line_number = 0
 
+    def tell(self):
+        return self._handle.tell()
+
+    def seek(self, value):
+        return self._handle.seek(value)
+
     def write(self, *args, **kwargs):
         return self._handle.write(*args, **kwargs)
 

--- a/chemistry/charmm/parameters.py
+++ b/chemistry/charmm/parameters.py
@@ -5,16 +5,22 @@ topology files and extracts all parameters from the parameter files
 
 Author: Jason M. Swails
 Contributors:
-Date: Sep. 17, 2014
+Date: Apr. 13, 2015
 """
+from __future__ import division
 from chemistry.constants import DEG_TO_RAD
-from chemistry import (AtomType, BondType, AngleType, DihedralType,
+from chemistry import (Atom, AtomType, BondType, AngleType, DihedralType,
                        DihedralTypeList, ImproperType, CmapType, NoUreyBradley)
 from chemistry.charmm._charmmfile import CharmmFile, CharmmStreamFile
 from chemistry.exceptions import CharmmFileError
-from chemistry.periodic_table import AtomicNum, Mass, Element
+from chemistry.modeller import ResidueTemplate, PatchTemplate
+from chemistry.periodic_table import AtomicNum, Mass, Element, element_by_mass
 import compat24 # needs to be before collections
 from collections import OrderedDict
+try:
+    from itertools import izip as zip
+except ImportError:
+    pass
 import os
 import warnings
 
@@ -99,6 +105,8 @@ class CharmmParameterSet(object):
         self.cmap_types = OrderedDict()
         self.nbfix_types = OrderedDict()
         self.parametersets = []
+        self.residues = dict()
+        self.patches = dict()
 
         # Load all of the files
         tops, pars, strs = [], [], []
@@ -501,35 +509,179 @@ class CharmmParameterSet(object):
         conv = CharmmParameterSet._convert
         if isinstance(tfile, str):
             own_handle = True
-            f = CharmmFile(tfile)
+            f = iter(CharmmFile(tfile))
         else:
             own_handle = False
             f = tfile
-        for line in f:
-            line = line.strip()
-            if line[:4] != 'MASS': continue
-            words = line.split()
-            try:
-                idx = conv(words[1], int, 'atom type')
-                name = words[2]
-                mass = conv(words[3], float, 'atom mass')
-            except IndexError:
-                raise CharmmFileError('Could not parse MASS section of %s' %
-                                      tfile)
-            # The parameter file might or might not have an element name
-            try:
-                elem = words[4]
-                if len(elem) == 2:
-                    elem = elem[0] + elem[1].lower()
-                atomic_number = AtomicNum[elem]
-            except (IndexError, KeyError):
-                # Figure it out from the mass
-                atomic_number = AtomicNum[element_by_mass(mass)]
-            atype = AtomType(name=name, number=idx, mass=mass,
-                             atomic_number=atomic_number)
-            self.atom_types_str[atype.name] = atype
-            self.atom_types_int[atype.number] = atype
-            self.atom_types_tuple[(atype.name, atype.number)] = atype
+        hpatch = tpatch = None # default Head and Tail patches
+        residues = dict()
+        patches = dict()
+        hpatches = dict()
+        tpatches = dict()
+        line = next(f)
+        try:
+            while line:
+                line = line.strip()
+                if line[:4] == 'MASS':
+                    words = line.split()
+                    try:
+                        idx = conv(words[1], int, 'atom type')
+                        name = words[2]
+                        mass = conv(words[3], float, 'atom mass')
+                    except IndexError:
+                        raise CharmmFileError('Could not parse MASS section of '
+                                              '%s' % tfile)
+                    # The parameter file might or might not have an element name
+                    try:
+                        elem = words[4]
+                        if len(elem) == 2:
+                            elem = elem[0] + elem[1].lower()
+                        atomic_number = AtomicNum[elem]
+                    except (IndexError, KeyError):
+                        # Figure it out from the mass
+                        atomic_number = AtomicNum[element_by_mass(mass)]
+                    atype = AtomType(name=name, number=idx, mass=mass,
+                                     atomic_number=atomic_number)
+                    self.atom_types_str[atype.name] = atype
+                    self.atom_types_int[atype.number] = atype
+                    self.atom_types_tuple[(atype.name, atype.number)] = atype
+                elif line[:4] == 'DECL':
+                    pass # Not really sure what this means
+                elif line[:4] == 'DEFA':
+                    words = line.split()
+                    if len(words) < 5:
+                        warnings.warn('DEFA line has %d tokens; expected 5' %
+                                      len(words))
+                    else:
+                        it = iter(words[1:5])
+                        for tok, val in zip(it, it):
+                            if val.upper() == 'NONE':
+                                val = None
+                            if tok.upper().startswith('FIRS'):
+                                hpatch = val
+                            elif tok.upper() == 'LAST':
+                                tpatch = val
+                            else:
+                                warnings.warn('DEFA patch %s unknown' % val)
+                elif line[:4].upper() in ('RESI', 'PRES'):
+                    restype = line[:4].upper()
+                    # Get the residue definition
+                    words = line.split()
+                    resname = words[1]
+                    # Assign default patches
+                    hpatches[resname] = hpatch
+                    tpatches[resname] = tpatch
+                    try:
+                        charge = float(words[2])
+                    except (IndexError, ValueError):
+                        warnings.warn('No charge for %s' % resname)
+                    if restype == 'RESI':
+                        res = ResidueTemplate(resname)
+                    elif restype == 'PRES':
+                        res = PatchTemplate(resname)
+                    else:
+                        assert False, 'restype != RESI or PRES'
+                    line = next(f)
+                    group = []
+                    ictable = []
+                    while line:
+                        if line[:5].upper() == 'GROUP':
+                            if group:
+                                res.groups.append(group)
+                            group = []
+                        elif line[:4].upper() == 'ATOM':
+                            words = line.split()
+                            name, type, charge = words[1:4]
+                            charge = float(charge)
+                            atom = Atom(name=name, type=type, charge=charge)
+                            group.append(atom)
+                            res.add_atom(atom)
+                        elif line.strip() and line.split()[0].upper() in \
+                                ('BOND', 'DOUBLE'):
+                            words = line.split()[1:]
+                            it = iter(words)
+                            for a1, a2 in zip(it, it):
+                                if a1.startswith('-'):
+                                    res.head = res[a2]
+                                    continue
+                                if a2.startswith('-'):
+                                    res.head = res[a1]
+                                    continue
+                                if a1.startswith('+'):
+                                    res.tail = res[a2]
+                                    continue
+                                if a2.startswith('+'):
+                                    res.tail = res[a1]
+                                    continue
+                                # Apparently PRES objects do not need to put +
+                                # or - in front of atoms that belong to adjacent
+                                # residues
+                                if restype == 'PRES' and (a1 not in res or
+                                                          a2 not in res):
+                                    continue
+                                res.add_bond(a1, a2)
+                        elif line[:4].upper() == 'CMAP':
+                            pass
+                        elif line[:5].upper() == 'DONOR':
+                            pass
+                        elif line[:6].upper() == 'ACCEPT':
+                            pass
+                        elif line[:2].upper() == 'IC':
+                            w = line.split()[1:]
+                            ictable.append((w[:4], [float(x) for x in w[4:]]))
+                        elif line[:3].upper() == 'END':
+                            break
+                        elif line[:5].upper() == 'PATCH':
+                            it = iter(line.split()[1:])
+                            for tok, val in zip(it, it):
+                                if val.upper() == 'NONE': val = None
+                                if tok.upper().startswith('FIRS'):
+                                    hpatches[resname] = val
+                                elif tok.upper().startswith('LAST'):
+                                    tpatches[resname] = val
+                        elif line[:5].upper() == 'DELETE':
+                            pass
+                        elif line[:4].upper() == 'IMPR':
+                            it = iter(line.split()[1:])
+                            for a1, a2, a3, a4 in zip(it, it, it, it):
+                                if a2[0] == '-' or a3[0] == '-' or a4 == '-':
+                                    res.head = res[a1]
+                        elif line[:4].upper() in ('RESI', 'PRES', 'MASS'):
+                            # Back up a line and bail
+                            break
+                        line = next(f)
+                    if group: res.groups.append(group)
+                    _fit_IC_table(res, ictable)
+                    if restype == 'RESI':
+                        residues[resname] = res
+                    elif restype == 'PRES':
+                        patches[resname] = res
+                    else:
+                        assert False, 'restype != RESI or PRES'
+                    # We parsed a line we need to look at. So don't update the
+                    # iterator
+                    continue
+                # Get the next line and cycle through
+                line = next(f)
+        except StopIteration:
+            pass
+
+        # Go through the patches and add the appropriate one
+        for resname, res in residues.iteritems():
+            if hpatches[resname] is not None:
+                try:
+                    res.first_patch = patches[hpatches[resname]]
+                except KeyError:
+                    warnings.warn('Patch %s not found' % hpatches[resname])
+            if tpatches[resname] is not None:
+                try:
+                    res.last_patch = patches[tpatches[resname]]
+                except KeyError:
+                    warnings.warn('Patch %s not found' % tpatches[resname])
+        # Now update the residues and patches with the ones we parsed here
+        self.residues.update(residues)
+        self.patches.update(patches)
+
         if own_handle: f.close()
 
     def read_stream_file(self, sfile):
@@ -552,7 +704,7 @@ class CharmmParameterSet(object):
             words = title.lower().split()
             if words[1] == 'rtf':
                 # This is a Residue Topology File section.
-                self.read_topology_file(section)
+                self.read_topology_file(iter(section))
             elif words[1].startswith('para'):
                 # This is a Parameter file section
                 self.read_parameter_file(section)
@@ -618,16 +770,25 @@ class CharmmParameterSet(object):
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-def element_by_mass(mass):
-    """ Determines what element the given atom is based on its mass """
+def _fit_IC_table(res, ictable):
+    """
+    Determines cartesian coordinates from an internal coordinate table stored in
+    CHARMM residue topology files
 
-    diff = mass
-    best_guess = 'EP'
+    Parameters
+    ----------
+    res : ResidueTemplate
+        The residue template for which coordinates are being determined
+    ictable : list[tuple(atoms, measurements)]
+        The internal coordinate table
 
-    for element in Element:
-        if abs(Mass[element] - mass) < diff:
-            best_guess = element
-            diff = abs(Mass[element] - mass)
-
-    return best_guess
-
+    Notes
+    -----
+    This method assigns an xx, xy, and xz attribute to ``res``. For the time
+    being, this is just a placeholder, as its functionality has not yet been
+    implemented (CHARMM does not use a 'traditional' Z-matrix, and I don't know
+    of any existing code that will compute the proper cartesian coordinates from
+    the form used by CHARMM)
+    """
+    for atom in res:
+        atom.xx = atom.xy = atom.xz = 0.0

--- a/chemistry/modeller/residue.py
+++ b/chemistry/modeller/residue.py
@@ -327,7 +327,7 @@ class ResidueTemplateContainer(list):
             # Behave like a dict here... albeit a slow one
             for res in self:
                 if res.name == value: return res
-        return list.__getitem__(value)
+        return list.__getitem__(self, value)
 
     def to_library(self):
         """

--- a/chemistry/modeller/residue.py
+++ b/chemistry/modeller/residue.py
@@ -14,7 +14,7 @@ except ImportError:
 import warnings
 
 __all__ = ['PROTEIN', 'NUCLEIC', 'SOLVENT', 'UNKNOWN', 'ResidueTemplate',
-           'ResidueTemplateContainer']
+           'ResidueTemplateContainer', 'PatchTemplate']
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -63,6 +63,14 @@ class ResidueTemplate(object):
         The atom that is connected to the residue that comes before this one
     tail : :class:`Atom` or None
         The atom that is connected to the *next* residue after this one
+    first_patch : :class:`ResidueTemplate` or None
+        If it is not None, this is the patch whose tail is added to the head
+        atom of this residue when this residue is the first in a chain
+    last_patch : :class:`ResidueTemplate` or None
+        If it is not None, this is the patch whose head is added to the tail
+        atom of this residue when this residue is the last in a chain
+    groups : list of list(:class:`Atom`)
+        If set, each group is a list of Atom instances making up each group
     """
 
     def __init__(self, name=''):
@@ -74,6 +82,23 @@ class ResidueTemplate(object):
         self.connections = []
         self._atomnames = set()
         self.type = UNKNOWN
+        self.first_patch = None
+        self.last_patch = None
+        self.groups = []
+        self.cmaps = []
+
+    def __repr__(self):
+        if self.head is not None:
+            head = self.head.name
+        else:
+            head = 'None'
+        if self.tail is not None:
+            tail = self.tail.name
+        else:
+            tail = 'None'
+        return '<%s %s: %d atoms; %d bonds; head=%s; tail=%s>' % (
+                    type(self).__name__, self.name, len(self.atoms),
+                    len(self.bonds), head, tail)
 
     def add_atom(self, atom):
         """ Adds an atom to this residue template
@@ -99,11 +124,11 @@ class ResidueTemplate(object):
 
         Parameters
         ----------
-        atom1 : :class:`Atom` or int
+        atom1 : :class:`Atom` or int or str
             One of the atoms in the bond. It must be in the ``atoms`` list of
             this ResidueTemplate. It can also be the atom index (index from 0)
             of the atom in the bond.
-        atom2 : :class:`Atom` or int
+        atom2 : :class:`Atom` or int or str
             The other atom in the bond. It must be in the ``atoms`` list of this
             ResidueTemplate. It can also be the atom index (index from 0) of the
             atom in the bond.
@@ -118,12 +143,14 @@ class ResidueTemplate(object):
 
         Notes
         -----
-        If atom1 and atom2 are already bonded, this routine does nothing
+        If atom1 and atom2 are already bonded, this routine does nothing. If
+        atom1 or atom2 are strings, then they will match the first instance of
+        the atom name that is the same as the atom name passed.
         """
-        if isinstance(atom1, int):
-            atom1 = self.atoms[atom1]
-        if isinstance(atom2, int):
-            atom2 = self.atoms[atom2]
+        if not isinstance(atom1, Atom):
+            atom1 = self[atom1]
+        if not isinstance(atom2, Atom):
+            atom2 = self[atom2]
         if atom1.list is not self.atoms or atom2.list is not self.atoms:
             raise RuntimeError('Both atoms must belong to template.atoms')
         # Do not add the same bond twice
@@ -183,11 +210,61 @@ class ResidueTemplate(object):
             self._crd = np.array([[a.xx, a.xy, a.xz] for a in self]).flatten()
         return self._crd
 
-    # Make ResidueTemplate look like a container of atoms
+    # Make ResidueTemplate look like a container of atoms, also indexable by the
+    # atom name
     def __len__(self):
         return len(self.atoms)
+
+    def __iter__(self):
+        return iter(self.atoms)
+
+    def __contains__(self, atom):
+        if isinstance(atom, Atom):
+            return atom in self.atoms
+        if isinstance(atom, str):
+            for a in self.atoms:
+                if a.name == atom:
+                    return True
+        return False
+
     def __getitem__(self, idx):
+        if isinstance(idx, str):
+            for atom in self.atoms:
+                if atom.name == idx:
+                    return atom
+            raise IndexError('Atom %s not found in %s' % (idx, self.name))
         return self.atoms[idx]
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+class PatchTemplate(ResidueTemplate):
+    """
+    A residue patch (typically used for CHARMM) that is used to modify existing
+    residues in some way (e.g., terminal patches, disulfide bridges, etc.)
+
+    Parameters
+    ----------
+    name : str, optional
+        If provided, this is the name of the residue
+
+    Attributes
+    ----------
+    delete : list of str
+        List of atoms that need to be deleted in applying the patch
+
+    See Also
+    --------
+    :class:`ResidueTemplate`
+
+    Notes
+    -----
+    This class basically just provides an additional list of atoms that need to
+    be deleted when applying this patch -- something that does not apply to
+    standard Residues
+    """
+    def __init__(self, name=''):
+        super(PatchTemplate, self).__init__(name)
+        self.delete = []
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -244,6 +321,13 @@ class ResidueTemplateContainer(list):
                     rt.name = '%s3' % rt.name
             inst.append(rt)
         return inst
+
+    def __getitem__(self, value):
+        if isinstance(value, str):
+            # Behave like a dict here... albeit a slow one
+            for res in self:
+                if res.name == value: return res
+        return list.__getitem__(value)
 
     def to_library(self):
         """

--- a/test/test_chemistry_charmm.py
+++ b/test/test_chemistry_charmm.py
@@ -337,6 +337,28 @@ class TestCharmmParameters(unittest.TestCase):
         self.assertEqual(len(params.nbfix_types), 0)
         self.assertEqual(len(params.parametersets), 1)
         self.assertEqual(len(params.urey_bradley_types), 685)
+        # Look at the parsed residue templates and make sure they line up
+        self.assertEqual(len(params.residues), 32)
+        self.assertEqual(set(params.residues.keys()),
+                set(['ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY',
+                     'HSD', 'HSE', 'HSP', 'ILE', 'LEU', 'LYS', 'MET', 'PHE',
+                     'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'ALAD', 'TIP3',
+                     'TP3M', 'SOD', 'MG', 'POT', 'CES', 'CAL', 'CLA', 'ZN2'])
+        )
+        self.assertEqual(len(params.patches), 22)
+        for resname, res in params.residues.items():
+            if resname in ('TIP3', 'TP3M', 'SOD', 'MG', 'CLA', 'POT', 'CES',
+                    'CAL', 'ZN2', 'ALAD'):
+                self.assertIs(res.first_patch, None)
+                self.assertIs(res.last_patch, None)
+                continue
+            self.assertIs(res.last_patch, params.patches['CTER'])
+            if resname == 'GLY':
+                self.assertIs(res.first_patch, params.patches['GLYP'])
+            elif resname == 'PRO':
+                self.assertIs(res.first_patch, params.patches['PROP'])
+            else:
+                self.assertIs(res.first_patch, params.patches['NTER'])
         # Look at the number of unique terms
         def uniques(stuff):
             myset = set()


### PR DESCRIPTION
Still doesn't convert the IC table into a set of cartesian coordinates. But you
can now access the patches and residue templates from the ``residues`` and
``patches`` attributes of the resulting ``CharmmParameterSet``