### PR TITLE
Gromacs support

### DIFF
--- a/chemistry/gromacs/gromacstop.py
+++ b/chemistry/gromacs/gromacstop.py
@@ -486,7 +486,7 @@ class GromacsTopologyFile(Structure):
     #===================================================
 
     @staticmethod
-    def write(struct, dest, include_itps=None):
+    def write(struct, dest, include_itps=None, combine=None):
         """ Write a Gromacs Topology File from a Structure
 
         Parameters
@@ -498,6 +498,17 @@ class GromacsTopologyFile(Structure):
         include_itps : list of str
             This keyword-only parameter contains a list of ITP files to include
             in the beginning of the generated Gromacs topology file
+        combine : 'all', None, or list of iterables
+            If None, no molecules are combined into a single moleculetype. If
+            'all', all molecules are combined into a single moleculetype.
+            Otherwise, the list of molecule indices will control which atoms are
+            combined into single moleculetype's. Each index can appear *only*
+            once, and start from 0. The same molecule number cannot appear in
+            two lists
+
+        Raises
+        ------
+        ValueError if the same molecule number appears in multiple combine lists
         """
         import chemistry.gromacs as gmx
         from chemistry import __version__
@@ -541,127 +552,141 @@ class GromacsTopologyFile(Structure):
                 else:
                     for include in include_itps:
                         dest.write('#include "%s"\n' % include)
-            # TODO split the molecule and add a separate "moleculetypes" for
-            # each molecule
-
-            if struct.title:
-                title = struct.title.split()[0]
+            if combine is None:
+                molecules = struct.split()
+                sysnum = 1
+                names = []
+                for molecule, num in molecules:
+                    if len(molecule.residues) == 1:
+                        title = molecule.residues[0].name
+                    else:
+                        title = 'system%d' % sysnum
+                        sysnum += 1
+                    names.append(title)
+                    GromacsTopologyFile._write_molecule(molecule, dest, title)
+                # System
+                dest.write('[ system ]\n; Name\n')
+                if struct.title:
+                    dest.write(struct.title)
+                else:
+                    dest.write('Generic title')
+                dest.write('\n\n')
+                # Molecules
+                dest.write('[ molecules ]\n; Compound       #mols\n')
+                for i, (molecule, num) in enumerate(molecules):
+                    dest.write('%-15s %6d\n' % (names[i], num))
+            elif isinstance(combine, string_types) and combine.lower() == 'all':
+                GromacsTopologyFile._write_molecule(struct, dest, 'system')
             else:
-                title = 'Protein'
-            dest.write('\n[ moleculetype ]\n; Name            nrexcl\n')
-            dest.write('%s          %d\n\n' % (title, struct.nrexcl))
-            dest.write('[ atoms ]\n')
-            dest.write(';   nr       type  resnr residue  atom   cgnr    '
-                       'charge       mass  typeB    chargeB      massB\n')
-            runchg = 0
-            for residue in struct.residues:
-                dest.write('; residue %4d %s rtp %s q %.1f\n' %
-                           (residue.idx+1, residue.name, residue.name,
-                            sum(a.charge for a in residue)))
-                for atom in residue:
-                    runchg += atom.charge
-                    dest.write('%5d %10s %6d %6s %6s %6d %8.4f %10.3f   ; '
-                               'qtot %.4f\n' % (atom.idx+1, atom.type,
-                                residue.idx+1, residue.name, atom.name,
-                                atom.idx+1, atom.charge, atom.mass, runchg))
-            dest.write('\n')
-            # Do valence terms now
-            if struct.bonds:
-                dest.write('[ bonds ]\n')
-                dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
-                           'funct', 'c0', 'c1', 'c2', 'c3'))
-                for bond in struct.bonds:
-                    dest.write('%7d %6d %5d\n' % (bond.atom1.idx+1,
-                               bond.atom2.idx+1, bond.funct))
-                dest.write('\n')
-            # Do the pair-exceptions
-            if struct.adjusts:
-                dest.write('[ pairs ]\n')
-                dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
-                           'funct', 'c0', 'c1', 'c2', 'c3'))
-                for adjust in struct.adjusts:
-                    dest.write('%7d %6d %5d\n' % (adjust.atom1.idx+1,
-                               adjust.atom2.idx+1, adjust.funct))
-                dest.write('\n')
-            elif struct.dihedrals:
-                dest.write('[ pairs ]\n')
-                dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
-                           'funct', 'c0', 'c1', 'c2', 'c3'))
-                # Get the 1-4 pairs from the dihedral list
-                for dihed in struct.dihedrals:
-                    if dihed.ignore_end or dihed.improper: continue
-                    a1, a2 = dihed.atom1, dihed.atom4
-                    if a1 in a2.bond_partners or a1 in a2.angle_partners:
-                        continue
-                    dest.write('%7d %6d %5d\n' % (a1.idx+1, a2.idx+1, 1))
-                dest.write('\n')
-            # Angles
-            if struct.angles:
-                dest.write('[ angles ]\n')
-                dest.write(';%6s %6s %6s %5s %10s %10s %10s %10s\n' %
-                           ('ai', 'aj', 'ak', 'funct', 'c0', 'c1', 'c2', 'c3'))
-                for angle in struct.angles:
-                    dest.write('%7d %6d %6d %5d\n' % (angle.atom1.idx+1,
-                               angle.atom2.idx+1, angle.atom3.idx+1,
-                               angle.funct))
-                dest.write('\n')
-            # Dihedrals
-            if struct.dihedrals:
-                dest.write('[ dihedrals ]\n')
-                dest.write((';%6s %6s %6s %6s %5s'+' %10s'*6) % ('ai', 'aj',
-                           'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3',
-                           'c4', 'c5'))
-                dest.write('\n')
-                for dihed in struct.dihedrals:
-                    dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
-                               dihed.atom2.idx+1, dihed.atom3.idx+1,
-                               dihed.atom4.idx+1, dihed.funct))
-                dest.write('\n')
-            # RB-torsions
-            if struct.rb_torsions:
-                dest.write('[ dihedrals ]\n')
-                dest.write((';%6s %6s %6s %6s %5s'+' %10s'*6) % ('ai', 'aj',
-                           'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3',
-                           'c4', 'c5'))
-                dest.write('\n')
-                for dihed in struct.rb_torsions:
-                    dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
-                               dihed.atom2.idx+1, dihed.atom3.idx+1,
-                               dihed.atom4.idx+1, dihed.funct))
-                dest.write('\n')
-            # Impropers
-            if struct.impropers:
-                dest.write('[ dihedrals ]\n')
-                dest.write((';%6s %6s %6s %6s %5s'+' %10s'*4) % ('ai', 'aj',
-                           'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3'))
-                dest.write('\n')
-                for dihed in struct.impropers:
-                    dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
-                               dihed.atom2.idx+1, dihed.atom3.idx+1,
-                               dihed.atom4.idx+1, dihed.funct))
-                dest.write('\n')
-            # Cmaps
-            if struct.cmaps:
-                dest.write('[ cmap ]\n')
-                dest.write(';%6s %6s %6s %6s %6s %5s\n' % ('ai', 'aj', 'ak',
-                           'al', 'am', 'funct'))
-                for cmap in struct.cmaps:
-                    dest.write('%7d %6d %6d %6d %6d %5d\n' % (cmap.atom1.idx+1,
-                               cmap.atom2.idx+1, cmap.atom3.idx+1,
-                               cmap.atom4.idx+1, cmap.atom5.idx+1, cmap.funct))
-            # System
-            dest.write('[ system ]\n; Name\n')
-            if struct.title:
-                dest.write(struct.title)
-            else:
-                dest.write('Generic title')
-            dest.write('\n\n')
-            # Molecules
-            dest.write('[ molecules ]\n; Compound       #mols\n')
-            dest.write('%s     1\n' % title)
+                raise NotImplementedError('Specialized molecule splitting is '
+                                          'not yet supported')
         finally:
             if own_handle:
                 dest.close()
+
+    @staticmethod
+    def _write_molecule(struct, dest, title):
+        dest.write('\n[ moleculetype ]\n; Name            nrexcl\n')
+        dest.write('%s          %d\n\n' % (title, struct.nrexcl))
+        dest.write('[ atoms ]\n')
+        dest.write(';   nr       type  resnr residue  atom   cgnr    '
+                   'charge       mass  typeB    chargeB      massB\n')
+        runchg = 0
+        for residue in struct.residues:
+            dest.write('; residue %4d %s rtp %s q %.1f\n' %
+                       (residue.idx+1, residue.name, residue.name,
+                        sum(a.charge for a in residue)))
+            for atom in residue:
+                runchg += atom.charge
+                dest.write('%5d %10s %6d %6s %6s %6d %8.4f %10.3f   ; '
+                           'qtot %.4f\n' % (atom.idx+1, atom.type,
+                            residue.idx+1, residue.name, atom.name,
+                            atom.idx+1, atom.charge, atom.mass, runchg))
+        dest.write('\n')
+        # Do valence terms now
+        if struct.bonds:
+            dest.write('[ bonds ]\n')
+            dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
+                       'funct', 'c0', 'c1', 'c2', 'c3'))
+            for bond in struct.bonds:
+                dest.write('%7d %6d %5d\n' % (bond.atom1.idx+1,
+                           bond.atom2.idx+1, bond.funct))
+            dest.write('\n')
+        # Do the pair-exceptions
+        if struct.adjusts:
+            dest.write('[ pairs ]\n')
+            dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
+                       'funct', 'c0', 'c1', 'c2', 'c3'))
+            for adjust in struct.adjusts:
+                dest.write('%7d %6d %5d\n' % (adjust.atom1.idx+1,
+                           adjust.atom2.idx+1, adjust.funct))
+            dest.write('\n')
+        elif struct.dihedrals:
+            dest.write('[ pairs ]\n')
+            dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
+                       'funct', 'c0', 'c1', 'c2', 'c3'))
+            # Get the 1-4 pairs from the dihedral list
+            for dihed in struct.dihedrals:
+                if dihed.ignore_end or dihed.improper: continue
+                a1, a2 = dihed.atom1, dihed.atom4
+                if a1 in a2.bond_partners or a1 in a2.angle_partners:
+                    continue
+                dest.write('%7d %6d %5d\n' % (a1.idx+1, a2.idx+1, 1))
+            dest.write('\n')
+        # Angles
+        if struct.angles:
+            dest.write('[ angles ]\n')
+            dest.write(';%6s %6s %6s %5s %10s %10s %10s %10s\n' %
+                       ('ai', 'aj', 'ak', 'funct', 'c0', 'c1', 'c2', 'c3'))
+            for angle in struct.angles:
+                dest.write('%7d %6d %6d %5d\n' % (angle.atom1.idx+1,
+                           angle.atom2.idx+1, angle.atom3.idx+1,
+                           angle.funct))
+            dest.write('\n')
+        # Dihedrals
+        if struct.dihedrals:
+            dest.write('[ dihedrals ]\n')
+            dest.write((';%6s %6s %6s %6s %5s'+' %10s'*6) % ('ai', 'aj',
+                       'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3',
+                       'c4', 'c5'))
+            dest.write('\n')
+            for dihed in struct.dihedrals:
+                dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
+                           dihed.atom2.idx+1, dihed.atom3.idx+1,
+                           dihed.atom4.idx+1, dihed.funct))
+            dest.write('\n')
+        # RB-torsions
+        if struct.rb_torsions:
+            dest.write('[ dihedrals ]\n')
+            dest.write((';%6s %6s %6s %6s %5s'+' %10s'*6) % ('ai', 'aj',
+                       'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3',
+                       'c4', 'c5'))
+            dest.write('\n')
+            for dihed in struct.rb_torsions:
+                dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
+                           dihed.atom2.idx+1, dihed.atom3.idx+1,
+                           dihed.atom4.idx+1, dihed.funct))
+            dest.write('\n')
+        # Impropers
+        if struct.impropers:
+            dest.write('[ dihedrals ]\n')
+            dest.write((';%6s %6s %6s %6s %5s'+' %10s'*4) % ('ai', 'aj',
+                       'ak', 'al', 'funct', 'c0', 'c1', 'c2', 'c3'))
+            dest.write('\n')
+            for dihed in struct.impropers:
+                dest.write('%7d %6d %6d %6d %5d\n' % (dihed.atom1.idx+1,
+                           dihed.atom2.idx+1, dihed.atom3.idx+1,
+                           dihed.atom4.idx+1, dihed.funct))
+            dest.write('\n')
+        # Cmaps
+        if struct.cmaps:
+            dest.write('[ cmap ]\n')
+            dest.write(';%6s %6s %6s %6s %6s %5s\n' % ('ai', 'aj', 'ak',
+                       'al', 'am', 'funct'))
+            for cmap in struct.cmaps:
+                dest.write('%7d %6d %6d %6d %6d %5d\n' % (cmap.atom1.idx+1,
+                           cmap.atom2.idx+1, cmap.atom3.idx+1,
+                           cmap.atom4.idx+1, cmap.atom5.idx+1, cmap.funct))
 
 def _any_atoms_farther_than(structure, limit=3):
     """

--- a/chemistry/gromacs/gromacstop.py
+++ b/chemistry/gromacs/gromacstop.py
@@ -13,7 +13,8 @@ from chemistry.structure import Structure
 from chemistry.topologyobjects import (Atom, Bond, Angle, Dihedral, Improper,
             NonbondedException, ExtraPoint, BondType, Cmap, NoUreyBradley,
             AngleType, DihedralType, DihedralTypeList, ImproperType,
-            RBTorsionType, ThreeParticleExtraPointFrame, AtomType)
+            RBTorsionType, ThreeParticleExtraPointFrame, AtomType,
+            TwoParticleExtraPointFrame, OutOfPlaneExtraPointFrame)
 from chemistry.periodic_table import element_by_mass, AtomicNum
 from chemistry import unit as u
 from chemistry.utils.io import genopen
@@ -315,9 +316,9 @@ class GromacsTopologyFile(Structure):
                         doh, dhh = float(doh), float(dhh)
                     except ValueError:
                         raise GromacsTopologyError('Bad [ settles ] line')
-                    bt_oh = BondType(1000*u.kilojoules_per_mole/u.nanometers**2,
+                    bt_oh = BondType(5e5*u.kilojoules_per_mole/u.nanometers**2,
                                      doh*u.nanometers, list=molecule.bond_types)
-                    bt_hh = BondType(1000*u.kilojoules_per_mole/u.nanometers**2,
+                    bt_hh = BondType(5e5*u.kilojoules_per_mole/u.nanometers**2,
                                      dhh*u.nanometers, list=molecule.bond_types)
                     molecule.bond_types.extend([bt_oh, bt_hh])
                     molecule.bonds.append(Bond(oxy, hyd1, bt_oh))
@@ -339,12 +340,13 @@ class GromacsTopologyFile(Structure):
                     parent = atoms[0]
                     bondlen = ThreeParticleExtraPointFrame.from_weights(parent,
                             atoms[1], atoms[2], a, b)
-                    bt_vs = BondType(0, bondlen*u.nanometers,
+                    bt_vs = BondType(0, bondlen*u.angstroms,
                                      list=molecule.bond_types)
                     if vsite in parent.bond_partners:
                         raise GromacsTopologyError('Unexpected bond b/w '
                                     'virtual site and its parent')
                     molecule.bonds.append(Bond(vsite, parent, bt_vs))
+                    molecule.bond_types.append(bt_vs)
                 elif current_section == 'exclusions':
                     atoms = [molecule.atoms[int(w)-1] for w in line.split()]
                     for a in atoms[1:]:
@@ -604,7 +606,16 @@ class GromacsTopologyFile(Structure):
                             atom.idx+1, atom.charge, atom.mass, runchg))
         dest.write('\n')
         # Do valence terms now
-        if struct.bonds:
+        EPs = [a for a in struct.atoms if isinstance(a, ExtraPoint)]
+        settle = False
+        if len(struct.atoms) - len(EPs) == 3:
+            try:
+                oxy, = (a for a in struct.atoms if a.atomic_number == 8)
+                hyd1, hyd2 = (a for a in struct.atoms if a.atomic_number == 1)
+                settle = True
+            except ValueError:
+                pass
+        if struct.bonds and not settle:
             dest.write('[ bonds ]\n')
             dest.write(';%6s %6s %5s %10s %10s %10s %10s\n' % ('ai', 'aj',
                        'funct', 'c0', 'c1', 'c2', 'c3'))
@@ -687,6 +698,73 @@ class GromacsTopologyFile(Structure):
                 dest.write('%7d %6d %6d %6d %6d %5d\n' % (cmap.atom1.idx+1,
                            cmap.atom2.idx+1, cmap.atom3.idx+1,
                            cmap.atom4.idx+1, cmap.atom5.idx+1, cmap.funct))
+        # See if this is a solvent molecule with 3 or fewer particles that can
+        # be SETTLEd
+        if settle:
+            dest.write('[ settles ]\n')
+            dest.write('; i	funct	doh	dhh\n')
+            for b in oxy.bonds:
+                if hyd1 in b:
+                    if b.type is None:
+                        # Use default values for TIPnP
+                        doh = 0.09572
+                    else:
+                        doh = b.type.req / 10
+                    break
+            for b in hyd1.bonds:
+                if hyd2 in b:
+                    if b.type is None:
+                        # Use default values for TIPnP
+                        dhh = 0.15139
+                    else:
+                        dhh = b.type.req / 10
+                    break
+            dest.write('1     1   %.5f   %.5f\n\n' % (doh, dhh))
+        # Virtual sites
+        if EPs:
+            ftypes = set(type(a.frame_type) for a in EPs)
+            for ftype in ftypes:
+                if ftype is TwoParticleExtraPointFrame:
+                    dest.write('[ virtual_sites2 ]\n')
+                    dest.write('; Site  from    funct  a\n')
+                    for EP in EPs:
+                        if not isinstance(EP.frame_type, ftype): continue
+                        a1, a2 = EP.frame_type.get_atoms()
+                        dest.write('%-5d %-4d %-4d %-4d   %.6f\n' %
+                                   (EP.idx+1, a1.idx+1, a2.idx+1, 1,
+                                    EP.get_weights()[0]))
+                    dest.write('\n')
+                elif ftype in (ThreeParticleExtraPointFrame,
+                               OutOfPlaneExtraPointFrame):
+                    dest.write('[ virtual_sites3 ]\n')
+                    dest.write('; Site  from                   funct\n')
+                    for EP in EPs:
+                        if isinstance(EP.frame_type,
+                                ThreeParticleExtraPointFrame):
+                            a1, a2, a3 = EP.frame_type.get_atoms()
+                            junk, w1, w2 = EP.frame_type.get_weights()
+                            dest.write('%-5d %-4d %-4d %-4d %-4d   %.6f  %.6f\n'
+                                    % (EP.idx+1, a1.idx+1, a2.idx+1, a3.idx+1,
+                                       1, w1, w2))
+                        elif isinstance(EP.frame_type,
+                                OutOfPlaneExtraPointFrame):
+                            a1, a2, a3 = EP.frame_type.get_atoms()
+                            w1, w2, w3 = EP.frame_type.get_weights()
+                            dest.write('%-5d %-4d %-4d %-4d %-4d   %.6f  %.6f  '
+                                       '%.6f\n' % (EP.idx+1, a1.idx+1, a2.idx+1,
+                                       a3.idx+1, w1, w2, w3))
+                    dest.write('\n')
+        # Do we need to list exclusions for systems with EPs?
+        if EPs or settle:
+            dest.write('[ exclusions ]\n')
+            for i, atom in enumerate(struct.atoms):
+                dest.write('%d' % (i+1))
+                for a in atom.bond_partners:
+                    dest.write(' %d' % (a.idx+1))
+                for a in atom.angle_partners:
+                    dest.write(' %d' % (a.idx+1))
+                dest.write('\n')
+            dest.write('\n')
 
 def _any_atoms_farther_than(structure, limit=3):
     """

--- a/chemistry/topologyobjects.py
+++ b/chemistry/topologyobjects.py
@@ -1299,8 +1299,8 @@ class ThreeParticleExtraPointFrame(object):
                 assert False, "Could not find matching angle"
         if abs(dp1 - dp2) > TINY:
             raise ValueError('Cannot deal with asymmetry in EP frame')
-        # Assume EP bisects
-        return w1 * math.cos(theteq * 0.5) * dp1
+
+        return w1 * 2 * math.cos(theteq * 0.5) * dp1
 
     def get_weights(self):
         """

--- a/test/files/saved/1aki.ff99sbildn.top
+++ b/test/files/saved/1aki.ff99sbildn.top
@@ -1,0 +1,18410 @@
+;
+;   File /Users/swails/src/ParmEd/test/files/writes/1aki.ff99sbildn.top was generated
+;   By user: swails (501)
+;   On host: Jasons-MBP
+;   At date: Tue. May  2 22:49:23 2015
+;
+;   This is a standalone topology file
+;
+;   Created by:
+;   ParmEd:       nosetests, VERSION 15.1
+;   Executable:   nosetests
+;   Library dir:  /usr/local/share/gromacs/top
+;   Command line:
+;     /Users/swails/miniconda/envs/py27/bin/nosetests -vs test/test_chemistry_gromacs.py --pdb
+;   Force field was read from the standard Gromacs share directory
+;
+
+[ moleculetype ]
+; Name            nrexcl
+system1          3
+
+[ atoms ]
+;   nr       type  resnr residue  atom   cgnr    charge       mass  typeB    chargeB      massB
+; residue    1 LYS rtp LYS q 2.0
+    1         N3      1    LYS      N      1   0.0966     14.010   ; qtot 0.0966
+    2          H      1    LYS     H1      2   0.2165      1.008   ; qtot 0.3131
+    3          H      1    LYS     H2      3   0.2165      1.008   ; qtot 0.5296
+    4          H      1    LYS     H3      4   0.2165      1.008   ; qtot 0.7461
+    5         CT      1    LYS     CA      5  -0.0015     12.010   ; qtot 0.7446
+    6         HP      1    LYS     HA      6   0.1180      1.008   ; qtot 0.8626
+    7         CT      1    LYS     CB      7   0.0212     12.010   ; qtot 0.8838
+    8         HC      1    LYS    HB1      8   0.0283      1.008   ; qtot 0.9121
+    9         HC      1    LYS    HB2      9   0.0283      1.008   ; qtot 0.9404
+   10         CT      1    LYS     CG     10  -0.0048     12.010   ; qtot 0.9356
+   11         HC      1    LYS    HG1     11   0.0121      1.008   ; qtot 0.9477
+   12         HC      1    LYS    HG2     12   0.0121      1.008   ; qtot 0.9598
+   13         CT      1    LYS     CD     13  -0.0608     12.010   ; qtot 0.8990
+   14         HC      1    LYS    HD1     14   0.0633      1.008   ; qtot 0.9623
+   15         HC      1    LYS    HD2     15   0.0633      1.008   ; qtot 1.0256
+   16         CT      1    LYS     CE     16  -0.0181     12.010   ; qtot 1.0075
+   17         HP      1    LYS    HE1     17   0.1171      1.008   ; qtot 1.1246
+   18         HP      1    LYS    HE2     18   0.1171      1.008   ; qtot 1.2417
+   19         N3      1    LYS     NZ     19  -0.3764     14.010   ; qtot 0.8653
+   20          H      1    LYS    HZ1     20   0.3382      1.008   ; qtot 1.2035
+   21          H      1    LYS    HZ2     21   0.3382      1.008   ; qtot 1.5417
+   22          H      1    LYS    HZ3     22   0.3382      1.008   ; qtot 1.8799
+   23          C      1    LYS      C     23   0.7214     12.010   ; qtot 2.6013
+   24          O      1    LYS      O     24  -0.6013     16.000   ; qtot 2.0000
+; residue    2 VAL rtp VAL q 0.0
+   25          N      2    VAL      N     25  -0.4157     14.010   ; qtot 1.5843
+   26          H      2    VAL      H     26   0.2719      1.008   ; qtot 1.8562
+   27         CT      2    VAL     CA     27  -0.0875     12.010   ; qtot 1.7687
+   28         H1      2    VAL     HA     28   0.0969      1.008   ; qtot 1.8656
+   29         CT      2    VAL     CB     29   0.2985     12.010   ; qtot 2.1641
+   30         HC      2    VAL     HB     30  -0.0297      1.008   ; qtot 2.1344
+   31         CT      2    VAL    CG1     31  -0.3192     12.010   ; qtot 1.8152
+   32         HC      2    VAL   HG11     32   0.0791      1.008   ; qtot 1.8943
+   33         HC      2    VAL   HG12     33   0.0791      1.008   ; qtot 1.9734
+   34         HC      2    VAL   HG13     34   0.0791      1.008   ; qtot 2.0525
+   35         CT      2    VAL    CG2     35  -0.3192     12.010   ; qtot 1.7333
+   36         HC      2    VAL   HG21     36   0.0791      1.008   ; qtot 1.8124
+   37         HC      2    VAL   HG22     37   0.0791      1.008   ; qtot 1.8915
+   38         HC      2    VAL   HG23     38   0.0791      1.008   ; qtot 1.9706
+   39          C      2    VAL      C     39   0.5973     12.010   ; qtot 2.5679
+   40          O      2    VAL      O     40  -0.5679     16.000   ; qtot 2.0000
+; residue    3 PHE rtp PHE q 0.0
+   41          N      3    PHE      N     41  -0.4157     14.010   ; qtot 1.5843
+   42          H      3    PHE      H     42   0.2719      1.008   ; qtot 1.8562
+   43         CT      3    PHE     CA     43  -0.0024     12.010   ; qtot 1.8538
+   44         H1      3    PHE     HA     44   0.0978      1.008   ; qtot 1.9516
+   45         CT      3    PHE     CB     45  -0.0343     12.010   ; qtot 1.9173
+   46         HC      3    PHE    HB1     46   0.0295      1.008   ; qtot 1.9468
+   47         HC      3    PHE    HB2     47   0.0295      1.008   ; qtot 1.9763
+   48         CA      3    PHE     CG     48   0.0118     12.010   ; qtot 1.9881
+   49         CA      3    PHE    CD1     49  -0.1256     12.010   ; qtot 1.8625
+   50         HA      3    PHE    HD1     50   0.1330      1.008   ; qtot 1.9955
+   51         CA      3    PHE    CE1     51  -0.1704     12.010   ; qtot 1.8251
+   52         HA      3    PHE    HE1     52   0.1430      1.008   ; qtot 1.9681
+   53         CA      3    PHE     CZ     53  -0.1072     12.010   ; qtot 1.8609
+   54         HA      3    PHE     HZ     54   0.1297      1.008   ; qtot 1.9906
+   55         CA      3    PHE    CE2     55  -0.1704     12.010   ; qtot 1.8202
+   56         HA      3    PHE    HE2     56   0.1430      1.008   ; qtot 1.9632
+   57         CA      3    PHE    CD2     57  -0.1256     12.010   ; qtot 1.8376
+   58         HA      3    PHE    HD2     58   0.1330      1.008   ; qtot 1.9706
+   59          C      3    PHE      C     59   0.5973     12.010   ; qtot 2.5679
+   60          O      3    PHE      O     60  -0.5679     16.000   ; qtot 2.0000
+; residue    4 GLY rtp GLY q 0.0
+   61          N      4    GLY      N     61  -0.4157     14.010   ; qtot 1.5843
+   62          H      4    GLY      H     62   0.2719      1.008   ; qtot 1.8562
+   63         CT      4    GLY     CA     63  -0.0252     12.010   ; qtot 1.8310
+   64         H1      4    GLY    HA1     64   0.0698      1.008   ; qtot 1.9008
+   65         H1      4    GLY    HA2     65   0.0698      1.008   ; qtot 1.9706
+   66          C      4    GLY      C     66   0.5973     12.010   ; qtot 2.5679
+   67          O      4    GLY      O     67  -0.5679     16.000   ; qtot 2.0000
+; residue    5 ARG rtp ARG q 1.0
+   68          N      5    ARG      N     68  -0.3479     14.010   ; qtot 1.6521
+   69          H      5    ARG      H     69   0.2747      1.008   ; qtot 1.9268
+   70         CT      5    ARG     CA     70  -0.2637     12.010   ; qtot 1.6631
+   71         H1      5    ARG     HA     71   0.1560      1.008   ; qtot 1.8191
+   72         CT      5    ARG     CB     72  -0.0007     12.010   ; qtot 1.8184
+   73         HC      5    ARG    HB1     73   0.0327      1.008   ; qtot 1.8511
+   74         HC      5    ARG    HB2     74   0.0327      1.008   ; qtot 1.8838
+   75         CT      5    ARG     CG     75   0.0390     12.010   ; qtot 1.9228
+   76         HC      5    ARG    HG1     76   0.0285      1.008   ; qtot 1.9513
+   77         HC      5    ARG    HG2     77   0.0285      1.008   ; qtot 1.9798
+   78         CT      5    ARG     CD     78   0.0486     12.010   ; qtot 2.0284
+   79         H1      5    ARG    HD1     79   0.0687      1.008   ; qtot 2.0971
+   80         H1      5    ARG    HD2     80   0.0687      1.008   ; qtot 2.1658
+   81         N2      5    ARG     NE     81  -0.5295     14.010   ; qtot 1.6363
+   82          H      5    ARG     HE     82   0.3456      1.008   ; qtot 1.9819
+   83         CA      5    ARG     CZ     83   0.8076     12.010   ; qtot 2.7895
+   84         N2      5    ARG    NH1     84  -0.8627     14.010   ; qtot 1.9268
+   85          H      5    ARG   HH11     85   0.4478      1.008   ; qtot 2.3746
+   86          H      5    ARG   HH12     86   0.4478      1.008   ; qtot 2.8224
+   87         N2      5    ARG    NH2     87  -0.8627     14.010   ; qtot 1.9597
+   88          H      5    ARG   HH21     88   0.4478      1.008   ; qtot 2.4075
+   89          H      5    ARG   HH22     89   0.4478      1.008   ; qtot 2.8553
+   90          C      5    ARG      C     90   0.7341     12.010   ; qtot 3.5894
+   91          O      5    ARG      O     91  -0.5894     16.000   ; qtot 3.0000
+; residue    6 CYS rtp CYS q 0.0
+   92          N      6    CYS      N     92  -0.4157     14.010   ; qtot 2.5843
+   93          H      6    CYS      H     93   0.2719      1.008   ; qtot 2.8562
+   94         CT      6    CYS     CA     94   0.0429     12.010   ; qtot 2.8991
+   95         H1      6    CYS     HA     95   0.0766      1.008   ; qtot 2.9757
+   96         CT      6    CYS     CB     96  -0.0790     12.010   ; qtot 2.8967
+   97         H1      6    CYS    HB1     97   0.0910      1.008   ; qtot 2.9877
+   98         H1      6    CYS    HB2     98   0.0910      1.008   ; qtot 3.0787
+   99          S      6    CYS     SG     99  -0.1081     32.060   ; qtot 2.9706
+  100          C      6    CYS      C    100   0.5973     12.010   ; qtot 3.5679
+  101          O      6    CYS      O    101  -0.5679     16.000   ; qtot 3.0000
+; residue    7 GLU rtp GLU q -1.0
+  102          N      7    GLU      N    102  -0.5163     14.010   ; qtot 2.4837
+  103          H      7    GLU      H    103   0.2936      1.008   ; qtot 2.7773
+  104         CT      7    GLU     CA    104   0.0397     12.010   ; qtot 2.8170
+  105         H1      7    GLU     HA    105   0.1105      1.008   ; qtot 2.9275
+  106         CT      7    GLU     CB    106   0.0560     12.010   ; qtot 2.9835
+  107         HC      7    GLU    HB1    107  -0.0173      1.008   ; qtot 2.9662
+  108         HC      7    GLU    HB2    108  -0.0173      1.008   ; qtot 2.9489
+  109         CT      7    GLU     CG    109   0.0136     12.010   ; qtot 2.9625
+  110         HC      7    GLU    HG1    110  -0.0425      1.008   ; qtot 2.9200
+  111         HC      7    GLU    HG2    111  -0.0425      1.008   ; qtot 2.8775
+  112          C      7    GLU     CD    112   0.8054     12.010   ; qtot 3.6829
+  113         O2      7    GLU    OE1    113  -0.8188     16.000   ; qtot 2.8641
+  114         O2      7    GLU    OE2    114  -0.8188     16.000   ; qtot 2.0453
+  115          C      7    GLU      C    115   0.5366     12.010   ; qtot 2.5819
+  116          O      7    GLU      O    116  -0.5819     16.000   ; qtot 2.0000
+; residue    8 LEU rtp LEU q 0.0
+  117          N      8    LEU      N    117  -0.4157     14.010   ; qtot 1.5843
+  118          H      8    LEU      H    118   0.2719      1.008   ; qtot 1.8562
+  119         CT      8    LEU     CA    119  -0.0518     12.010   ; qtot 1.8044
+  120         H1      8    LEU     HA    120   0.0922      1.008   ; qtot 1.8966
+  121         CT      8    LEU     CB    121  -0.1102     12.010   ; qtot 1.7864
+  122         HC      8    LEU    HB1    122   0.0457      1.008   ; qtot 1.8321
+  123         HC      8    LEU    HB2    123   0.0457      1.008   ; qtot 1.8778
+  124         CT      8    LEU     CG    124   0.3531     12.010   ; qtot 2.2309
+  125         HC      8    LEU     HG    125  -0.0361      1.008   ; qtot 2.1948
+  126         CT      8    LEU    CD1    126  -0.4121     12.010   ; qtot 1.7827
+  127         HC      8    LEU   HD11    127   0.1000      1.008   ; qtot 1.8827
+  128         HC      8    LEU   HD12    128   0.1000      1.008   ; qtot 1.9827
+  129         HC      8    LEU   HD13    129   0.1000      1.008   ; qtot 2.0827
+  130         CT      8    LEU    CD2    130  -0.4121     12.010   ; qtot 1.6706
+  131         HC      8    LEU   HD21    131   0.1000      1.008   ; qtot 1.7706
+  132         HC      8    LEU   HD22    132   0.1000      1.008   ; qtot 1.8706
+  133         HC      8    LEU   HD23    133   0.1000      1.008   ; qtot 1.9706
+  134          C      8    LEU      C    134   0.5973     12.010   ; qtot 2.5679
+  135          O      8    LEU      O    135  -0.5679     16.000   ; qtot 2.0000
+; residue    9 ALA rtp ALA q 0.0
+  136          N      9    ALA      N    136  -0.4157     14.010   ; qtot 1.5843
+  137          H      9    ALA      H    137   0.2719      1.008   ; qtot 1.8562
+  138         CT      9    ALA     CA    138   0.0337     12.010   ; qtot 1.8899
+  139         H1      9    ALA     HA    139   0.0823      1.008   ; qtot 1.9722
+  140         CT      9    ALA     CB    140  -0.1825     12.010   ; qtot 1.7897
+  141         HC      9    ALA    HB1    141   0.0603      1.008   ; qtot 1.8500
+  142         HC      9    ALA    HB2    142   0.0603      1.008   ; qtot 1.9103
+  143         HC      9    ALA    HB3    143   0.0603      1.008   ; qtot 1.9706
+  144          C      9    ALA      C    144   0.5973     12.010   ; qtot 2.5679
+  145          O      9    ALA      O    145  -0.5679     16.000   ; qtot 2.0000
+; residue   10 ALA rtp ALA q 0.0
+  146          N     10    ALA      N    146  -0.4157     14.010   ; qtot 1.5843
+  147          H     10    ALA      H    147   0.2719      1.008   ; qtot 1.8562
+  148         CT     10    ALA     CA    148   0.0337     12.010   ; qtot 1.8899
+  149         H1     10    ALA     HA    149   0.0823      1.008   ; qtot 1.9722
+  150         CT     10    ALA     CB    150  -0.1825     12.010   ; qtot 1.7897
+  151         HC     10    ALA    HB1    151   0.0603      1.008   ; qtot 1.8500
+  152         HC     10    ALA    HB2    152   0.0603      1.008   ; qtot 1.9103
+  153         HC     10    ALA    HB3    153   0.0603      1.008   ; qtot 1.9706
+  154          C     10    ALA      C    154   0.5973     12.010   ; qtot 2.5679
+  155          O     10    ALA      O    155  -0.5679     16.000   ; qtot 2.0000
+; residue   11 ALA rtp ALA q 0.0
+  156          N     11    ALA      N    156  -0.4157     14.010   ; qtot 1.5843
+  157          H     11    ALA      H    157   0.2719      1.008   ; qtot 1.8562
+  158         CT     11    ALA     CA    158   0.0337     12.010   ; qtot 1.8899
+  159         H1     11    ALA     HA    159   0.0823      1.008   ; qtot 1.9722
+  160         CT     11    ALA     CB    160  -0.1825     12.010   ; qtot 1.7897
+  161         HC     11    ALA    HB1    161   0.0603      1.008   ; qtot 1.8500
+  162         HC     11    ALA    HB2    162   0.0603      1.008   ; qtot 1.9103
+  163         HC     11    ALA    HB3    163   0.0603      1.008   ; qtot 1.9706
+  164          C     11    ALA      C    164   0.5973     12.010   ; qtot 2.5679
+  165          O     11    ALA      O    165  -0.5679     16.000   ; qtot 2.0000
+; residue   12 MET rtp MET q 0.0
+  166          N     12    MET      N    166  -0.4157     14.010   ; qtot 1.5843
+  167          H     12    MET      H    167   0.2719      1.008   ; qtot 1.8562
+  168         CT     12    MET     CA    168  -0.0237     12.010   ; qtot 1.8325
+  169         H1     12    MET     HA    169   0.0880      1.008   ; qtot 1.9205
+  170         CT     12    MET     CB    170   0.0342     12.010   ; qtot 1.9547
+  171         HC     12    MET    HB1    171   0.0241      1.008   ; qtot 1.9788
+  172         HC     12    MET    HB2    172   0.0241      1.008   ; qtot 2.0029
+  173         CT     12    MET     CG    173   0.0018     12.010   ; qtot 2.0047
+  174         H1     12    MET    HG1    174   0.0440      1.008   ; qtot 2.0487
+  175         H1     12    MET    HG2    175   0.0440      1.008   ; qtot 2.0927
+  176          S     12    MET     SD    176  -0.2737     32.060   ; qtot 1.8190
+  177         CT     12    MET     CE    177  -0.0536     12.010   ; qtot 1.7654
+  178         H1     12    MET    HE1    178   0.0684      1.008   ; qtot 1.8338
+  179         H1     12    MET    HE2    179   0.0684      1.008   ; qtot 1.9022
+  180         H1     12    MET    HE3    180   0.0684      1.008   ; qtot 1.9706
+  181          C     12    MET      C    181   0.5973     12.010   ; qtot 2.5679
+  182          O     12    MET      O    182  -0.5679     16.000   ; qtot 2.0000
+; residue   13 LYS rtp LYS q 1.0
+  183          N     13    LYS      N    183  -0.3479     14.010   ; qtot 1.6521
+  184          H     13    LYS      H    184   0.2747      1.008   ; qtot 1.9268
+  185         CT     13    LYS     CA    185  -0.2400     12.010   ; qtot 1.6868
+  186         H1     13    LYS     HA    186   0.1426      1.008   ; qtot 1.8294
+  187         CT     13    LYS     CB    187  -0.0094     12.010   ; qtot 1.8200
+  188         HC     13    LYS    HB1    188   0.0362      1.008   ; qtot 1.8562
+  189         HC     13    LYS    HB2    189   0.0362      1.008   ; qtot 1.8924
+  190         CT     13    LYS     CG    190   0.0187     12.010   ; qtot 1.9111
+  191         HC     13    LYS    HG1    191   0.0103      1.008   ; qtot 1.9214
+  192         HC     13    LYS    HG2    192   0.0103      1.008   ; qtot 1.9317
+  193         CT     13    LYS     CD    193  -0.0479     12.010   ; qtot 1.8838
+  194         HC     13    LYS    HD1    194   0.0621      1.008   ; qtot 1.9459
+  195         HC     13    LYS    HD2    195   0.0621      1.008   ; qtot 2.0080
+  196         CT     13    LYS     CE    196  -0.0143     12.010   ; qtot 1.9937
+  197         HP     13    LYS    HE1    197   0.1135      1.008   ; qtot 2.1072
+  198         HP     13    LYS    HE2    198   0.1135      1.008   ; qtot 2.2207
+  199         N3     13    LYS     NZ    199  -0.3854     14.010   ; qtot 1.8353
+  200          H     13    LYS    HZ1    200   0.3400      1.008   ; qtot 2.1753
+  201          H     13    LYS    HZ2    201   0.3400      1.008   ; qtot 2.5153
+  202          H     13    LYS    HZ3    202   0.3400      1.008   ; qtot 2.8553
+  203          C     13    LYS      C    203   0.7341     12.010   ; qtot 3.5894
+  204          O     13    LYS      O    204  -0.5894     16.000   ; qtot 3.0000
+; residue   14 ARG rtp ARG q 1.0
+  205          N     14    ARG      N    205  -0.3479     14.010   ; qtot 2.6521
+  206          H     14    ARG      H    206   0.2747      1.008   ; qtot 2.9268
+  207         CT     14    ARG     CA    207  -0.2637     12.010   ; qtot 2.6631
+  208         H1     14    ARG     HA    208   0.1560      1.008   ; qtot 2.8191
+  209         CT     14    ARG     CB    209  -0.0007     12.010   ; qtot 2.8184
+  210         HC     14    ARG    HB1    210   0.0327      1.008   ; qtot 2.8511
+  211         HC     14    ARG    HB2    211   0.0327      1.008   ; qtot 2.8838
+  212         CT     14    ARG     CG    212   0.0390     12.010   ; qtot 2.9228
+  213         HC     14    ARG    HG1    213   0.0285      1.008   ; qtot 2.9513
+  214         HC     14    ARG    HG2    214   0.0285      1.008   ; qtot 2.9798
+  215         CT     14    ARG     CD    215   0.0486     12.010   ; qtot 3.0284
+  216         H1     14    ARG    HD1    216   0.0687      1.008   ; qtot 3.0971
+  217         H1     14    ARG    HD2    217   0.0687      1.008   ; qtot 3.1658
+  218         N2     14    ARG     NE    218  -0.5295     14.010   ; qtot 2.6363
+  219          H     14    ARG     HE    219   0.3456      1.008   ; qtot 2.9819
+  220         CA     14    ARG     CZ    220   0.8076     12.010   ; qtot 3.7895
+  221         N2     14    ARG    NH1    221  -0.8627     14.010   ; qtot 2.9268
+  222          H     14    ARG   HH11    222   0.4478      1.008   ; qtot 3.3746
+  223          H     14    ARG   HH12    223   0.4478      1.008   ; qtot 3.8224
+  224         N2     14    ARG    NH2    224  -0.8627     14.010   ; qtot 2.9597
+  225          H     14    ARG   HH21    225   0.4478      1.008   ; qtot 3.4075
+  226          H     14    ARG   HH22    226   0.4478      1.008   ; qtot 3.8553
+  227          C     14    ARG      C    227   0.7341     12.010   ; qtot 4.5894
+  228          O     14    ARG      O    228  -0.5894     16.000   ; qtot 4.0000
+; residue   15 HIS rtp HIS q 0.0
+  229          N     15    HIS      N    229  -0.4157     14.010   ; qtot 3.5843
+  230          H     15    HIS      H    230   0.2719      1.008   ; qtot 3.8562
+  231         CT     15    HIS     CA    231  -0.0581     12.010   ; qtot 3.7981
+  232         H1     15    HIS     HA    232   0.1360      1.008   ; qtot 3.9341
+  233         CT     15    HIS     CB    233  -0.0074     12.010   ; qtot 3.9267
+  234         HC     15    HIS    HB1    234   0.0367      1.008   ; qtot 3.9634
+  235         HC     15    HIS    HB2    235   0.0367      1.008   ; qtot 4.0001
+  236         CC     15    HIS     CG    236   0.1868     12.010   ; qtot 4.1869
+  237         NB     15    HIS    ND1    237  -0.5432     14.010   ; qtot 3.6437
+  238         CR     15    HIS    CE1    238   0.1635     12.010   ; qtot 3.8072
+  239         H5     15    HIS    HE1    239   0.1435      1.008   ; qtot 3.9507
+  240         NA     15    HIS    NE2    240  -0.2795     14.010   ; qtot 3.6712
+  241          H     15    HIS    HE2    241   0.3339      1.008   ; qtot 4.0051
+  242         CW     15    HIS    CD2    242  -0.2207     12.010   ; qtot 3.7844
+  243         H4     15    HIS    HD2    243   0.1862      1.008   ; qtot 3.9706
+  244          C     15    HIS      C    244   0.5973     12.010   ; qtot 4.5679
+  245          O     15    HIS      O    245  -0.5679     16.000   ; qtot 4.0000
+; residue   16 GLY rtp GLY q 0.0
+  246          N     16    GLY      N    246  -0.4157     14.010   ; qtot 3.5843
+  247          H     16    GLY      H    247   0.2719      1.008   ; qtot 3.8562
+  248         CT     16    GLY     CA    248  -0.0252     12.010   ; qtot 3.8310
+  249         H1     16    GLY    HA1    249   0.0698      1.008   ; qtot 3.9008
+  250         H1     16    GLY    HA2    250   0.0698      1.008   ; qtot 3.9706
+  251          C     16    GLY      C    251   0.5973     12.010   ; qtot 4.5679
+  252          O     16    GLY      O    252  -0.5679     16.000   ; qtot 4.0000
+; residue   17 LEU rtp LEU q 0.0
+  253          N     17    LEU      N    253  -0.4157     14.010   ; qtot 3.5843
+  254          H     17    LEU      H    254   0.2719      1.008   ; qtot 3.8562
+  255         CT     17    LEU     CA    255  -0.0518     12.010   ; qtot 3.8044
+  256         H1     17    LEU     HA    256   0.0922      1.008   ; qtot 3.8966
+  257         CT     17    LEU     CB    257  -0.1102     12.010   ; qtot 3.7864
+  258         HC     17    LEU    HB1    258   0.0457      1.008   ; qtot 3.8321
+  259         HC     17    LEU    HB2    259   0.0457      1.008   ; qtot 3.8778
+  260         CT     17    LEU     CG    260   0.3531     12.010   ; qtot 4.2309
+  261         HC     17    LEU     HG    261  -0.0361      1.008   ; qtot 4.1948
+  262         CT     17    LEU    CD1    262  -0.4121     12.010   ; qtot 3.7827
+  263         HC     17    LEU   HD11    263   0.1000      1.008   ; qtot 3.8827
+  264         HC     17    LEU   HD12    264   0.1000      1.008   ; qtot 3.9827
+  265         HC     17    LEU   HD13    265   0.1000      1.008   ; qtot 4.0827
+  266         CT     17    LEU    CD2    266  -0.4121     12.010   ; qtot 3.6706
+  267         HC     17    LEU   HD21    267   0.1000      1.008   ; qtot 3.7706
+  268         HC     17    LEU   HD22    268   0.1000      1.008   ; qtot 3.8706
+  269         HC     17    LEU   HD23    269   0.1000      1.008   ; qtot 3.9706
+  270          C     17    LEU      C    270   0.5973     12.010   ; qtot 4.5679
+  271          O     17    LEU      O    271  -0.5679     16.000   ; qtot 4.0000
+; residue   18 ASP rtp ASP q -1.0
+  272          N     18    ASP      N    272  -0.5163     14.010   ; qtot 3.4837
+  273          H     18    ASP      H    273   0.2936      1.008   ; qtot 3.7773
+  274         CT     18    ASP     CA    274   0.0381     12.010   ; qtot 3.8154
+  275         H1     18    ASP     HA    275   0.0880      1.008   ; qtot 3.9034
+  276         CT     18    ASP     CB    276  -0.0303     12.010   ; qtot 3.8731
+  277         HC     18    ASP    HB1    277  -0.0122      1.008   ; qtot 3.8609
+  278         HC     18    ASP    HB2    278  -0.0122      1.008   ; qtot 3.8487
+  279          C     18    ASP     CG    279   0.7994     12.010   ; qtot 4.6481
+  280         O2     18    ASP    OD1    280  -0.8014     16.000   ; qtot 3.8467
+  281         O2     18    ASP    OD2    281  -0.8014     16.000   ; qtot 3.0453
+  282          C     18    ASP      C    282   0.5366     12.010   ; qtot 3.5819
+  283          O     18    ASP      O    283  -0.5819     16.000   ; qtot 3.0000
+; residue   19 ASN rtp ASN q 0.0
+  284          N     19    ASN      N    284  -0.4157     14.010   ; qtot 2.5843
+  285          H     19    ASN      H    285   0.2719      1.008   ; qtot 2.8562
+  286         CT     19    ASN     CA    286   0.0143     12.010   ; qtot 2.8705
+  287         H1     19    ASN     HA    287   0.1048      1.008   ; qtot 2.9753
+  288         CT     19    ASN     CB    288  -0.2041     12.010   ; qtot 2.7712
+  289         HC     19    ASN    HB1    289   0.0797      1.008   ; qtot 2.8509
+  290         HC     19    ASN    HB2    290   0.0797      1.008   ; qtot 2.9306
+  291          C     19    ASN     CG    291   0.7130     12.010   ; qtot 3.6436
+  292          O     19    ASN    OD1    292  -0.5931     16.000   ; qtot 3.0505
+  293          N     19    ASN    ND2    293  -0.9191     14.010   ; qtot 2.1314
+  294          H     19    ASN   HD21    294   0.4196      1.008   ; qtot 2.5510
+  295          H     19    ASN   HD22    295   0.4196      1.008   ; qtot 2.9706
+  296          C     19    ASN      C    296   0.5973     12.010   ; qtot 3.5679
+  297          O     19    ASN      O    297  -0.5679     16.000   ; qtot 3.0000
+; residue   20 TYR rtp TYR q 0.0
+  298          N     20    TYR      N    298  -0.4157     14.010   ; qtot 2.5843
+  299          H     20    TYR      H    299   0.2719      1.008   ; qtot 2.8562
+  300         CT     20    TYR     CA    300  -0.0014     12.010   ; qtot 2.8548
+  301         H1     20    TYR     HA    301   0.0876      1.008   ; qtot 2.9424
+  302         CT     20    TYR     CB    302  -0.0152     12.010   ; qtot 2.9272
+  303         HC     20    TYR    HB1    303   0.0295      1.008   ; qtot 2.9567
+  304         HC     20    TYR    HB2    304   0.0295      1.008   ; qtot 2.9862
+  305         CA     20    TYR     CG    305  -0.0011     12.010   ; qtot 2.9851
+  306         CA     20    TYR    CD1    306  -0.1906     12.010   ; qtot 2.7945
+  307         HA     20    TYR    HD1    307   0.1699      1.008   ; qtot 2.9644
+  308         CA     20    TYR    CE1    308  -0.2341     12.010   ; qtot 2.7303
+  309         HA     20    TYR    HE1    309   0.1656      1.008   ; qtot 2.8959
+  310          C     20    TYR     CZ    310   0.3226     12.010   ; qtot 3.2185
+  311         OH     20    TYR     OH    311  -0.5579     16.000   ; qtot 2.6606
+  312         HO     20    TYR     HH    312   0.3992      1.008   ; qtot 3.0598
+  313         CA     20    TYR    CE2    313  -0.2341     12.010   ; qtot 2.8257
+  314         HA     20    TYR    HE2    314   0.1656      1.008   ; qtot 2.9913
+  315         CA     20    TYR    CD2    315  -0.1906     12.010   ; qtot 2.8007
+  316         HA     20    TYR    HD2    316   0.1699      1.008   ; qtot 2.9706
+  317          C     20    TYR      C    317   0.5973     12.010   ; qtot 3.5679
+  318          O     20    TYR      O    318  -0.5679     16.000   ; qtot 3.0000
+; residue   21 ARG rtp ARG q 1.0
+  319          N     21    ARG      N    319  -0.3479     14.010   ; qtot 2.6521
+  320          H     21    ARG      H    320   0.2747      1.008   ; qtot 2.9268
+  321         CT     21    ARG     CA    321  -0.2637     12.010   ; qtot 2.6631
+  322         H1     21    ARG     HA    322   0.1560      1.008   ; qtot 2.8191
+  323         CT     21    ARG     CB    323  -0.0007     12.010   ; qtot 2.8184
+  324         HC     21    ARG    HB1    324   0.0327      1.008   ; qtot 2.8511
+  325         HC     21    ARG    HB2    325   0.0327      1.008   ; qtot 2.8838
+  326         CT     21    ARG     CG    326   0.0390     12.010   ; qtot 2.9228
+  327         HC     21    ARG    HG1    327   0.0285      1.008   ; qtot 2.9513
+  328         HC     21    ARG    HG2    328   0.0285      1.008   ; qtot 2.9798
+  329         CT     21    ARG     CD    329   0.0486     12.010   ; qtot 3.0284
+  330         H1     21    ARG    HD1    330   0.0687      1.008   ; qtot 3.0971
+  331         H1     21    ARG    HD2    331   0.0687      1.008   ; qtot 3.1658
+  332         N2     21    ARG     NE    332  -0.5295     14.010   ; qtot 2.6363
+  333          H     21    ARG     HE    333   0.3456      1.008   ; qtot 2.9819
+  334         CA     21    ARG     CZ    334   0.8076     12.010   ; qtot 3.7895
+  335         N2     21    ARG    NH1    335  -0.8627     14.010   ; qtot 2.9268
+  336          H     21    ARG   HH11    336   0.4478      1.008   ; qtot 3.3746
+  337          H     21    ARG   HH12    337   0.4478      1.008   ; qtot 3.8224
+  338         N2     21    ARG    NH2    338  -0.8627     14.010   ; qtot 2.9597
+  339          H     21    ARG   HH21    339   0.4478      1.008   ; qtot 3.4075
+  340          H     21    ARG   HH22    340   0.4478      1.008   ; qtot 3.8553
+  341          C     21    ARG      C    341   0.7341     12.010   ; qtot 4.5894
+  342          O     21    ARG      O    342  -0.5894     16.000   ; qtot 4.0000
+; residue   22 GLY rtp GLY q 0.0
+  343          N     22    GLY      N    343  -0.4157     14.010   ; qtot 3.5843
+  344          H     22    GLY      H    344   0.2719      1.008   ; qtot 3.8562
+  345         CT     22    GLY     CA    345  -0.0252     12.010   ; qtot 3.8310
+  346         H1     22    GLY    HA1    346   0.0698      1.008   ; qtot 3.9008
+  347         H1     22    GLY    HA2    347   0.0698      1.008   ; qtot 3.9706
+  348          C     22    GLY      C    348   0.5973     12.010   ; qtot 4.5679
+  349          O     22    GLY      O    349  -0.5679     16.000   ; qtot 4.0000
+; residue   23 TYR rtp TYR q 0.0
+  350          N     23    TYR      N    350  -0.4157     14.010   ; qtot 3.5843
+  351          H     23    TYR      H    351   0.2719      1.008   ; qtot 3.8562
+  352         CT     23    TYR     CA    352  -0.0014     12.010   ; qtot 3.8548
+  353         H1     23    TYR     HA    353   0.0876      1.008   ; qtot 3.9424
+  354         CT     23    TYR     CB    354  -0.0152     12.010   ; qtot 3.9272
+  355         HC     23    TYR    HB1    355   0.0295      1.008   ; qtot 3.9567
+  356         HC     23    TYR    HB2    356   0.0295      1.008   ; qtot 3.9862
+  357         CA     23    TYR     CG    357  -0.0011     12.010   ; qtot 3.9851
+  358         CA     23    TYR    CD1    358  -0.1906     12.010   ; qtot 3.7945
+  359         HA     23    TYR    HD1    359   0.1699      1.008   ; qtot 3.9644
+  360         CA     23    TYR    CE1    360  -0.2341     12.010   ; qtot 3.7303
+  361         HA     23    TYR    HE1    361   0.1656      1.008   ; qtot 3.8959
+  362          C     23    TYR     CZ    362   0.3226     12.010   ; qtot 4.2185
+  363         OH     23    TYR     OH    363  -0.5579     16.000   ; qtot 3.6606
+  364         HO     23    TYR     HH    364   0.3992      1.008   ; qtot 4.0598
+  365         CA     23    TYR    CE2    365  -0.2341     12.010   ; qtot 3.8257
+  366         HA     23    TYR    HE2    366   0.1656      1.008   ; qtot 3.9913
+  367         CA     23    TYR    CD2    367  -0.1906     12.010   ; qtot 3.8007
+  368         HA     23    TYR    HD2    368   0.1699      1.008   ; qtot 3.9706
+  369          C     23    TYR      C    369   0.5973     12.010   ; qtot 4.5679
+  370          O     23    TYR      O    370  -0.5679     16.000   ; qtot 4.0000
+; residue   24 SER rtp SER q 0.0
+  371          N     24    SER      N    371  -0.4157     14.010   ; qtot 3.5843
+  372          H     24    SER      H    372   0.2719      1.008   ; qtot 3.8562
+  373         CT     24    SER     CA    373  -0.0249     12.010   ; qtot 3.8313
+  374         H1     24    SER     HA    374   0.0843      1.008   ; qtot 3.9156
+  375         CT     24    SER     CB    375   0.2117     12.010   ; qtot 4.1273
+  376         H1     24    SER    HB1    376   0.0352      1.008   ; qtot 4.1625
+  377         H1     24    SER    HB2    377   0.0352      1.008   ; qtot 4.1977
+  378         OH     24    SER     OG    378  -0.6546     16.000   ; qtot 3.5431
+  379         HO     24    SER     HG    379   0.4275      1.008   ; qtot 3.9706
+  380          C     24    SER      C    380   0.5973     12.010   ; qtot 4.5679
+  381          O     24    SER      O    381  -0.5679     16.000   ; qtot 4.0000
+; residue   25 LEU rtp LEU q 0.0
+  382          N     25    LEU      N    382  -0.4157     14.010   ; qtot 3.5843
+  383          H     25    LEU      H    383   0.2719      1.008   ; qtot 3.8562
+  384         CT     25    LEU     CA    384  -0.0518     12.010   ; qtot 3.8044
+  385         H1     25    LEU     HA    385   0.0922      1.008   ; qtot 3.8966
+  386         CT     25    LEU     CB    386  -0.1102     12.010   ; qtot 3.7864
+  387         HC     25    LEU    HB1    387   0.0457      1.008   ; qtot 3.8321
+  388         HC     25    LEU    HB2    388   0.0457      1.008   ; qtot 3.8778
+  389         CT     25    LEU     CG    389   0.3531     12.010   ; qtot 4.2309
+  390         HC     25    LEU     HG    390  -0.0361      1.008   ; qtot 4.1948
+  391         CT     25    LEU    CD1    391  -0.4121     12.010   ; qtot 3.7827
+  392         HC     25    LEU   HD11    392   0.1000      1.008   ; qtot 3.8827
+  393         HC     25    LEU   HD12    393   0.1000      1.008   ; qtot 3.9827
+  394         HC     25    LEU   HD13    394   0.1000      1.008   ; qtot 4.0827
+  395         CT     25    LEU    CD2    395  -0.4121     12.010   ; qtot 3.6706
+  396         HC     25    LEU   HD21    396   0.1000      1.008   ; qtot 3.7706
+  397         HC     25    LEU   HD22    397   0.1000      1.008   ; qtot 3.8706
+  398         HC     25    LEU   HD23    398   0.1000      1.008   ; qtot 3.9706
+  399          C     25    LEU      C    399   0.5973     12.010   ; qtot 4.5679
+  400          O     25    LEU      O    400  -0.5679     16.000   ; qtot 4.0000
+; residue   26 GLY rtp GLY q 0.0
+  401          N     26    GLY      N    401  -0.4157     14.010   ; qtot 3.5843
+  402          H     26    GLY      H    402   0.2719      1.008   ; qtot 3.8562
+  403         CT     26    GLY     CA    403  -0.0252     12.010   ; qtot 3.8310
+  404         H1     26    GLY    HA1    404   0.0698      1.008   ; qtot 3.9008
+  405         H1     26    GLY    HA2    405   0.0698      1.008   ; qtot 3.9706
+  406          C     26    GLY      C    406   0.5973     12.010   ; qtot 4.5679
+  407          O     26    GLY      O    407  -0.5679     16.000   ; qtot 4.0000
+; residue   27 ASN rtp ASN q 0.0
+  408          N     27    ASN      N    408  -0.4157     14.010   ; qtot 3.5843
+  409          H     27    ASN      H    409   0.2719      1.008   ; qtot 3.8562
+  410         CT     27    ASN     CA    410   0.0143     12.010   ; qtot 3.8705
+  411         H1     27    ASN     HA    411   0.1048      1.008   ; qtot 3.9753
+  412         CT     27    ASN     CB    412  -0.2041     12.010   ; qtot 3.7712
+  413         HC     27    ASN    HB1    413   0.0797      1.008   ; qtot 3.8509
+  414         HC     27    ASN    HB2    414   0.0797      1.008   ; qtot 3.9306
+  415          C     27    ASN     CG    415   0.7130     12.010   ; qtot 4.6436
+  416          O     27    ASN    OD1    416  -0.5931     16.000   ; qtot 4.0505
+  417          N     27    ASN    ND2    417  -0.9191     14.010   ; qtot 3.1314
+  418          H     27    ASN   HD21    418   0.4196      1.008   ; qtot 3.5510
+  419          H     27    ASN   HD22    419   0.4196      1.008   ; qtot 3.9706
+  420          C     27    ASN      C    420   0.5973     12.010   ; qtot 4.5679
+  421          O     27    ASN      O    421  -0.5679     16.000   ; qtot 4.0000
+; residue   28 TRP rtp TRP q 0.0
+  422          N     28    TRP      N    422  -0.4157     14.010   ; qtot 3.5843
+  423          H     28    TRP      H    423   0.2719      1.008   ; qtot 3.8562
+  424         CT     28    TRP     CA    424  -0.0275     12.010   ; qtot 3.8287
+  425         H1     28    TRP     HA    425   0.1123      1.008   ; qtot 3.9410
+  426         CT     28    TRP     CB    426  -0.0050     12.010   ; qtot 3.9360
+  427         HC     28    TRP    HB1    427   0.0339      1.008   ; qtot 3.9699
+  428         HC     28    TRP    HB2    428   0.0339      1.008   ; qtot 4.0038
+  429         C*     28    TRP     CG    429  -0.1415     12.010   ; qtot 3.8623
+  430         CW     28    TRP    CD1    430  -0.1638     12.010   ; qtot 3.6985
+  431         H4     28    TRP    HD1    431   0.2062      1.008   ; qtot 3.9047
+  432         NA     28    TRP    NE1    432  -0.3418     14.010   ; qtot 3.5629
+  433          H     28    TRP    HE1    433   0.3412      1.008   ; qtot 3.9041
+  434         CN     28    TRP    CE2    434   0.1380     12.010   ; qtot 4.0421
+  435         CA     28    TRP    CZ2    435  -0.2601     12.010   ; qtot 3.7820
+  436         HA     28    TRP    HZ2    436   0.1572      1.008   ; qtot 3.9392
+  437         CA     28    TRP    CH2    437  -0.1134     12.010   ; qtot 3.8258
+  438         HA     28    TRP    HH2    438   0.1417      1.008   ; qtot 3.9675
+  439         CA     28    TRP    CZ3    439  -0.1972     12.010   ; qtot 3.7703
+  440         HA     28    TRP    HZ3    440   0.1447      1.008   ; qtot 3.9150
+  441         CA     28    TRP    CE3    441  -0.2387     12.010   ; qtot 3.6763
+  442         HA     28    TRP    HE3    442   0.1700      1.008   ; qtot 3.8463
+  443         CB     28    TRP    CD2    443   0.1243     12.010   ; qtot 3.9706
+  444          C     28    TRP      C    444   0.5973     12.010   ; qtot 4.5679
+  445          O     28    TRP      O    445  -0.5679     16.000   ; qtot 4.0000
+; residue   29 VAL rtp VAL q 0.0
+  446          N     29    VAL      N    446  -0.4157     14.010   ; qtot 3.5843
+  447          H     29    VAL      H    447   0.2719      1.008   ; qtot 3.8562
+  448         CT     29    VAL     CA    448  -0.0875     12.010   ; qtot 3.7687
+  449         H1     29    VAL     HA    449   0.0969      1.008   ; qtot 3.8656
+  450         CT     29    VAL     CB    450   0.2985     12.010   ; qtot 4.1641
+  451         HC     29    VAL     HB    451  -0.0297      1.008   ; qtot 4.1344
+  452         CT     29    VAL    CG1    452  -0.3192     12.010   ; qtot 3.8152
+  453         HC     29    VAL   HG11    453   0.0791      1.008   ; qtot 3.8943
+  454         HC     29    VAL   HG12    454   0.0791      1.008   ; qtot 3.9734
+  455         HC     29    VAL   HG13    455   0.0791      1.008   ; qtot 4.0525
+  456         CT     29    VAL    CG2    456  -0.3192     12.010   ; qtot 3.7333
+  457         HC     29    VAL   HG21    457   0.0791      1.008   ; qtot 3.8124
+  458         HC     29    VAL   HG22    458   0.0791      1.008   ; qtot 3.8915
+  459         HC     29    VAL   HG23    459   0.0791      1.008   ; qtot 3.9706
+  460          C     29    VAL      C    460   0.5973     12.010   ; qtot 4.5679
+  461          O     29    VAL      O    461  -0.5679     16.000   ; qtot 4.0000
+; residue   30 CYS rtp CYS q 0.0
+  462          N     30    CYS      N    462  -0.4157     14.010   ; qtot 3.5843
+  463          H     30    CYS      H    463   0.2719      1.008   ; qtot 3.8562
+  464         CT     30    CYS     CA    464   0.0429     12.010   ; qtot 3.8991
+  465         H1     30    CYS     HA    465   0.0766      1.008   ; qtot 3.9757
+  466         CT     30    CYS     CB    466  -0.0790     12.010   ; qtot 3.8967
+  467         H1     30    CYS    HB1    467   0.0910      1.008   ; qtot 3.9877
+  468         H1     30    CYS    HB2    468   0.0910      1.008   ; qtot 4.0787
+  469          S     30    CYS     SG    469  -0.1081     32.060   ; qtot 3.9706
+  470          C     30    CYS      C    470   0.5973     12.010   ; qtot 4.5679
+  471          O     30    CYS      O    471  -0.5679     16.000   ; qtot 4.0000
+; residue   31 ALA rtp ALA q 0.0
+  472          N     31    ALA      N    472  -0.4157     14.010   ; qtot 3.5843
+  473          H     31    ALA      H    473   0.2719      1.008   ; qtot 3.8562
+  474         CT     31    ALA     CA    474   0.0337     12.010   ; qtot 3.8899
+  475         H1     31    ALA     HA    475   0.0823      1.008   ; qtot 3.9722
+  476         CT     31    ALA     CB    476  -0.1825     12.010   ; qtot 3.7897
+  477         HC     31    ALA    HB1    477   0.0603      1.008   ; qtot 3.8500
+  478         HC     31    ALA    HB2    478   0.0603      1.008   ; qtot 3.9103
+  479         HC     31    ALA    HB3    479   0.0603      1.008   ; qtot 3.9706
+  480          C     31    ALA      C    480   0.5973     12.010   ; qtot 4.5679
+  481          O     31    ALA      O    481  -0.5679     16.000   ; qtot 4.0000
+; residue   32 ALA rtp ALA q 0.0
+  482          N     32    ALA      N    482  -0.4157     14.010   ; qtot 3.5843
+  483          H     32    ALA      H    483   0.2719      1.008   ; qtot 3.8562
+  484         CT     32    ALA     CA    484   0.0337     12.010   ; qtot 3.8899
+  485         H1     32    ALA     HA    485   0.0823      1.008   ; qtot 3.9722
+  486         CT     32    ALA     CB    486  -0.1825     12.010   ; qtot 3.7897
+  487         HC     32    ALA    HB1    487   0.0603      1.008   ; qtot 3.8500
+  488         HC     32    ALA    HB2    488   0.0603      1.008   ; qtot 3.9103
+  489         HC     32    ALA    HB3    489   0.0603      1.008   ; qtot 3.9706
+  490          C     32    ALA      C    490   0.5973     12.010   ; qtot 4.5679
+  491          O     32    ALA      O    491  -0.5679     16.000   ; qtot 4.0000
+; residue   33 LYS rtp LYS q 1.0
+  492          N     33    LYS      N    492  -0.3479     14.010   ; qtot 3.6521
+  493          H     33    LYS      H    493   0.2747      1.008   ; qtot 3.9268
+  494         CT     33    LYS     CA    494  -0.2400     12.010   ; qtot 3.6868
+  495         H1     33    LYS     HA    495   0.1426      1.008   ; qtot 3.8294
+  496         CT     33    LYS     CB    496  -0.0094     12.010   ; qtot 3.8200
+  497         HC     33    LYS    HB1    497   0.0362      1.008   ; qtot 3.8562
+  498         HC     33    LYS    HB2    498   0.0362      1.008   ; qtot 3.8924
+  499         CT     33    LYS     CG    499   0.0187     12.010   ; qtot 3.9111
+  500         HC     33    LYS    HG1    500   0.0103      1.008   ; qtot 3.9214
+  501         HC     33    LYS    HG2    501   0.0103      1.008   ; qtot 3.9317
+  502         CT     33    LYS     CD    502  -0.0479     12.010   ; qtot 3.8838
+  503         HC     33    LYS    HD1    503   0.0621      1.008   ; qtot 3.9459
+  504         HC     33    LYS    HD2    504   0.0621      1.008   ; qtot 4.0080
+  505         CT     33    LYS     CE    505  -0.0143     12.010   ; qtot 3.9937
+  506         HP     33    LYS    HE1    506   0.1135      1.008   ; qtot 4.1072
+  507         HP     33    LYS    HE2    507   0.1135      1.008   ; qtot 4.2207
+  508         N3     33    LYS     NZ    508  -0.3854     14.010   ; qtot 3.8353
+  509          H     33    LYS    HZ1    509   0.3400      1.008   ; qtot 4.1753
+  510          H     33    LYS    HZ2    510   0.3400      1.008   ; qtot 4.5153
+  511          H     33    LYS    HZ3    511   0.3400      1.008   ; qtot 4.8553
+  512          C     33    LYS      C    512   0.7341     12.010   ; qtot 5.5894
+  513          O     33    LYS      O    513  -0.5894     16.000   ; qtot 5.0000
+; residue   34 PHE rtp PHE q 0.0
+  514          N     34    PHE      N    514  -0.4157     14.010   ; qtot 4.5843
+  515          H     34    PHE      H    515   0.2719      1.008   ; qtot 4.8562
+  516         CT     34    PHE     CA    516  -0.0024     12.010   ; qtot 4.8538
+  517         H1     34    PHE     HA    517   0.0978      1.008   ; qtot 4.9516
+  518         CT     34    PHE     CB    518  -0.0343     12.010   ; qtot 4.9173
+  519         HC     34    PHE    HB1    519   0.0295      1.008   ; qtot 4.9468
+  520         HC     34    PHE    HB2    520   0.0295      1.008   ; qtot 4.9763
+  521         CA     34    PHE     CG    521   0.0118     12.010   ; qtot 4.9881
+  522         CA     34    PHE    CD1    522  -0.1256     12.010   ; qtot 4.8625
+  523         HA     34    PHE    HD1    523   0.1330      1.008   ; qtot 4.9955
+  524         CA     34    PHE    CE1    524  -0.1704     12.010   ; qtot 4.8251
+  525         HA     34    PHE    HE1    525   0.1430      1.008   ; qtot 4.9681
+  526         CA     34    PHE     CZ    526  -0.1072     12.010   ; qtot 4.8609
+  527         HA     34    PHE     HZ    527   0.1297      1.008   ; qtot 4.9906
+  528         CA     34    PHE    CE2    528  -0.1704     12.010   ; qtot 4.8202
+  529         HA     34    PHE    HE2    529   0.1430      1.008   ; qtot 4.9632
+  530         CA     34    PHE    CD2    530  -0.1256     12.010   ; qtot 4.8376
+  531         HA     34    PHE    HD2    531   0.1330      1.008   ; qtot 4.9706
+  532          C     34    PHE      C    532   0.5973     12.010   ; qtot 5.5679
+  533          O     34    PHE      O    533  -0.5679     16.000   ; qtot 5.0000
+; residue   35 GLU rtp GLU q -1.0
+  534          N     35    GLU      N    534  -0.5163     14.010   ; qtot 4.4837
+  535          H     35    GLU      H    535   0.2936      1.008   ; qtot 4.7773
+  536         CT     35    GLU     CA    536   0.0397     12.010   ; qtot 4.8170
+  537         H1     35    GLU     HA    537   0.1105      1.008   ; qtot 4.9275
+  538         CT     35    GLU     CB    538   0.0560     12.010   ; qtot 4.9835
+  539         HC     35    GLU    HB1    539  -0.0173      1.008   ; qtot 4.9662
+  540         HC     35    GLU    HB2    540  -0.0173      1.008   ; qtot 4.9489
+  541         CT     35    GLU     CG    541   0.0136     12.010   ; qtot 4.9625
+  542         HC     35    GLU    HG1    542  -0.0425      1.008   ; qtot 4.9200
+  543         HC     35    GLU    HG2    543  -0.0425      1.008   ; qtot 4.8775
+  544          C     35    GLU     CD    544   0.8054     12.010   ; qtot 5.6829
+  545         O2     35    GLU    OE1    545  -0.8188     16.000   ; qtot 4.8641
+  546         O2     35    GLU    OE2    546  -0.8188     16.000   ; qtot 4.0453
+  547          C     35    GLU      C    547   0.5366     12.010   ; qtot 4.5819
+  548          O     35    GLU      O    548  -0.5819     16.000   ; qtot 4.0000
+; residue   36 SER rtp SER q 0.0
+  549          N     36    SER      N    549  -0.4157     14.010   ; qtot 3.5843
+  550          H     36    SER      H    550   0.2719      1.008   ; qtot 3.8562
+  551         CT     36    SER     CA    551  -0.0249     12.010   ; qtot 3.8313
+  552         H1     36    SER     HA    552   0.0843      1.008   ; qtot 3.9156
+  553         CT     36    SER     CB    553   0.2117     12.010   ; qtot 4.1273
+  554         H1     36    SER    HB1    554   0.0352      1.008   ; qtot 4.1625
+  555         H1     36    SER    HB2    555   0.0352      1.008   ; qtot 4.1977
+  556         OH     36    SER     OG    556  -0.6546     16.000   ; qtot 3.5431
+  557         HO     36    SER     HG    557   0.4275      1.008   ; qtot 3.9706
+  558          C     36    SER      C    558   0.5973     12.010   ; qtot 4.5679
+  559          O     36    SER      O    559  -0.5679     16.000   ; qtot 4.0000
+; residue   37 ASN rtp ASN q 0.0
+  560          N     37    ASN      N    560  -0.4157     14.010   ; qtot 3.5843
+  561          H     37    ASN      H    561   0.2719      1.008   ; qtot 3.8562
+  562         CT     37    ASN     CA    562   0.0143     12.010   ; qtot 3.8705
+  563         H1     37    ASN     HA    563   0.1048      1.008   ; qtot 3.9753
+  564         CT     37    ASN     CB    564  -0.2041     12.010   ; qtot 3.7712
+  565         HC     37    ASN    HB1    565   0.0797      1.008   ; qtot 3.8509
+  566         HC     37    ASN    HB2    566   0.0797      1.008   ; qtot 3.9306
+  567          C     37    ASN     CG    567   0.7130     12.010   ; qtot 4.6436
+  568          O     37    ASN    OD1    568  -0.5931     16.000   ; qtot 4.0505
+  569          N     37    ASN    ND2    569  -0.9191     14.010   ; qtot 3.1314
+  570          H     37    ASN   HD21    570   0.4196      1.008   ; qtot 3.5510
+  571          H     37    ASN   HD22    571   0.4196      1.008   ; qtot 3.9706
+  572          C     37    ASN      C    572   0.5973     12.010   ; qtot 4.5679
+  573          O     37    ASN      O    573  -0.5679     16.000   ; qtot 4.0000
+; residue   38 PHE rtp PHE q 0.0
+  574          N     38    PHE      N    574  -0.4157     14.010   ; qtot 3.5843
+  575          H     38    PHE      H    575   0.2719      1.008   ; qtot 3.8562
+  576         CT     38    PHE     CA    576  -0.0024     12.010   ; qtot 3.8538
+  577         H1     38    PHE     HA    577   0.0978      1.008   ; qtot 3.9516
+  578         CT     38    PHE     CB    578  -0.0343     12.010   ; qtot 3.9173
+  579         HC     38    PHE    HB1    579   0.0295      1.008   ; qtot 3.9468
+  580         HC     38    PHE    HB2    580   0.0295      1.008   ; qtot 3.9763
+  581         CA     38    PHE     CG    581   0.0118     12.010   ; qtot 3.9881
+  582         CA     38    PHE    CD1    582  -0.1256     12.010   ; qtot 3.8625
+  583         HA     38    PHE    HD1    583   0.1330      1.008   ; qtot 3.9955
+  584         CA     38    PHE    CE1    584  -0.1704     12.010   ; qtot 3.8251
+  585         HA     38    PHE    HE1    585   0.1430      1.008   ; qtot 3.9681
+  586         CA     38    PHE     CZ    586  -0.1072     12.010   ; qtot 3.8609
+  587         HA     38    PHE     HZ    587   0.1297      1.008   ; qtot 3.9906
+  588         CA     38    PHE    CE2    588  -0.1704     12.010   ; qtot 3.8202
+  589         HA     38    PHE    HE2    589   0.1430      1.008   ; qtot 3.9632
+  590         CA     38    PHE    CD2    590  -0.1256     12.010   ; qtot 3.8376
+  591         HA     38    PHE    HD2    591   0.1330      1.008   ; qtot 3.9706
+  592          C     38    PHE      C    592   0.5973     12.010   ; qtot 4.5679
+  593          O     38    PHE      O    593  -0.5679     16.000   ; qtot 4.0000
+; residue   39 ASN rtp ASN q 0.0
+  594          N     39    ASN      N    594  -0.4157     14.010   ; qtot 3.5843
+  595          H     39    ASN      H    595   0.2719      1.008   ; qtot 3.8562
+  596         CT     39    ASN     CA    596   0.0143     12.010   ; qtot 3.8705
+  597         H1     39    ASN     HA    597   0.1048      1.008   ; qtot 3.9753
+  598         CT     39    ASN     CB    598  -0.2041     12.010   ; qtot 3.7712
+  599         HC     39    ASN    HB1    599   0.0797      1.008   ; qtot 3.8509
+  600         HC     39    ASN    HB2    600   0.0797      1.008   ; qtot 3.9306
+  601          C     39    ASN     CG    601   0.7130     12.010   ; qtot 4.6436
+  602          O     39    ASN    OD1    602  -0.5931     16.000   ; qtot 4.0505
+  603          N     39    ASN    ND2    603  -0.9191     14.010   ; qtot 3.1314
+  604          H     39    ASN   HD21    604   0.4196      1.008   ; qtot 3.5510
+  605          H     39    ASN   HD22    605   0.4196      1.008   ; qtot 3.9706
+  606          C     39    ASN      C    606   0.5973     12.010   ; qtot 4.5679
+  607          O     39    ASN      O    607  -0.5679     16.000   ; qtot 4.0000
+; residue   40 THR rtp THR q 0.0
+  608          N     40    THR      N    608  -0.4157     14.010   ; qtot 3.5843
+  609          H     40    THR      H    609   0.2719      1.008   ; qtot 3.8562
+  610         CT     40    THR     CA    610  -0.0389     12.010   ; qtot 3.8173
+  611         H1     40    THR     HA    611   0.1007      1.008   ; qtot 3.9180
+  612         CT     40    THR     CB    612   0.3654     12.010   ; qtot 4.2834
+  613         H1     40    THR     HB    613   0.0043      1.008   ; qtot 4.2877
+  614         CT     40    THR    CG2    614  -0.2438     12.010   ; qtot 4.0439
+  615         HC     40    THR   HG21    615   0.0642      1.008   ; qtot 4.1081
+  616         HC     40    THR   HG22    616   0.0642      1.008   ; qtot 4.1723
+  617         HC     40    THR   HG23    617   0.0642      1.008   ; qtot 4.2365
+  618         OH     40    THR    OG1    618  -0.6761     16.000   ; qtot 3.5604
+  619         HO     40    THR    HG1    619   0.4102      1.008   ; qtot 3.9706
+  620          C     40    THR      C    620   0.5973     12.010   ; qtot 4.5679
+  621          O     40    THR      O    621  -0.5679     16.000   ; qtot 4.0000
+; residue   41 GLN rtp GLN q 0.0
+  622          N     41    GLN      N    622  -0.4157     14.010   ; qtot 3.5843
+  623          H     41    GLN      H    623   0.2719      1.008   ; qtot 3.8562
+  624         CT     41    GLN     CA    624  -0.0031     12.010   ; qtot 3.8531
+  625         H1     41    GLN     HA    625   0.0850      1.008   ; qtot 3.9381
+  626         CT     41    GLN     CB    626  -0.0036     12.010   ; qtot 3.9345
+  627         HC     41    GLN    HB1    627   0.0171      1.008   ; qtot 3.9516
+  628         HC     41    GLN    HB2    628   0.0171      1.008   ; qtot 3.9687
+  629         CT     41    GLN     CG    629  -0.0645     12.010   ; qtot 3.9042
+  630         HC     41    GLN    HG1    630   0.0352      1.008   ; qtot 3.9394
+  631         HC     41    GLN    HG2    631   0.0352      1.008   ; qtot 3.9746
+  632          C     41    GLN     CD    632   0.6951     12.010   ; qtot 4.6697
+  633          O     41    GLN    OE1    633  -0.6086     16.000   ; qtot 4.0611
+  634          N     41    GLN    NE2    634  -0.9407     14.010   ; qtot 3.1204
+  635          H     41    GLN   HE21    635   0.4251      1.008   ; qtot 3.5455
+  636          H     41    GLN   HE22    636   0.4251      1.008   ; qtot 3.9706
+  637          C     41    GLN      C    637   0.5973     12.010   ; qtot 4.5679
+  638          O     41    GLN      O    638  -0.5679     16.000   ; qtot 4.0000
+; residue   42 ALA rtp ALA q 0.0
+  639          N     42    ALA      N    639  -0.4157     14.010   ; qtot 3.5843
+  640          H     42    ALA      H    640   0.2719      1.008   ; qtot 3.8562
+  641         CT     42    ALA     CA    641   0.0337     12.010   ; qtot 3.8899
+  642         H1     42    ALA     HA    642   0.0823      1.008   ; qtot 3.9722
+  643         CT     42    ALA     CB    643  -0.1825     12.010   ; qtot 3.7897
+  644         HC     42    ALA    HB1    644   0.0603      1.008   ; qtot 3.8500
+  645         HC     42    ALA    HB2    645   0.0603      1.008   ; qtot 3.9103
+  646         HC     42    ALA    HB3    646   0.0603      1.008   ; qtot 3.9706
+  647          C     42    ALA      C    647   0.5973     12.010   ; qtot 4.5679
+  648          O     42    ALA      O    648  -0.5679     16.000   ; qtot 4.0000
+; residue   43 THR rtp THR q 0.0
+  649          N     43    THR      N    649  -0.4157     14.010   ; qtot 3.5843
+  650          H     43    THR      H    650   0.2719      1.008   ; qtot 3.8562
+  651         CT     43    THR     CA    651  -0.0389     12.010   ; qtot 3.8173
+  652         H1     43    THR     HA    652   0.1007      1.008   ; qtot 3.9180
+  653         CT     43    THR     CB    653   0.3654     12.010   ; qtot 4.2834
+  654         H1     43    THR     HB    654   0.0043      1.008   ; qtot 4.2877
+  655         CT     43    THR    CG2    655  -0.2438     12.010   ; qtot 4.0439
+  656         HC     43    THR   HG21    656   0.0642      1.008   ; qtot 4.1081
+  657         HC     43    THR   HG22    657   0.0642      1.008   ; qtot 4.1723
+  658         HC     43    THR   HG23    658   0.0642      1.008   ; qtot 4.2365
+  659         OH     43    THR    OG1    659  -0.6761     16.000   ; qtot 3.5604
+  660         HO     43    THR    HG1    660   0.4102      1.008   ; qtot 3.9706
+  661          C     43    THR      C    661   0.5973     12.010   ; qtot 4.5679
+  662          O     43    THR      O    662  -0.5679     16.000   ; qtot 4.0000
+; residue   44 ASN rtp ASN q 0.0
+  663          N     44    ASN      N    663  -0.4157     14.010   ; qtot 3.5843
+  664          H     44    ASN      H    664   0.2719      1.008   ; qtot 3.8562
+  665         CT     44    ASN     CA    665   0.0143     12.010   ; qtot 3.8705
+  666         H1     44    ASN     HA    666   0.1048      1.008   ; qtot 3.9753
+  667         CT     44    ASN     CB    667  -0.2041     12.010   ; qtot 3.7712
+  668         HC     44    ASN    HB1    668   0.0797      1.008   ; qtot 3.8509
+  669         HC     44    ASN    HB2    669   0.0797      1.008   ; qtot 3.9306
+  670          C     44    ASN     CG    670   0.7130     12.010   ; qtot 4.6436
+  671          O     44    ASN    OD1    671  -0.5931     16.000   ; qtot 4.0505
+  672          N     44    ASN    ND2    672  -0.9191     14.010   ; qtot 3.1314
+  673          H     44    ASN   HD21    673   0.4196      1.008   ; qtot 3.5510
+  674          H     44    ASN   HD22    674   0.4196      1.008   ; qtot 3.9706
+  675          C     44    ASN      C    675   0.5973     12.010   ; qtot 4.5679
+  676          O     44    ASN      O    676  -0.5679     16.000   ; qtot 4.0000
+; residue   45 ARG rtp ARG q 1.0
+  677          N     45    ARG      N    677  -0.3479     14.010   ; qtot 3.6521
+  678          H     45    ARG      H    678   0.2747      1.008   ; qtot 3.9268
+  679         CT     45    ARG     CA    679  -0.2637     12.010   ; qtot 3.6631
+  680         H1     45    ARG     HA    680   0.1560      1.008   ; qtot 3.8191
+  681         CT     45    ARG     CB    681  -0.0007     12.010   ; qtot 3.8184
+  682         HC     45    ARG    HB1    682   0.0327      1.008   ; qtot 3.8511
+  683         HC     45    ARG    HB2    683   0.0327      1.008   ; qtot 3.8838
+  684         CT     45    ARG     CG    684   0.0390     12.010   ; qtot 3.9228
+  685         HC     45    ARG    HG1    685   0.0285      1.008   ; qtot 3.9513
+  686         HC     45    ARG    HG2    686   0.0285      1.008   ; qtot 3.9798
+  687         CT     45    ARG     CD    687   0.0486     12.010   ; qtot 4.0284
+  688         H1     45    ARG    HD1    688   0.0687      1.008   ; qtot 4.0971
+  689         H1     45    ARG    HD2    689   0.0687      1.008   ; qtot 4.1658
+  690         N2     45    ARG     NE    690  -0.5295     14.010   ; qtot 3.6363
+  691          H     45    ARG     HE    691   0.3456      1.008   ; qtot 3.9819
+  692         CA     45    ARG     CZ    692   0.8076     12.010   ; qtot 4.7895
+  693         N2     45    ARG    NH1    693  -0.8627     14.010   ; qtot 3.9268
+  694          H     45    ARG   HH11    694   0.4478      1.008   ; qtot 4.3746
+  695          H     45    ARG   HH12    695   0.4478      1.008   ; qtot 4.8224
+  696         N2     45    ARG    NH2    696  -0.8627     14.010   ; qtot 3.9597
+  697          H     45    ARG   HH21    697   0.4478      1.008   ; qtot 4.4075
+  698          H     45    ARG   HH22    698   0.4478      1.008   ; qtot 4.8553
+  699          C     45    ARG      C    699   0.7341     12.010   ; qtot 5.5894
+  700          O     45    ARG      O    700  -0.5894     16.000   ; qtot 5.0000
+; residue   46 ASN rtp ASN q 0.0
+  701          N     46    ASN      N    701  -0.4157     14.010   ; qtot 4.5843
+  702          H     46    ASN      H    702   0.2719      1.008   ; qtot 4.8562
+  703         CT     46    ASN     CA    703   0.0143     12.010   ; qtot 4.8705
+  704         H1     46    ASN     HA    704   0.1048      1.008   ; qtot 4.9753
+  705         CT     46    ASN     CB    705  -0.2041     12.010   ; qtot 4.7712
+  706         HC     46    ASN    HB1    706   0.0797      1.008   ; qtot 4.8509
+  707         HC     46    ASN    HB2    707   0.0797      1.008   ; qtot 4.9306
+  708          C     46    ASN     CG    708   0.7130     12.010   ; qtot 5.6436
+  709          O     46    ASN    OD1    709  -0.5931     16.000   ; qtot 5.0505
+  710          N     46    ASN    ND2    710  -0.9191     14.010   ; qtot 4.1314
+  711          H     46    ASN   HD21    711   0.4196      1.008   ; qtot 4.5510
+  712          H     46    ASN   HD22    712   0.4196      1.008   ; qtot 4.9706
+  713          C     46    ASN      C    713   0.5973     12.010   ; qtot 5.5679
+  714          O     46    ASN      O    714  -0.5679     16.000   ; qtot 5.0000
+; residue   47 THR rtp THR q 0.0
+  715          N     47    THR      N    715  -0.4157     14.010   ; qtot 4.5843
+  716          H     47    THR      H    716   0.2719      1.008   ; qtot 4.8562
+  717         CT     47    THR     CA    717  -0.0389     12.010   ; qtot 4.8173
+  718         H1     47    THR     HA    718   0.1007      1.008   ; qtot 4.9180
+  719         CT     47    THR     CB    719   0.3654     12.010   ; qtot 5.2834
+  720         H1     47    THR     HB    720   0.0043      1.008   ; qtot 5.2877
+  721         CT     47    THR    CG2    721  -0.2438     12.010   ; qtot 5.0439
+  722         HC     47    THR   HG21    722   0.0642      1.008   ; qtot 5.1081
+  723         HC     47    THR   HG22    723   0.0642      1.008   ; qtot 5.1723
+  724         HC     47    THR   HG23    724   0.0642      1.008   ; qtot 5.2365
+  725         OH     47    THR    OG1    725  -0.6761     16.000   ; qtot 4.5604
+  726         HO     47    THR    HG1    726   0.4102      1.008   ; qtot 4.9706
+  727          C     47    THR      C    727   0.5973     12.010   ; qtot 5.5679
+  728          O     47    THR      O    728  -0.5679     16.000   ; qtot 5.0000
+; residue   48 ASP rtp ASP q -1.0
+  729          N     48    ASP      N    729  -0.5163     14.010   ; qtot 4.4837
+  730          H     48    ASP      H    730   0.2936      1.008   ; qtot 4.7773
+  731         CT     48    ASP     CA    731   0.0381     12.010   ; qtot 4.8154
+  732         H1     48    ASP     HA    732   0.0880      1.008   ; qtot 4.9034
+  733         CT     48    ASP     CB    733  -0.0303     12.010   ; qtot 4.8731
+  734         HC     48    ASP    HB1    734  -0.0122      1.008   ; qtot 4.8609
+  735         HC     48    ASP    HB2    735  -0.0122      1.008   ; qtot 4.8487
+  736          C     48    ASP     CG    736   0.7994     12.010   ; qtot 5.6481
+  737         O2     48    ASP    OD1    737  -0.8014     16.000   ; qtot 4.8467
+  738         O2     48    ASP    OD2    738  -0.8014     16.000   ; qtot 4.0453
+  739          C     48    ASP      C    739   0.5366     12.010   ; qtot 4.5819
+  740          O     48    ASP      O    740  -0.5819     16.000   ; qtot 4.0000
+; residue   49 GLY rtp GLY q 0.0
+  741          N     49    GLY      N    741  -0.4157     14.010   ; qtot 3.5843
+  742          H     49    GLY      H    742   0.2719      1.008   ; qtot 3.8562
+  743         CT     49    GLY     CA    743  -0.0252     12.010   ; qtot 3.8310
+  744         H1     49    GLY    HA1    744   0.0698      1.008   ; qtot 3.9008
+  745         H1     49    GLY    HA2    745   0.0698      1.008   ; qtot 3.9706
+  746          C     49    GLY      C    746   0.5973     12.010   ; qtot 4.5679
+  747          O     49    GLY      O    747  -0.5679     16.000   ; qtot 4.0000
+; residue   50 SER rtp SER q 0.0
+  748          N     50    SER      N    748  -0.4157     14.010   ; qtot 3.5843
+  749          H     50    SER      H    749   0.2719      1.008   ; qtot 3.8562
+  750         CT     50    SER     CA    750  -0.0249     12.010   ; qtot 3.8313
+  751         H1     50    SER     HA    751   0.0843      1.008   ; qtot 3.9156
+  752         CT     50    SER     CB    752   0.2117     12.010   ; qtot 4.1273
+  753         H1     50    SER    HB1    753   0.0352      1.008   ; qtot 4.1625
+  754         H1     50    SER    HB2    754   0.0352      1.008   ; qtot 4.1977
+  755         OH     50    SER     OG    755  -0.6546     16.000   ; qtot 3.5431
+  756         HO     50    SER     HG    756   0.4275      1.008   ; qtot 3.9706
+  757          C     50    SER      C    757   0.5973     12.010   ; qtot 4.5679
+  758          O     50    SER      O    758  -0.5679     16.000   ; qtot 4.0000
+; residue   51 THR rtp THR q 0.0
+  759          N     51    THR      N    759  -0.4157     14.010   ; qtot 3.5843
+  760          H     51    THR      H    760   0.2719      1.008   ; qtot 3.8562
+  761         CT     51    THR     CA    761  -0.0389     12.010   ; qtot 3.8173
+  762         H1     51    THR     HA    762   0.1007      1.008   ; qtot 3.9180
+  763         CT     51    THR     CB    763   0.3654     12.010   ; qtot 4.2834
+  764         H1     51    THR     HB    764   0.0043      1.008   ; qtot 4.2877
+  765         CT     51    THR    CG2    765  -0.2438     12.010   ; qtot 4.0439
+  766         HC     51    THR   HG21    766   0.0642      1.008   ; qtot 4.1081
+  767         HC     51    THR   HG22    767   0.0642      1.008   ; qtot 4.1723
+  768         HC     51    THR   HG23    768   0.0642      1.008   ; qtot 4.2365
+  769         OH     51    THR    OG1    769  -0.6761     16.000   ; qtot 3.5604
+  770         HO     51    THR    HG1    770   0.4102      1.008   ; qtot 3.9706
+  771          C     51    THR      C    771   0.5973     12.010   ; qtot 4.5679
+  772          O     51    THR      O    772  -0.5679     16.000   ; qtot 4.0000
+; residue   52 ASP rtp ASP q -1.0
+  773          N     52    ASP      N    773  -0.5163     14.010   ; qtot 3.4837
+  774          H     52    ASP      H    774   0.2936      1.008   ; qtot 3.7773
+  775         CT     52    ASP     CA    775   0.0381     12.010   ; qtot 3.8154
+  776         H1     52    ASP     HA    776   0.0880      1.008   ; qtot 3.9034
+  777         CT     52    ASP     CB    777  -0.0303     12.010   ; qtot 3.8731
+  778         HC     52    ASP    HB1    778  -0.0122      1.008   ; qtot 3.8609
+  779         HC     52    ASP    HB2    779  -0.0122      1.008   ; qtot 3.8487
+  780          C     52    ASP     CG    780   0.7994     12.010   ; qtot 4.6481
+  781         O2     52    ASP    OD1    781  -0.8014     16.000   ; qtot 3.8467
+  782         O2     52    ASP    OD2    782  -0.8014     16.000   ; qtot 3.0453
+  783          C     52    ASP      C    783   0.5366     12.010   ; qtot 3.5819
+  784          O     52    ASP      O    784  -0.5819     16.000   ; qtot 3.0000
+; residue   53 TYR rtp TYR q 0.0
+  785          N     53    TYR      N    785  -0.4157     14.010   ; qtot 2.5843
+  786          H     53    TYR      H    786   0.2719      1.008   ; qtot 2.8562
+  787         CT     53    TYR     CA    787  -0.0014     12.010   ; qtot 2.8548
+  788         H1     53    TYR     HA    788   0.0876      1.008   ; qtot 2.9424
+  789         CT     53    TYR     CB    789  -0.0152     12.010   ; qtot 2.9272
+  790         HC     53    TYR    HB1    790   0.0295      1.008   ; qtot 2.9567
+  791         HC     53    TYR    HB2    791   0.0295      1.008   ; qtot 2.9862
+  792         CA     53    TYR     CG    792  -0.0011     12.010   ; qtot 2.9851
+  793         CA     53    TYR    CD1    793  -0.1906     12.010   ; qtot 2.7945
+  794         HA     53    TYR    HD1    794   0.1699      1.008   ; qtot 2.9644
+  795         CA     53    TYR    CE1    795  -0.2341     12.010   ; qtot 2.7303
+  796         HA     53    TYR    HE1    796   0.1656      1.008   ; qtot 2.8959
+  797          C     53    TYR     CZ    797   0.3226     12.010   ; qtot 3.2185
+  798         OH     53    TYR     OH    798  -0.5579     16.000   ; qtot 2.6606
+  799         HO     53    TYR     HH    799   0.3992      1.008   ; qtot 3.0598
+  800         CA     53    TYR    CE2    800  -0.2341     12.010   ; qtot 2.8257
+  801         HA     53    TYR    HE2    801   0.1656      1.008   ; qtot 2.9913
+  802         CA     53    TYR    CD2    802  -0.1906     12.010   ; qtot 2.8007
+  803         HA     53    TYR    HD2    803   0.1699      1.008   ; qtot 2.9706
+  804          C     53    TYR      C    804   0.5973     12.010   ; qtot 3.5679
+  805          O     53    TYR      O    805  -0.5679     16.000   ; qtot 3.0000
+; residue   54 GLY rtp GLY q 0.0
+  806          N     54    GLY      N    806  -0.4157     14.010   ; qtot 2.5843
+  807          H     54    GLY      H    807   0.2719      1.008   ; qtot 2.8562
+  808         CT     54    GLY     CA    808  -0.0252     12.010   ; qtot 2.8310
+  809         H1     54    GLY    HA1    809   0.0698      1.008   ; qtot 2.9008
+  810         H1     54    GLY    HA2    810   0.0698      1.008   ; qtot 2.9706
+  811          C     54    GLY      C    811   0.5973     12.010   ; qtot 3.5679
+  812          O     54    GLY      O    812  -0.5679     16.000   ; qtot 3.0000
+; residue   55 ILE rtp ILE q 0.0
+  813          N     55    ILE      N    813  -0.4157     14.010   ; qtot 2.5843
+  814          H     55    ILE      H    814   0.2719      1.008   ; qtot 2.8562
+  815         CT     55    ILE     CA    815  -0.0597     12.010   ; qtot 2.7965
+  816         H1     55    ILE     HA    816   0.0869      1.008   ; qtot 2.8834
+  817         CT     55    ILE     CB    817   0.1303     12.010   ; qtot 3.0137
+  818         HC     55    ILE     HB    818   0.0187      1.008   ; qtot 3.0324
+  819         CT     55    ILE    CG2    819  -0.3204     12.010   ; qtot 2.7120
+  820         HC     55    ILE   HG21    820   0.0882      1.008   ; qtot 2.8002
+  821         HC     55    ILE   HG22    821   0.0882      1.008   ; qtot 2.8884
+  822         HC     55    ILE   HG23    822   0.0882      1.008   ; qtot 2.9766
+  823         CT     55    ILE    CG1    823  -0.0430     12.010   ; qtot 2.9336
+  824         HC     55    ILE   HG11    824   0.0236      1.008   ; qtot 2.9572
+  825         HC     55    ILE   HG12    825   0.0236      1.008   ; qtot 2.9808
+  826         CT     55    ILE     CD    826  -0.0660     12.010   ; qtot 2.9148
+  827         HC     55    ILE    HD1    827   0.0186      1.008   ; qtot 2.9334
+  828         HC     55    ILE    HD2    828   0.0186      1.008   ; qtot 2.9520
+  829         HC     55    ILE    HD3    829   0.0186      1.008   ; qtot 2.9706
+  830          C     55    ILE      C    830   0.5973     12.010   ; qtot 3.5679
+  831          O     55    ILE      O    831  -0.5679     16.000   ; qtot 3.0000
+; residue   56 LEU rtp LEU q 0.0
+  832          N     56    LEU      N    832  -0.4157     14.010   ; qtot 2.5843
+  833          H     56    LEU      H    833   0.2719      1.008   ; qtot 2.8562
+  834         CT     56    LEU     CA    834  -0.0518     12.010   ; qtot 2.8044
+  835         H1     56    LEU     HA    835   0.0922      1.008   ; qtot 2.8966
+  836         CT     56    LEU     CB    836  -0.1102     12.010   ; qtot 2.7864
+  837         HC     56    LEU    HB1    837   0.0457      1.008   ; qtot 2.8321
+  838         HC     56    LEU    HB2    838   0.0457      1.008   ; qtot 2.8778
+  839         CT     56    LEU     CG    839   0.3531     12.010   ; qtot 3.2309
+  840         HC     56    LEU     HG    840  -0.0361      1.008   ; qtot 3.1948
+  841         CT     56    LEU    CD1    841  -0.4121     12.010   ; qtot 2.7827
+  842         HC     56    LEU   HD11    842   0.1000      1.008   ; qtot 2.8827
+  843         HC     56    LEU   HD12    843   0.1000      1.008   ; qtot 2.9827
+  844         HC     56    LEU   HD13    844   0.1000      1.008   ; qtot 3.0827
+  845         CT     56    LEU    CD2    845  -0.4121     12.010   ; qtot 2.6706
+  846         HC     56    LEU   HD21    846   0.1000      1.008   ; qtot 2.7706
+  847         HC     56    LEU   HD22    847   0.1000      1.008   ; qtot 2.8706
+  848         HC     56    LEU   HD23    848   0.1000      1.008   ; qtot 2.9706
+  849          C     56    LEU      C    849   0.5973     12.010   ; qtot 3.5679
+  850          O     56    LEU      O    850  -0.5679     16.000   ; qtot 3.0000
+; residue   57 GLN rtp GLN q 0.0
+  851          N     57    GLN      N    851  -0.4157     14.010   ; qtot 2.5843
+  852          H     57    GLN      H    852   0.2719      1.008   ; qtot 2.8562
+  853         CT     57    GLN     CA    853  -0.0031     12.010   ; qtot 2.8531
+  854         H1     57    GLN     HA    854   0.0850      1.008   ; qtot 2.9381
+  855         CT     57    GLN     CB    855  -0.0036     12.010   ; qtot 2.9345
+  856         HC     57    GLN    HB1    856   0.0171      1.008   ; qtot 2.9516
+  857         HC     57    GLN    HB2    857   0.0171      1.008   ; qtot 2.9687
+  858         CT     57    GLN     CG    858  -0.0645     12.010   ; qtot 2.9042
+  859         HC     57    GLN    HG1    859   0.0352      1.008   ; qtot 2.9394
+  860         HC     57    GLN    HG2    860   0.0352      1.008   ; qtot 2.9746
+  861          C     57    GLN     CD    861   0.6951     12.010   ; qtot 3.6697
+  862          O     57    GLN    OE1    862  -0.6086     16.000   ; qtot 3.0611
+  863          N     57    GLN    NE2    863  -0.9407     14.010   ; qtot 2.1204
+  864          H     57    GLN   HE21    864   0.4251      1.008   ; qtot 2.5455
+  865          H     57    GLN   HE22    865   0.4251      1.008   ; qtot 2.9706
+  866          C     57    GLN      C    866   0.5973     12.010   ; qtot 3.5679
+  867          O     57    GLN      O    867  -0.5679     16.000   ; qtot 3.0000
+; residue   58 ILE rtp ILE q 0.0
+  868          N     58    ILE      N    868  -0.4157     14.010   ; qtot 2.5843
+  869          H     58    ILE      H    869   0.2719      1.008   ; qtot 2.8562
+  870         CT     58    ILE     CA    870  -0.0597     12.010   ; qtot 2.7965
+  871         H1     58    ILE     HA    871   0.0869      1.008   ; qtot 2.8834
+  872         CT     58    ILE     CB    872   0.1303     12.010   ; qtot 3.0137
+  873         HC     58    ILE     HB    873   0.0187      1.008   ; qtot 3.0324
+  874         CT     58    ILE    CG2    874  -0.3204     12.010   ; qtot 2.7120
+  875         HC     58    ILE   HG21    875   0.0882      1.008   ; qtot 2.8002
+  876         HC     58    ILE   HG22    876   0.0882      1.008   ; qtot 2.8884
+  877         HC     58    ILE   HG23    877   0.0882      1.008   ; qtot 2.9766
+  878         CT     58    ILE    CG1    878  -0.0430     12.010   ; qtot 2.9336
+  879         HC     58    ILE   HG11    879   0.0236      1.008   ; qtot 2.9572
+  880         HC     58    ILE   HG12    880   0.0236      1.008   ; qtot 2.9808
+  881         CT     58    ILE     CD    881  -0.0660     12.010   ; qtot 2.9148
+  882         HC     58    ILE    HD1    882   0.0186      1.008   ; qtot 2.9334
+  883         HC     58    ILE    HD2    883   0.0186      1.008   ; qtot 2.9520
+  884         HC     58    ILE    HD3    884   0.0186      1.008   ; qtot 2.9706
+  885          C     58    ILE      C    885   0.5973     12.010   ; qtot 3.5679
+  886          O     58    ILE      O    886  -0.5679     16.000   ; qtot 3.0000
+; residue   59 ASN rtp ASN q 0.0
+  887          N     59    ASN      N    887  -0.4157     14.010   ; qtot 2.5843
+  888          H     59    ASN      H    888   0.2719      1.008   ; qtot 2.8562
+  889         CT     59    ASN     CA    889   0.0143     12.010   ; qtot 2.8705
+  890         H1     59    ASN     HA    890   0.1048      1.008   ; qtot 2.9753
+  891         CT     59    ASN     CB    891  -0.2041     12.010   ; qtot 2.7712
+  892         HC     59    ASN    HB1    892   0.0797      1.008   ; qtot 2.8509
+  893         HC     59    ASN    HB2    893   0.0797      1.008   ; qtot 2.9306
+  894          C     59    ASN     CG    894   0.7130     12.010   ; qtot 3.6436
+  895          O     59    ASN    OD1    895  -0.5931     16.000   ; qtot 3.0505
+  896          N     59    ASN    ND2    896  -0.9191     14.010   ; qtot 2.1314
+  897          H     59    ASN   HD21    897   0.4196      1.008   ; qtot 2.5510
+  898          H     59    ASN   HD22    898   0.4196      1.008   ; qtot 2.9706
+  899          C     59    ASN      C    899   0.5973     12.010   ; qtot 3.5679
+  900          O     59    ASN      O    900  -0.5679     16.000   ; qtot 3.0000
+; residue   60 SER rtp SER q 0.0
+  901          N     60    SER      N    901  -0.4157     14.010   ; qtot 2.5843
+  902          H     60    SER      H    902   0.2719      1.008   ; qtot 2.8562
+  903         CT     60    SER     CA    903  -0.0249     12.010   ; qtot 2.8313
+  904         H1     60    SER     HA    904   0.0843      1.008   ; qtot 2.9156
+  905         CT     60    SER     CB    905   0.2117     12.010   ; qtot 3.1273
+  906         H1     60    SER    HB1    906   0.0352      1.008   ; qtot 3.1625
+  907         H1     60    SER    HB2    907   0.0352      1.008   ; qtot 3.1977
+  908         OH     60    SER     OG    908  -0.6546     16.000   ; qtot 2.5431
+  909         HO     60    SER     HG    909   0.4275      1.008   ; qtot 2.9706
+  910          C     60    SER      C    910   0.5973     12.010   ; qtot 3.5679
+  911          O     60    SER      O    911  -0.5679     16.000   ; qtot 3.0000
+; residue   61 ARG rtp ARG q 1.0
+  912          N     61    ARG      N    912  -0.3479     14.010   ; qtot 2.6521
+  913          H     61    ARG      H    913   0.2747      1.008   ; qtot 2.9268
+  914         CT     61    ARG     CA    914  -0.2637     12.010   ; qtot 2.6631
+  915         H1     61    ARG     HA    915   0.1560      1.008   ; qtot 2.8191
+  916         CT     61    ARG     CB    916  -0.0007     12.010   ; qtot 2.8184
+  917         HC     61    ARG    HB1    917   0.0327      1.008   ; qtot 2.8511
+  918         HC     61    ARG    HB2    918   0.0327      1.008   ; qtot 2.8838
+  919         CT     61    ARG     CG    919   0.0390     12.010   ; qtot 2.9228
+  920         HC     61    ARG    HG1    920   0.0285      1.008   ; qtot 2.9513
+  921         HC     61    ARG    HG2    921   0.0285      1.008   ; qtot 2.9798
+  922         CT     61    ARG     CD    922   0.0486     12.010   ; qtot 3.0284
+  923         H1     61    ARG    HD1    923   0.0687      1.008   ; qtot 3.0971
+  924         H1     61    ARG    HD2    924   0.0687      1.008   ; qtot 3.1658
+  925         N2     61    ARG     NE    925  -0.5295     14.010   ; qtot 2.6363
+  926          H     61    ARG     HE    926   0.3456      1.008   ; qtot 2.9819
+  927         CA     61    ARG     CZ    927   0.8076     12.010   ; qtot 3.7895
+  928         N2     61    ARG    NH1    928  -0.8627     14.010   ; qtot 2.9268
+  929          H     61    ARG   HH11    929   0.4478      1.008   ; qtot 3.3746
+  930          H     61    ARG   HH12    930   0.4478      1.008   ; qtot 3.8224
+  931         N2     61    ARG    NH2    931  -0.8627     14.010   ; qtot 2.9597
+  932          H     61    ARG   HH21    932   0.4478      1.008   ; qtot 3.4075
+  933          H     61    ARG   HH22    933   0.4478      1.008   ; qtot 3.8553
+  934          C     61    ARG      C    934   0.7341     12.010   ; qtot 4.5894
+  935          O     61    ARG      O    935  -0.5894     16.000   ; qtot 4.0000
+; residue   62 TRP rtp TRP q 0.0
+  936          N     62    TRP      N    936  -0.4157     14.010   ; qtot 3.5843
+  937          H     62    TRP      H    937   0.2719      1.008   ; qtot 3.8562
+  938         CT     62    TRP     CA    938  -0.0275     12.010   ; qtot 3.8287
+  939         H1     62    TRP     HA    939   0.1123      1.008   ; qtot 3.9410
+  940         CT     62    TRP     CB    940  -0.0050     12.010   ; qtot 3.9360
+  941         HC     62    TRP    HB1    941   0.0339      1.008   ; qtot 3.9699
+  942         HC     62    TRP    HB2    942   0.0339      1.008   ; qtot 4.0038
+  943         C*     62    TRP     CG    943  -0.1415     12.010   ; qtot 3.8623
+  944         CW     62    TRP    CD1    944  -0.1638     12.010   ; qtot 3.6985
+  945         H4     62    TRP    HD1    945   0.2062      1.008   ; qtot 3.9047
+  946         NA     62    TRP    NE1    946  -0.3418     14.010   ; qtot 3.5629
+  947          H     62    TRP    HE1    947   0.3412      1.008   ; qtot 3.9041
+  948         CN     62    TRP    CE2    948   0.1380     12.010   ; qtot 4.0421
+  949         CA     62    TRP    CZ2    949  -0.2601     12.010   ; qtot 3.7820
+  950         HA     62    TRP    HZ2    950   0.1572      1.008   ; qtot 3.9392
+  951         CA     62    TRP    CH2    951  -0.1134     12.010   ; qtot 3.8258
+  952         HA     62    TRP    HH2    952   0.1417      1.008   ; qtot 3.9675
+  953         CA     62    TRP    CZ3    953  -0.1972     12.010   ; qtot 3.7703
+  954         HA     62    TRP    HZ3    954   0.1447      1.008   ; qtot 3.9150
+  955         CA     62    TRP    CE3    955  -0.2387     12.010   ; qtot 3.6763
+  956         HA     62    TRP    HE3    956   0.1700      1.008   ; qtot 3.8463
+  957         CB     62    TRP    CD2    957   0.1243     12.010   ; qtot 3.9706
+  958          C     62    TRP      C    958   0.5973     12.010   ; qtot 4.5679
+  959          O     62    TRP      O    959  -0.5679     16.000   ; qtot 4.0000
+; residue   63 TRP rtp TRP q 0.0
+  960          N     63    TRP      N    960  -0.4157     14.010   ; qtot 3.5843
+  961          H     63    TRP      H    961   0.2719      1.008   ; qtot 3.8562
+  962         CT     63    TRP     CA    962  -0.0275     12.010   ; qtot 3.8287
+  963         H1     63    TRP     HA    963   0.1123      1.008   ; qtot 3.9410
+  964         CT     63    TRP     CB    964  -0.0050     12.010   ; qtot 3.9360
+  965         HC     63    TRP    HB1    965   0.0339      1.008   ; qtot 3.9699
+  966         HC     63    TRP    HB2    966   0.0339      1.008   ; qtot 4.0038
+  967         C*     63    TRP     CG    967  -0.1415     12.010   ; qtot 3.8623
+  968         CW     63    TRP    CD1    968  -0.1638     12.010   ; qtot 3.6985
+  969         H4     63    TRP    HD1    969   0.2062      1.008   ; qtot 3.9047
+  970         NA     63    TRP    NE1    970  -0.3418     14.010   ; qtot 3.5629
+  971          H     63    TRP    HE1    971   0.3412      1.008   ; qtot 3.9041
+  972         CN     63    TRP    CE2    972   0.1380     12.010   ; qtot 4.0421
+  973         CA     63    TRP    CZ2    973  -0.2601     12.010   ; qtot 3.7820
+  974         HA     63    TRP    HZ2    974   0.1572      1.008   ; qtot 3.9392
+  975         CA     63    TRP    CH2    975  -0.1134     12.010   ; qtot 3.8258
+  976         HA     63    TRP    HH2    976   0.1417      1.008   ; qtot 3.9675
+  977         CA     63    TRP    CZ3    977  -0.1972     12.010   ; qtot 3.7703
+  978         HA     63    TRP    HZ3    978   0.1447      1.008   ; qtot 3.9150
+  979         CA     63    TRP    CE3    979  -0.2387     12.010   ; qtot 3.6763
+  980         HA     63    TRP    HE3    980   0.1700      1.008   ; qtot 3.8463
+  981         CB     63    TRP    CD2    981   0.1243     12.010   ; qtot 3.9706
+  982          C     63    TRP      C    982   0.5973     12.010   ; qtot 4.5679
+  983          O     63    TRP      O    983  -0.5679     16.000   ; qtot 4.0000
+; residue   64 CYS rtp CYS q 0.0
+  984          N     64    CYS      N    984  -0.4157     14.010   ; qtot 3.5843
+  985          H     64    CYS      H    985   0.2719      1.008   ; qtot 3.8562
+  986         CT     64    CYS     CA    986   0.0429     12.010   ; qtot 3.8991
+  987         H1     64    CYS     HA    987   0.0766      1.008   ; qtot 3.9757
+  988         CT     64    CYS     CB    988  -0.0790     12.010   ; qtot 3.8967
+  989         H1     64    CYS    HB1    989   0.0910      1.008   ; qtot 3.9877
+  990         H1     64    CYS    HB2    990   0.0910      1.008   ; qtot 4.0787
+  991          S     64    CYS     SG    991  -0.1081     32.060   ; qtot 3.9706
+  992          C     64    CYS      C    992   0.5973     12.010   ; qtot 4.5679
+  993          O     64    CYS      O    993  -0.5679     16.000   ; qtot 4.0000
+; residue   65 ASN rtp ASN q 0.0
+  994          N     65    ASN      N    994  -0.4157     14.010   ; qtot 3.5843
+  995          H     65    ASN      H    995   0.2719      1.008   ; qtot 3.8562
+  996         CT     65    ASN     CA    996   0.0143     12.010   ; qtot 3.8705
+  997         H1     65    ASN     HA    997   0.1048      1.008   ; qtot 3.9753
+  998         CT     65    ASN     CB    998  -0.2041     12.010   ; qtot 3.7712
+  999         HC     65    ASN    HB1    999   0.0797      1.008   ; qtot 3.8509
+ 1000         HC     65    ASN    HB2   1000   0.0797      1.008   ; qtot 3.9306
+ 1001          C     65    ASN     CG   1001   0.7130     12.010   ; qtot 4.6436
+ 1002          O     65    ASN    OD1   1002  -0.5931     16.000   ; qtot 4.0505
+ 1003          N     65    ASN    ND2   1003  -0.9191     14.010   ; qtot 3.1314
+ 1004          H     65    ASN   HD21   1004   0.4196      1.008   ; qtot 3.5510
+ 1005          H     65    ASN   HD22   1005   0.4196      1.008   ; qtot 3.9706
+ 1006          C     65    ASN      C   1006   0.5973     12.010   ; qtot 4.5679
+ 1007          O     65    ASN      O   1007  -0.5679     16.000   ; qtot 4.0000
+; residue   66 ASP rtp ASP q -1.0
+ 1008          N     66    ASP      N   1008  -0.5163     14.010   ; qtot 3.4837
+ 1009          H     66    ASP      H   1009   0.2936      1.008   ; qtot 3.7773
+ 1010         CT     66    ASP     CA   1010   0.0381     12.010   ; qtot 3.8154
+ 1011         H1     66    ASP     HA   1011   0.0880      1.008   ; qtot 3.9034
+ 1012         CT     66    ASP     CB   1012  -0.0303     12.010   ; qtot 3.8731
+ 1013         HC     66    ASP    HB1   1013  -0.0122      1.008   ; qtot 3.8609
+ 1014         HC     66    ASP    HB2   1014  -0.0122      1.008   ; qtot 3.8487
+ 1015          C     66    ASP     CG   1015   0.7994     12.010   ; qtot 4.6481
+ 1016         O2     66    ASP    OD1   1016  -0.8014     16.000   ; qtot 3.8467
+ 1017         O2     66    ASP    OD2   1017  -0.8014     16.000   ; qtot 3.0453
+ 1018          C     66    ASP      C   1018   0.5366     12.010   ; qtot 3.5819
+ 1019          O     66    ASP      O   1019  -0.5819     16.000   ; qtot 3.0000
+; residue   67 GLY rtp GLY q 0.0
+ 1020          N     67    GLY      N   1020  -0.4157     14.010   ; qtot 2.5843
+ 1021          H     67    GLY      H   1021   0.2719      1.008   ; qtot 2.8562
+ 1022         CT     67    GLY     CA   1022  -0.0252     12.010   ; qtot 2.8310
+ 1023         H1     67    GLY    HA1   1023   0.0698      1.008   ; qtot 2.9008
+ 1024         H1     67    GLY    HA2   1024   0.0698      1.008   ; qtot 2.9706
+ 1025          C     67    GLY      C   1025   0.5973     12.010   ; qtot 3.5679
+ 1026          O     67    GLY      O   1026  -0.5679     16.000   ; qtot 3.0000
+; residue   68 ARG rtp ARG q 1.0
+ 1027          N     68    ARG      N   1027  -0.3479     14.010   ; qtot 2.6521
+ 1028          H     68    ARG      H   1028   0.2747      1.008   ; qtot 2.9268
+ 1029         CT     68    ARG     CA   1029  -0.2637     12.010   ; qtot 2.6631
+ 1030         H1     68    ARG     HA   1030   0.1560      1.008   ; qtot 2.8191
+ 1031         CT     68    ARG     CB   1031  -0.0007     12.010   ; qtot 2.8184
+ 1032         HC     68    ARG    HB1   1032   0.0327      1.008   ; qtot 2.8511
+ 1033         HC     68    ARG    HB2   1033   0.0327      1.008   ; qtot 2.8838
+ 1034         CT     68    ARG     CG   1034   0.0390     12.010   ; qtot 2.9228
+ 1035         HC     68    ARG    HG1   1035   0.0285      1.008   ; qtot 2.9513
+ 1036         HC     68    ARG    HG2   1036   0.0285      1.008   ; qtot 2.9798
+ 1037         CT     68    ARG     CD   1037   0.0486     12.010   ; qtot 3.0284
+ 1038         H1     68    ARG    HD1   1038   0.0687      1.008   ; qtot 3.0971
+ 1039         H1     68    ARG    HD2   1039   0.0687      1.008   ; qtot 3.1658
+ 1040         N2     68    ARG     NE   1040  -0.5295     14.010   ; qtot 2.6363
+ 1041          H     68    ARG     HE   1041   0.3456      1.008   ; qtot 2.9819
+ 1042         CA     68    ARG     CZ   1042   0.8076     12.010   ; qtot 3.7895
+ 1043         N2     68    ARG    NH1   1043  -0.8627     14.010   ; qtot 2.9268
+ 1044          H     68    ARG   HH11   1044   0.4478      1.008   ; qtot 3.3746
+ 1045          H     68    ARG   HH12   1045   0.4478      1.008   ; qtot 3.8224
+ 1046         N2     68    ARG    NH2   1046  -0.8627     14.010   ; qtot 2.9597
+ 1047          H     68    ARG   HH21   1047   0.4478      1.008   ; qtot 3.4075
+ 1048          H     68    ARG   HH22   1048   0.4478      1.008   ; qtot 3.8553
+ 1049          C     68    ARG      C   1049   0.7341     12.010   ; qtot 4.5894
+ 1050          O     68    ARG      O   1050  -0.5894     16.000   ; qtot 4.0000
+; residue   69 THR rtp THR q 0.0
+ 1051          N     69    THR      N   1051  -0.4157     14.010   ; qtot 3.5843
+ 1052          H     69    THR      H   1052   0.2719      1.008   ; qtot 3.8562
+ 1053         CT     69    THR     CA   1053  -0.0389     12.010   ; qtot 3.8173
+ 1054         H1     69    THR     HA   1054   0.1007      1.008   ; qtot 3.9180
+ 1055         CT     69    THR     CB   1055   0.3654     12.010   ; qtot 4.2834
+ 1056         H1     69    THR     HB   1056   0.0043      1.008   ; qtot 4.2877
+ 1057         CT     69    THR    CG2   1057  -0.2438     12.010   ; qtot 4.0439
+ 1058         HC     69    THR   HG21   1058   0.0642      1.008   ; qtot 4.1081
+ 1059         HC     69    THR   HG22   1059   0.0642      1.008   ; qtot 4.1723
+ 1060         HC     69    THR   HG23   1060   0.0642      1.008   ; qtot 4.2365
+ 1061         OH     69    THR    OG1   1061  -0.6761     16.000   ; qtot 3.5604
+ 1062         HO     69    THR    HG1   1062   0.4102      1.008   ; qtot 3.9706
+ 1063          C     69    THR      C   1063   0.5973     12.010   ; qtot 4.5679
+ 1064          O     69    THR      O   1064  -0.5679     16.000   ; qtot 4.0000
+; residue   70 PRO rtp PRO q 0.0
+ 1065          N     70    PRO      N   1065  -0.2548     14.010   ; qtot 3.7452
+ 1066         CT     70    PRO     CD   1066   0.0192     12.010   ; qtot 3.7644
+ 1067         H1     70    PRO    HD1   1067   0.0391      1.008   ; qtot 3.8035
+ 1068         H1     70    PRO    HD2   1068   0.0391      1.008   ; qtot 3.8426
+ 1069         CT     70    PRO     CG   1069   0.0189     12.010   ; qtot 3.8615
+ 1070         HC     70    PRO    HG1   1070   0.0213      1.008   ; qtot 3.8828
+ 1071         HC     70    PRO    HG2   1071   0.0213      1.008   ; qtot 3.9041
+ 1072         CT     70    PRO     CB   1072  -0.0070     12.010   ; qtot 3.8971
+ 1073         HC     70    PRO    HB1   1073   0.0253      1.008   ; qtot 3.9224
+ 1074         HC     70    PRO    HB2   1074   0.0253      1.008   ; qtot 3.9477
+ 1075         CT     70    PRO     CA   1075  -0.0266     12.010   ; qtot 3.9211
+ 1076         H1     70    PRO     HA   1076   0.0641      1.008   ; qtot 3.9852
+ 1077          C     70    PRO      C   1077   0.5896     12.010   ; qtot 4.5748
+ 1078          O     70    PRO      O   1078  -0.5748     16.000   ; qtot 4.0000
+; residue   71 GLY rtp GLY q 0.0
+ 1079          N     71    GLY      N   1079  -0.4157     14.010   ; qtot 3.5843
+ 1080          H     71    GLY      H   1080   0.2719      1.008   ; qtot 3.8562
+ 1081         CT     71    GLY     CA   1081  -0.0252     12.010   ; qtot 3.8310
+ 1082         H1     71    GLY    HA1   1082   0.0698      1.008   ; qtot 3.9008
+ 1083         H1     71    GLY    HA2   1083   0.0698      1.008   ; qtot 3.9706
+ 1084          C     71    GLY      C   1084   0.5973     12.010   ; qtot 4.5679
+ 1085          O     71    GLY      O   1085  -0.5679     16.000   ; qtot 4.0000
+; residue   72 SER rtp SER q 0.0
+ 1086          N     72    SER      N   1086  -0.4157     14.010   ; qtot 3.5843
+ 1087          H     72    SER      H   1087   0.2719      1.008   ; qtot 3.8562
+ 1088         CT     72    SER     CA   1088  -0.0249     12.010   ; qtot 3.8313
+ 1089         H1     72    SER     HA   1089   0.0843      1.008   ; qtot 3.9156
+ 1090         CT     72    SER     CB   1090   0.2117     12.010   ; qtot 4.1273
+ 1091         H1     72    SER    HB1   1091   0.0352      1.008   ; qtot 4.1625
+ 1092         H1     72    SER    HB2   1092   0.0352      1.008   ; qtot 4.1977
+ 1093         OH     72    SER     OG   1093  -0.6546     16.000   ; qtot 3.5431
+ 1094         HO     72    SER     HG   1094   0.4275      1.008   ; qtot 3.9706
+ 1095          C     72    SER      C   1095   0.5973     12.010   ; qtot 4.5679
+ 1096          O     72    SER      O   1096  -0.5679     16.000   ; qtot 4.0000
+; residue   73 ARG rtp ARG q 1.0
+ 1097          N     73    ARG      N   1097  -0.3479     14.010   ; qtot 3.6521
+ 1098          H     73    ARG      H   1098   0.2747      1.008   ; qtot 3.9268
+ 1099         CT     73    ARG     CA   1099  -0.2637     12.010   ; qtot 3.6631
+ 1100         H1     73    ARG     HA   1100   0.1560      1.008   ; qtot 3.8191
+ 1101         CT     73    ARG     CB   1101  -0.0007     12.010   ; qtot 3.8184
+ 1102         HC     73    ARG    HB1   1102   0.0327      1.008   ; qtot 3.8511
+ 1103         HC     73    ARG    HB2   1103   0.0327      1.008   ; qtot 3.8838
+ 1104         CT     73    ARG     CG   1104   0.0390     12.010   ; qtot 3.9228
+ 1105         HC     73    ARG    HG1   1105   0.0285      1.008   ; qtot 3.9513
+ 1106         HC     73    ARG    HG2   1106   0.0285      1.008   ; qtot 3.9798
+ 1107         CT     73    ARG     CD   1107   0.0486     12.010   ; qtot 4.0284
+ 1108         H1     73    ARG    HD1   1108   0.0687      1.008   ; qtot 4.0971
+ 1109         H1     73    ARG    HD2   1109   0.0687      1.008   ; qtot 4.1658
+ 1110         N2     73    ARG     NE   1110  -0.5295     14.010   ; qtot 3.6363
+ 1111          H     73    ARG     HE   1111   0.3456      1.008   ; qtot 3.9819
+ 1112         CA     73    ARG     CZ   1112   0.8076     12.010   ; qtot 4.7895
+ 1113         N2     73    ARG    NH1   1113  -0.8627     14.010   ; qtot 3.9268
+ 1114          H     73    ARG   HH11   1114   0.4478      1.008   ; qtot 4.3746
+ 1115          H     73    ARG   HH12   1115   0.4478      1.008   ; qtot 4.8224
+ 1116         N2     73    ARG    NH2   1116  -0.8627     14.010   ; qtot 3.9597
+ 1117          H     73    ARG   HH21   1117   0.4478      1.008   ; qtot 4.4075
+ 1118          H     73    ARG   HH22   1118   0.4478      1.008   ; qtot 4.8553
+ 1119          C     73    ARG      C   1119   0.7341     12.010   ; qtot 5.5894
+ 1120          O     73    ARG      O   1120  -0.5894     16.000   ; qtot 5.0000
+; residue   74 ASN rtp ASN q 0.0
+ 1121          N     74    ASN      N   1121  -0.4157     14.010   ; qtot 4.5843
+ 1122          H     74    ASN      H   1122   0.2719      1.008   ; qtot 4.8562
+ 1123         CT     74    ASN     CA   1123   0.0143     12.010   ; qtot 4.8705
+ 1124         H1     74    ASN     HA   1124   0.1048      1.008   ; qtot 4.9753
+ 1125         CT     74    ASN     CB   1125  -0.2041     12.010   ; qtot 4.7712
+ 1126         HC     74    ASN    HB1   1126   0.0797      1.008   ; qtot 4.8509
+ 1127         HC     74    ASN    HB2   1127   0.0797      1.008   ; qtot 4.9306
+ 1128          C     74    ASN     CG   1128   0.7130     12.010   ; qtot 5.6436
+ 1129          O     74    ASN    OD1   1129  -0.5931     16.000   ; qtot 5.0505
+ 1130          N     74    ASN    ND2   1130  -0.9191     14.010   ; qtot 4.1314
+ 1131          H     74    ASN   HD21   1131   0.4196      1.008   ; qtot 4.5510
+ 1132          H     74    ASN   HD22   1132   0.4196      1.008   ; qtot 4.9706
+ 1133          C     74    ASN      C   1133   0.5973     12.010   ; qtot 5.5679
+ 1134          O     74    ASN      O   1134  -0.5679     16.000   ; qtot 5.0000
+; residue   75 LEU rtp LEU q 0.0
+ 1135          N     75    LEU      N   1135  -0.4157     14.010   ; qtot 4.5843
+ 1136          H     75    LEU      H   1136   0.2719      1.008   ; qtot 4.8562
+ 1137         CT     75    LEU     CA   1137  -0.0518     12.010   ; qtot 4.8044
+ 1138         H1     75    LEU     HA   1138   0.0922      1.008   ; qtot 4.8966
+ 1139         CT     75    LEU     CB   1139  -0.1102     12.010   ; qtot 4.7864
+ 1140         HC     75    LEU    HB1   1140   0.0457      1.008   ; qtot 4.8321
+ 1141         HC     75    LEU    HB2   1141   0.0457      1.008   ; qtot 4.8778
+ 1142         CT     75    LEU     CG   1142   0.3531     12.010   ; qtot 5.2309
+ 1143         HC     75    LEU     HG   1143  -0.0361      1.008   ; qtot 5.1948
+ 1144         CT     75    LEU    CD1   1144  -0.4121     12.010   ; qtot 4.7827
+ 1145         HC     75    LEU   HD11   1145   0.1000      1.008   ; qtot 4.8827
+ 1146         HC     75    LEU   HD12   1146   0.1000      1.008   ; qtot 4.9827
+ 1147         HC     75    LEU   HD13   1147   0.1000      1.008   ; qtot 5.0827
+ 1148         CT     75    LEU    CD2   1148  -0.4121     12.010   ; qtot 4.6706
+ 1149         HC     75    LEU   HD21   1149   0.1000      1.008   ; qtot 4.7706
+ 1150         HC     75    LEU   HD22   1150   0.1000      1.008   ; qtot 4.8706
+ 1151         HC     75    LEU   HD23   1151   0.1000      1.008   ; qtot 4.9706
+ 1152          C     75    LEU      C   1152   0.5973     12.010   ; qtot 5.5679
+ 1153          O     75    LEU      O   1153  -0.5679     16.000   ; qtot 5.0000
+; residue   76 CYS rtp CYS q 0.0
+ 1154          N     76    CYS      N   1154  -0.4157     14.010   ; qtot 4.5843
+ 1155          H     76    CYS      H   1155   0.2719      1.008   ; qtot 4.8562
+ 1156         CT     76    CYS     CA   1156   0.0429     12.010   ; qtot 4.8991
+ 1157         H1     76    CYS     HA   1157   0.0766      1.008   ; qtot 4.9757
+ 1158         CT     76    CYS     CB   1158  -0.0790     12.010   ; qtot 4.8967
+ 1159         H1     76    CYS    HB1   1159   0.0910      1.008   ; qtot 4.9877
+ 1160         H1     76    CYS    HB2   1160   0.0910      1.008   ; qtot 5.0787
+ 1161          S     76    CYS     SG   1161  -0.1081     32.060   ; qtot 4.9706
+ 1162          C     76    CYS      C   1162   0.5973     12.010   ; qtot 5.5679
+ 1163          O     76    CYS      O   1163  -0.5679     16.000   ; qtot 5.0000
+; residue   77 ASN rtp ASN q 0.0
+ 1164          N     77    ASN      N   1164  -0.4157     14.010   ; qtot 4.5843
+ 1165          H     77    ASN      H   1165   0.2719      1.008   ; qtot 4.8562
+ 1166         CT     77    ASN     CA   1166   0.0143     12.010   ; qtot 4.8705
+ 1167         H1     77    ASN     HA   1167   0.1048      1.008   ; qtot 4.9753
+ 1168         CT     77    ASN     CB   1168  -0.2041     12.010   ; qtot 4.7712
+ 1169         HC     77    ASN    HB1   1169   0.0797      1.008   ; qtot 4.8509
+ 1170         HC     77    ASN    HB2   1170   0.0797      1.008   ; qtot 4.9306
+ 1171          C     77    ASN     CG   1171   0.7130     12.010   ; qtot 5.6436
+ 1172          O     77    ASN    OD1   1172  -0.5931     16.000   ; qtot 5.0505
+ 1173          N     77    ASN    ND2   1173  -0.9191     14.010   ; qtot 4.1314
+ 1174          H     77    ASN   HD21   1174   0.4196      1.008   ; qtot 4.5510
+ 1175          H     77    ASN   HD22   1175   0.4196      1.008   ; qtot 4.9706
+ 1176          C     77    ASN      C   1176   0.5973     12.010   ; qtot 5.5679
+ 1177          O     77    ASN      O   1177  -0.5679     16.000   ; qtot 5.0000
+; residue   78 ILE rtp ILE q 0.0
+ 1178          N     78    ILE      N   1178  -0.4157     14.010   ; qtot 4.5843
+ 1179          H     78    ILE      H   1179   0.2719      1.008   ; qtot 4.8562
+ 1180         CT     78    ILE     CA   1180  -0.0597     12.010   ; qtot 4.7965
+ 1181         H1     78    ILE     HA   1181   0.0869      1.008   ; qtot 4.8834
+ 1182         CT     78    ILE     CB   1182   0.1303     12.010   ; qtot 5.0137
+ 1183         HC     78    ILE     HB   1183   0.0187      1.008   ; qtot 5.0324
+ 1184         CT     78    ILE    CG2   1184  -0.3204     12.010   ; qtot 4.7120
+ 1185         HC     78    ILE   HG21   1185   0.0882      1.008   ; qtot 4.8002
+ 1186         HC     78    ILE   HG22   1186   0.0882      1.008   ; qtot 4.8884
+ 1187         HC     78    ILE   HG23   1187   0.0882      1.008   ; qtot 4.9766
+ 1188         CT     78    ILE    CG1   1188  -0.0430     12.010   ; qtot 4.9336
+ 1189         HC     78    ILE   HG11   1189   0.0236      1.008   ; qtot 4.9572
+ 1190         HC     78    ILE   HG12   1190   0.0236      1.008   ; qtot 4.9808
+ 1191         CT     78    ILE     CD   1191  -0.0660     12.010   ; qtot 4.9148
+ 1192         HC     78    ILE    HD1   1192   0.0186      1.008   ; qtot 4.9334
+ 1193         HC     78    ILE    HD2   1193   0.0186      1.008   ; qtot 4.9520
+ 1194         HC     78    ILE    HD3   1194   0.0186      1.008   ; qtot 4.9706
+ 1195          C     78    ILE      C   1195   0.5973     12.010   ; qtot 5.5679
+ 1196          O     78    ILE      O   1196  -0.5679     16.000   ; qtot 5.0000
+; residue   79 PRO rtp PRO q 0.0
+ 1197          N     79    PRO      N   1197  -0.2548     14.010   ; qtot 4.7452
+ 1198         CT     79    PRO     CD   1198   0.0192     12.010   ; qtot 4.7644
+ 1199         H1     79    PRO    HD1   1199   0.0391      1.008   ; qtot 4.8035
+ 1200         H1     79    PRO    HD2   1200   0.0391      1.008   ; qtot 4.8426
+ 1201         CT     79    PRO     CG   1201   0.0189     12.010   ; qtot 4.8615
+ 1202         HC     79    PRO    HG1   1202   0.0213      1.008   ; qtot 4.8828
+ 1203         HC     79    PRO    HG2   1203   0.0213      1.008   ; qtot 4.9041
+ 1204         CT     79    PRO     CB   1204  -0.0070     12.010   ; qtot 4.8971
+ 1205         HC     79    PRO    HB1   1205   0.0253      1.008   ; qtot 4.9224
+ 1206         HC     79    PRO    HB2   1206   0.0253      1.008   ; qtot 4.9477
+ 1207         CT     79    PRO     CA   1207  -0.0266     12.010   ; qtot 4.9211
+ 1208         H1     79    PRO     HA   1208   0.0641      1.008   ; qtot 4.9852
+ 1209          C     79    PRO      C   1209   0.5896     12.010   ; qtot 5.5748
+ 1210          O     79    PRO      O   1210  -0.5748     16.000   ; qtot 5.0000
+; residue   80 CYS rtp CYS q 0.0
+ 1211          N     80    CYS      N   1211  -0.4157     14.010   ; qtot 4.5843
+ 1212          H     80    CYS      H   1212   0.2719      1.008   ; qtot 4.8562
+ 1213         CT     80    CYS     CA   1213   0.0429     12.010   ; qtot 4.8991
+ 1214         H1     80    CYS     HA   1214   0.0766      1.008   ; qtot 4.9757
+ 1215         CT     80    CYS     CB   1215  -0.0790     12.010   ; qtot 4.8967
+ 1216         H1     80    CYS    HB1   1216   0.0910      1.008   ; qtot 4.9877
+ 1217         H1     80    CYS    HB2   1217   0.0910      1.008   ; qtot 5.0787
+ 1218          S     80    CYS     SG   1218  -0.1081     32.060   ; qtot 4.9706
+ 1219          C     80    CYS      C   1219   0.5973     12.010   ; qtot 5.5679
+ 1220          O     80    CYS      O   1220  -0.5679     16.000   ; qtot 5.0000
+; residue   81 SER rtp SER q 0.0
+ 1221          N     81    SER      N   1221  -0.4157     14.010   ; qtot 4.5843
+ 1222          H     81    SER      H   1222   0.2719      1.008   ; qtot 4.8562
+ 1223         CT     81    SER     CA   1223  -0.0249     12.010   ; qtot 4.8313
+ 1224         H1     81    SER     HA   1224   0.0843      1.008   ; qtot 4.9156
+ 1225         CT     81    SER     CB   1225   0.2117     12.010   ; qtot 5.1273
+ 1226         H1     81    SER    HB1   1226   0.0352      1.008   ; qtot 5.1625
+ 1227         H1     81    SER    HB2   1227   0.0352      1.008   ; qtot 5.1977
+ 1228         OH     81    SER     OG   1228  -0.6546     16.000   ; qtot 4.5431
+ 1229         HO     81    SER     HG   1229   0.4275      1.008   ; qtot 4.9706
+ 1230          C     81    SER      C   1230   0.5973     12.010   ; qtot 5.5679
+ 1231          O     81    SER      O   1231  -0.5679     16.000   ; qtot 5.0000
+; residue   82 ALA rtp ALA q 0.0
+ 1232          N     82    ALA      N   1232  -0.4157     14.010   ; qtot 4.5843
+ 1233          H     82    ALA      H   1233   0.2719      1.008   ; qtot 4.8562
+ 1234         CT     82    ALA     CA   1234   0.0337     12.010   ; qtot 4.8899
+ 1235         H1     82    ALA     HA   1235   0.0823      1.008   ; qtot 4.9722
+ 1236         CT     82    ALA     CB   1236  -0.1825     12.010   ; qtot 4.7897
+ 1237         HC     82    ALA    HB1   1237   0.0603      1.008   ; qtot 4.8500
+ 1238         HC     82    ALA    HB2   1238   0.0603      1.008   ; qtot 4.9103
+ 1239         HC     82    ALA    HB3   1239   0.0603      1.008   ; qtot 4.9706
+ 1240          C     82    ALA      C   1240   0.5973     12.010   ; qtot 5.5679
+ 1241          O     82    ALA      O   1241  -0.5679     16.000   ; qtot 5.0000
+; residue   83 LEU rtp LEU q 0.0
+ 1242          N     83    LEU      N   1242  -0.4157     14.010   ; qtot 4.5843
+ 1243          H     83    LEU      H   1243   0.2719      1.008   ; qtot 4.8562
+ 1244         CT     83    LEU     CA   1244  -0.0518     12.010   ; qtot 4.8044
+ 1245         H1     83    LEU     HA   1245   0.0922      1.008   ; qtot 4.8966
+ 1246         CT     83    LEU     CB   1246  -0.1102     12.010   ; qtot 4.7864
+ 1247         HC     83    LEU    HB1   1247   0.0457      1.008   ; qtot 4.8321
+ 1248         HC     83    LEU    HB2   1248   0.0457      1.008   ; qtot 4.8778
+ 1249         CT     83    LEU     CG   1249   0.3531     12.010   ; qtot 5.2309
+ 1250         HC     83    LEU     HG   1250  -0.0361      1.008   ; qtot 5.1948
+ 1251         CT     83    LEU    CD1   1251  -0.4121     12.010   ; qtot 4.7827
+ 1252         HC     83    LEU   HD11   1252   0.1000      1.008   ; qtot 4.8827
+ 1253         HC     83    LEU   HD12   1253   0.1000      1.008   ; qtot 4.9827
+ 1254         HC     83    LEU   HD13   1254   0.1000      1.008   ; qtot 5.0827
+ 1255         CT     83    LEU    CD2   1255  -0.4121     12.010   ; qtot 4.6706
+ 1256         HC     83    LEU   HD21   1256   0.1000      1.008   ; qtot 4.7706
+ 1257         HC     83    LEU   HD22   1257   0.1000      1.008   ; qtot 4.8706
+ 1258         HC     83    LEU   HD23   1258   0.1000      1.008   ; qtot 4.9706
+ 1259          C     83    LEU      C   1259   0.5973     12.010   ; qtot 5.5679
+ 1260          O     83    LEU      O   1260  -0.5679     16.000   ; qtot 5.0000
+; residue   84 LEU rtp LEU q 0.0
+ 1261          N     84    LEU      N   1261  -0.4157     14.010   ; qtot 4.5843
+ 1262          H     84    LEU      H   1262   0.2719      1.008   ; qtot 4.8562
+ 1263         CT     84    LEU     CA   1263  -0.0518     12.010   ; qtot 4.8044
+ 1264         H1     84    LEU     HA   1264   0.0922      1.008   ; qtot 4.8966
+ 1265         CT     84    LEU     CB   1265  -0.1102     12.010   ; qtot 4.7864
+ 1266         HC     84    LEU    HB1   1266   0.0457      1.008   ; qtot 4.8321
+ 1267         HC     84    LEU    HB2   1267   0.0457      1.008   ; qtot 4.8778
+ 1268         CT     84    LEU     CG   1268   0.3531     12.010   ; qtot 5.2309
+ 1269         HC     84    LEU     HG   1269  -0.0361      1.008   ; qtot 5.1948
+ 1270         CT     84    LEU    CD1   1270  -0.4121     12.010   ; qtot 4.7827
+ 1271         HC     84    LEU   HD11   1271   0.1000      1.008   ; qtot 4.8827
+ 1272         HC     84    LEU   HD12   1272   0.1000      1.008   ; qtot 4.9827
+ 1273         HC     84    LEU   HD13   1273   0.1000      1.008   ; qtot 5.0827
+ 1274         CT     84    LEU    CD2   1274  -0.4121     12.010   ; qtot 4.6706
+ 1275         HC     84    LEU   HD21   1275   0.1000      1.008   ; qtot 4.7706
+ 1276         HC     84    LEU   HD22   1276   0.1000      1.008   ; qtot 4.8706
+ 1277         HC     84    LEU   HD23   1277   0.1000      1.008   ; qtot 4.9706
+ 1278          C     84    LEU      C   1278   0.5973     12.010   ; qtot 5.5679
+ 1279          O     84    LEU      O   1279  -0.5679     16.000   ; qtot 5.0000
+; residue   85 SER rtp SER q 0.0
+ 1280          N     85    SER      N   1280  -0.4157     14.010   ; qtot 4.5843
+ 1281          H     85    SER      H   1281   0.2719      1.008   ; qtot 4.8562
+ 1282         CT     85    SER     CA   1282  -0.0249     12.010   ; qtot 4.8313
+ 1283         H1     85    SER     HA   1283   0.0843      1.008   ; qtot 4.9156
+ 1284         CT     85    SER     CB   1284   0.2117     12.010   ; qtot 5.1273
+ 1285         H1     85    SER    HB1   1285   0.0352      1.008   ; qtot 5.1625
+ 1286         H1     85    SER    HB2   1286   0.0352      1.008   ; qtot 5.1977
+ 1287         OH     85    SER     OG   1287  -0.6546     16.000   ; qtot 4.5431
+ 1288         HO     85    SER     HG   1288   0.4275      1.008   ; qtot 4.9706
+ 1289          C     85    SER      C   1289   0.5973     12.010   ; qtot 5.5679
+ 1290          O     85    SER      O   1290  -0.5679     16.000   ; qtot 5.0000
+; residue   86 SER rtp SER q 0.0
+ 1291          N     86    SER      N   1291  -0.4157     14.010   ; qtot 4.5843
+ 1292          H     86    SER      H   1292   0.2719      1.008   ; qtot 4.8562
+ 1293         CT     86    SER     CA   1293  -0.0249     12.010   ; qtot 4.8313
+ 1294         H1     86    SER     HA   1294   0.0843      1.008   ; qtot 4.9156
+ 1295         CT     86    SER     CB   1295   0.2117     12.010   ; qtot 5.1273
+ 1296         H1     86    SER    HB1   1296   0.0352      1.008   ; qtot 5.1625
+ 1297         H1     86    SER    HB2   1297   0.0352      1.008   ; qtot 5.1977
+ 1298         OH     86    SER     OG   1298  -0.6546     16.000   ; qtot 4.5431
+ 1299         HO     86    SER     HG   1299   0.4275      1.008   ; qtot 4.9706
+ 1300          C     86    SER      C   1300   0.5973     12.010   ; qtot 5.5679
+ 1301          O     86    SER      O   1301  -0.5679     16.000   ; qtot 5.0000
+; residue   87 ASP rtp ASP q -1.0
+ 1302          N     87    ASP      N   1302  -0.5163     14.010   ; qtot 4.4837
+ 1303          H     87    ASP      H   1303   0.2936      1.008   ; qtot 4.7773
+ 1304         CT     87    ASP     CA   1304   0.0381     12.010   ; qtot 4.8154
+ 1305         H1     87    ASP     HA   1305   0.0880      1.008   ; qtot 4.9034
+ 1306         CT     87    ASP     CB   1306  -0.0303     12.010   ; qtot 4.8731
+ 1307         HC     87    ASP    HB1   1307  -0.0122      1.008   ; qtot 4.8609
+ 1308         HC     87    ASP    HB2   1308  -0.0122      1.008   ; qtot 4.8487
+ 1309          C     87    ASP     CG   1309   0.7994     12.010   ; qtot 5.6481
+ 1310         O2     87    ASP    OD1   1310  -0.8014     16.000   ; qtot 4.8467
+ 1311         O2     87    ASP    OD2   1311  -0.8014     16.000   ; qtot 4.0453
+ 1312          C     87    ASP      C   1312   0.5366     12.010   ; qtot 4.5819
+ 1313          O     87    ASP      O   1313  -0.5819     16.000   ; qtot 4.0000
+; residue   88 ILE rtp ILE q 0.0
+ 1314          N     88    ILE      N   1314  -0.4157     14.010   ; qtot 3.5843
+ 1315          H     88    ILE      H   1315   0.2719      1.008   ; qtot 3.8562
+ 1316         CT     88    ILE     CA   1316  -0.0597     12.010   ; qtot 3.7965
+ 1317         H1     88    ILE     HA   1317   0.0869      1.008   ; qtot 3.8834
+ 1318         CT     88    ILE     CB   1318   0.1303     12.010   ; qtot 4.0137
+ 1319         HC     88    ILE     HB   1319   0.0187      1.008   ; qtot 4.0324
+ 1320         CT     88    ILE    CG2   1320  -0.3204     12.010   ; qtot 3.7120
+ 1321         HC     88    ILE   HG21   1321   0.0882      1.008   ; qtot 3.8002
+ 1322         HC     88    ILE   HG22   1322   0.0882      1.008   ; qtot 3.8884
+ 1323         HC     88    ILE   HG23   1323   0.0882      1.008   ; qtot 3.9766
+ 1324         CT     88    ILE    CG1   1324  -0.0430     12.010   ; qtot 3.9336
+ 1325         HC     88    ILE   HG11   1325   0.0236      1.008   ; qtot 3.9572
+ 1326         HC     88    ILE   HG12   1326   0.0236      1.008   ; qtot 3.9808
+ 1327         CT     88    ILE     CD   1327  -0.0660     12.010   ; qtot 3.9148
+ 1328         HC     88    ILE    HD1   1328   0.0186      1.008   ; qtot 3.9334
+ 1329         HC     88    ILE    HD2   1329   0.0186      1.008   ; qtot 3.9520
+ 1330         HC     88    ILE    HD3   1330   0.0186      1.008   ; qtot 3.9706
+ 1331          C     88    ILE      C   1331   0.5973     12.010   ; qtot 4.5679
+ 1332          O     88    ILE      O   1332  -0.5679     16.000   ; qtot 4.0000
+; residue   89 THR rtp THR q 0.0
+ 1333          N     89    THR      N   1333  -0.4157     14.010   ; qtot 3.5843
+ 1334          H     89    THR      H   1334   0.2719      1.008   ; qtot 3.8562
+ 1335         CT     89    THR     CA   1335  -0.0389     12.010   ; qtot 3.8173
+ 1336         H1     89    THR     HA   1336   0.1007      1.008   ; qtot 3.9180
+ 1337         CT     89    THR     CB   1337   0.3654     12.010   ; qtot 4.2834
+ 1338         H1     89    THR     HB   1338   0.0043      1.008   ; qtot 4.2877
+ 1339         CT     89    THR    CG2   1339  -0.2438     12.010   ; qtot 4.0439
+ 1340         HC     89    THR   HG21   1340   0.0642      1.008   ; qtot 4.1081
+ 1341         HC     89    THR   HG22   1341   0.0642      1.008   ; qtot 4.1723
+ 1342         HC     89    THR   HG23   1342   0.0642      1.008   ; qtot 4.2365
+ 1343         OH     89    THR    OG1   1343  -0.6761     16.000   ; qtot 3.5604
+ 1344         HO     89    THR    HG1   1344   0.4102      1.008   ; qtot 3.9706
+ 1345          C     89    THR      C   1345   0.5973     12.010   ; qtot 4.5679
+ 1346          O     89    THR      O   1346  -0.5679     16.000   ; qtot 4.0000
+; residue   90 ALA rtp ALA q 0.0
+ 1347          N     90    ALA      N   1347  -0.4157     14.010   ; qtot 3.5843
+ 1348          H     90    ALA      H   1348   0.2719      1.008   ; qtot 3.8562
+ 1349         CT     90    ALA     CA   1349   0.0337     12.010   ; qtot 3.8899
+ 1350         H1     90    ALA     HA   1350   0.0823      1.008   ; qtot 3.9722
+ 1351         CT     90    ALA     CB   1351  -0.1825     12.010   ; qtot 3.7897
+ 1352         HC     90    ALA    HB1   1352   0.0603      1.008   ; qtot 3.8500
+ 1353         HC     90    ALA    HB2   1353   0.0603      1.008   ; qtot 3.9103
+ 1354         HC     90    ALA    HB3   1354   0.0603      1.008   ; qtot 3.9706
+ 1355          C     90    ALA      C   1355   0.5973     12.010   ; qtot 4.5679
+ 1356          O     90    ALA      O   1356  -0.5679     16.000   ; qtot 4.0000
+; residue   91 SER rtp SER q 0.0
+ 1357          N     91    SER      N   1357  -0.4157     14.010   ; qtot 3.5843
+ 1358          H     91    SER      H   1358   0.2719      1.008   ; qtot 3.8562
+ 1359         CT     91    SER     CA   1359  -0.0249     12.010   ; qtot 3.8313
+ 1360         H1     91    SER     HA   1360   0.0843      1.008   ; qtot 3.9156
+ 1361         CT     91    SER     CB   1361   0.2117     12.010   ; qtot 4.1273
+ 1362         H1     91    SER    HB1   1362   0.0352      1.008   ; qtot 4.1625
+ 1363         H1     91    SER    HB2   1363   0.0352      1.008   ; qtot 4.1977
+ 1364         OH     91    SER     OG   1364  -0.6546     16.000   ; qtot 3.5431
+ 1365         HO     91    SER     HG   1365   0.4275      1.008   ; qtot 3.9706
+ 1366          C     91    SER      C   1366   0.5973     12.010   ; qtot 4.5679
+ 1367          O     91    SER      O   1367  -0.5679     16.000   ; qtot 4.0000
+; residue   92 VAL rtp VAL q 0.0
+ 1368          N     92    VAL      N   1368  -0.4157     14.010   ; qtot 3.5843
+ 1369          H     92    VAL      H   1369   0.2719      1.008   ; qtot 3.8562
+ 1370         CT     92    VAL     CA   1370  -0.0875     12.010   ; qtot 3.7687
+ 1371         H1     92    VAL     HA   1371   0.0969      1.008   ; qtot 3.8656
+ 1372         CT     92    VAL     CB   1372   0.2985     12.010   ; qtot 4.1641
+ 1373         HC     92    VAL     HB   1373  -0.0297      1.008   ; qtot 4.1344
+ 1374         CT     92    VAL    CG1   1374  -0.3192     12.010   ; qtot 3.8152
+ 1375         HC     92    VAL   HG11   1375   0.0791      1.008   ; qtot 3.8943
+ 1376         HC     92    VAL   HG12   1376   0.0791      1.008   ; qtot 3.9734
+ 1377         HC     92    VAL   HG13   1377   0.0791      1.008   ; qtot 4.0525
+ 1378         CT     92    VAL    CG2   1378  -0.3192     12.010   ; qtot 3.7333
+ 1379         HC     92    VAL   HG21   1379   0.0791      1.008   ; qtot 3.8124
+ 1380         HC     92    VAL   HG22   1380   0.0791      1.008   ; qtot 3.8915
+ 1381         HC     92    VAL   HG23   1381   0.0791      1.008   ; qtot 3.9706
+ 1382          C     92    VAL      C   1382   0.5973     12.010   ; qtot 4.5679
+ 1383          O     92    VAL      O   1383  -0.5679     16.000   ; qtot 4.0000
+; residue   93 ASN rtp ASN q 0.0
+ 1384          N     93    ASN      N   1384  -0.4157     14.010   ; qtot 3.5843
+ 1385          H     93    ASN      H   1385   0.2719      1.008   ; qtot 3.8562
+ 1386         CT     93    ASN     CA   1386   0.0143     12.010   ; qtot 3.8705
+ 1387         H1     93    ASN     HA   1387   0.1048      1.008   ; qtot 3.9753
+ 1388         CT     93    ASN     CB   1388  -0.2041     12.010   ; qtot 3.7712
+ 1389         HC     93    ASN    HB1   1389   0.0797      1.008   ; qtot 3.8509
+ 1390         HC     93    ASN    HB2   1390   0.0797      1.008   ; qtot 3.9306
+ 1391          C     93    ASN     CG   1391   0.7130     12.010   ; qtot 4.6436
+ 1392          O     93    ASN    OD1   1392  -0.5931     16.000   ; qtot 4.0505
+ 1393          N     93    ASN    ND2   1393  -0.9191     14.010   ; qtot 3.1314
+ 1394          H     93    ASN   HD21   1394   0.4196      1.008   ; qtot 3.5510
+ 1395          H     93    ASN   HD22   1395   0.4196      1.008   ; qtot 3.9706
+ 1396          C     93    ASN      C   1396   0.5973     12.010   ; qtot 4.5679
+ 1397          O     93    ASN      O   1397  -0.5679     16.000   ; qtot 4.0000
+; residue   94 CYS rtp CYS q 0.0
+ 1398          N     94    CYS      N   1398  -0.4157     14.010   ; qtot 3.5843
+ 1399          H     94    CYS      H   1399   0.2719      1.008   ; qtot 3.8562
+ 1400         CT     94    CYS     CA   1400   0.0429     12.010   ; qtot 3.8991
+ 1401         H1     94    CYS     HA   1401   0.0766      1.008   ; qtot 3.9757
+ 1402         CT     94    CYS     CB   1402  -0.0790     12.010   ; qtot 3.8967
+ 1403         H1     94    CYS    HB1   1403   0.0910      1.008   ; qtot 3.9877
+ 1404         H1     94    CYS    HB2   1404   0.0910      1.008   ; qtot 4.0787
+ 1405          S     94    CYS     SG   1405  -0.1081     32.060   ; qtot 3.9706
+ 1406          C     94    CYS      C   1406   0.5973     12.010   ; qtot 4.5679
+ 1407          O     94    CYS      O   1407  -0.5679     16.000   ; qtot 4.0000
+; residue   95 ALA rtp ALA q 0.0
+ 1408          N     95    ALA      N   1408  -0.4157     14.010   ; qtot 3.5843
+ 1409          H     95    ALA      H   1409   0.2719      1.008   ; qtot 3.8562
+ 1410         CT     95    ALA     CA   1410   0.0337     12.010   ; qtot 3.8899
+ 1411         H1     95    ALA     HA   1411   0.0823      1.008   ; qtot 3.9722
+ 1412         CT     95    ALA     CB   1412  -0.1825     12.010   ; qtot 3.7897
+ 1413         HC     95    ALA    HB1   1413   0.0603      1.008   ; qtot 3.8500
+ 1414         HC     95    ALA    HB2   1414   0.0603      1.008   ; qtot 3.9103
+ 1415         HC     95    ALA    HB3   1415   0.0603      1.008   ; qtot 3.9706
+ 1416          C     95    ALA      C   1416   0.5973     12.010   ; qtot 4.5679
+ 1417          O     95    ALA      O   1417  -0.5679     16.000   ; qtot 4.0000
+; residue   96 LYS rtp LYS q 1.0
+ 1418          N     96    LYS      N   1418  -0.3479     14.010   ; qtot 3.6521
+ 1419          H     96    LYS      H   1419   0.2747      1.008   ; qtot 3.9268
+ 1420         CT     96    LYS     CA   1420  -0.2400     12.010   ; qtot 3.6868
+ 1421         H1     96    LYS     HA   1421   0.1426      1.008   ; qtot 3.8294
+ 1422         CT     96    LYS     CB   1422  -0.0094     12.010   ; qtot 3.8200
+ 1423         HC     96    LYS    HB1   1423   0.0362      1.008   ; qtot 3.8562
+ 1424         HC     96    LYS    HB2   1424   0.0362      1.008   ; qtot 3.8924
+ 1425         CT     96    LYS     CG   1425   0.0187     12.010   ; qtot 3.9111
+ 1426         HC     96    LYS    HG1   1426   0.0103      1.008   ; qtot 3.9214
+ 1427         HC     96    LYS    HG2   1427   0.0103      1.008   ; qtot 3.9317
+ 1428         CT     96    LYS     CD   1428  -0.0479     12.010   ; qtot 3.8838
+ 1429         HC     96    LYS    HD1   1429   0.0621      1.008   ; qtot 3.9459
+ 1430         HC     96    LYS    HD2   1430   0.0621      1.008   ; qtot 4.0080
+ 1431         CT     96    LYS     CE   1431  -0.0143     12.010   ; qtot 3.9937
+ 1432         HP     96    LYS    HE1   1432   0.1135      1.008   ; qtot 4.1072
+ 1433         HP     96    LYS    HE2   1433   0.1135      1.008   ; qtot 4.2207
+ 1434         N3     96    LYS     NZ   1434  -0.3854     14.010   ; qtot 3.8353
+ 1435          H     96    LYS    HZ1   1435   0.3400      1.008   ; qtot 4.1753
+ 1436          H     96    LYS    HZ2   1436   0.3400      1.008   ; qtot 4.5153
+ 1437          H     96    LYS    HZ3   1437   0.3400      1.008   ; qtot 4.8553
+ 1438          C     96    LYS      C   1438   0.7341     12.010   ; qtot 5.5894
+ 1439          O     96    LYS      O   1439  -0.5894     16.000   ; qtot 5.0000
+; residue   97 LYS rtp LYS q 1.0
+ 1440          N     97    LYS      N   1440  -0.3479     14.010   ; qtot 4.6521
+ 1441          H     97    LYS      H   1441   0.2747      1.008   ; qtot 4.9268
+ 1442         CT     97    LYS     CA   1442  -0.2400     12.010   ; qtot 4.6868
+ 1443         H1     97    LYS     HA   1443   0.1426      1.008   ; qtot 4.8294
+ 1444         CT     97    LYS     CB   1444  -0.0094     12.010   ; qtot 4.8200
+ 1445         HC     97    LYS    HB1   1445   0.0362      1.008   ; qtot 4.8562
+ 1446         HC     97    LYS    HB2   1446   0.0362      1.008   ; qtot 4.8924
+ 1447         CT     97    LYS     CG   1447   0.0187     12.010   ; qtot 4.9111
+ 1448         HC     97    LYS    HG1   1448   0.0103      1.008   ; qtot 4.9214
+ 1449         HC     97    LYS    HG2   1449   0.0103      1.008   ; qtot 4.9317
+ 1450         CT     97    LYS     CD   1450  -0.0479     12.010   ; qtot 4.8838
+ 1451         HC     97    LYS    HD1   1451   0.0621      1.008   ; qtot 4.9459
+ 1452         HC     97    LYS    HD2   1452   0.0621      1.008   ; qtot 5.0080
+ 1453         CT     97    LYS     CE   1453  -0.0143     12.010   ; qtot 4.9937
+ 1454         HP     97    LYS    HE1   1454   0.1135      1.008   ; qtot 5.1072
+ 1455         HP     97    LYS    HE2   1455   0.1135      1.008   ; qtot 5.2207
+ 1456         N3     97    LYS     NZ   1456  -0.3854     14.010   ; qtot 4.8353
+ 1457          H     97    LYS    HZ1   1457   0.3400      1.008   ; qtot 5.1753
+ 1458          H     97    LYS    HZ2   1458   0.3400      1.008   ; qtot 5.5153
+ 1459          H     97    LYS    HZ3   1459   0.3400      1.008   ; qtot 5.8553
+ 1460          C     97    LYS      C   1460   0.7341     12.010   ; qtot 6.5894
+ 1461          O     97    LYS      O   1461  -0.5894     16.000   ; qtot 6.0000
+; residue   98 ILE rtp ILE q 0.0
+ 1462          N     98    ILE      N   1462  -0.4157     14.010   ; qtot 5.5843
+ 1463          H     98    ILE      H   1463   0.2719      1.008   ; qtot 5.8562
+ 1464         CT     98    ILE     CA   1464  -0.0597     12.010   ; qtot 5.7965
+ 1465         H1     98    ILE     HA   1465   0.0869      1.008   ; qtot 5.8834
+ 1466         CT     98    ILE     CB   1466   0.1303     12.010   ; qtot 6.0137
+ 1467         HC     98    ILE     HB   1467   0.0187      1.008   ; qtot 6.0324
+ 1468         CT     98    ILE    CG2   1468  -0.3204     12.010   ; qtot 5.7120
+ 1469         HC     98    ILE   HG21   1469   0.0882      1.008   ; qtot 5.8002
+ 1470         HC     98    ILE   HG22   1470   0.0882      1.008   ; qtot 5.8884
+ 1471         HC     98    ILE   HG23   1471   0.0882      1.008   ; qtot 5.9766
+ 1472         CT     98    ILE    CG1   1472  -0.0430     12.010   ; qtot 5.9336
+ 1473         HC     98    ILE   HG11   1473   0.0236      1.008   ; qtot 5.9572
+ 1474         HC     98    ILE   HG12   1474   0.0236      1.008   ; qtot 5.9808
+ 1475         CT     98    ILE     CD   1475  -0.0660     12.010   ; qtot 5.9148
+ 1476         HC     98    ILE    HD1   1476   0.0186      1.008   ; qtot 5.9334
+ 1477         HC     98    ILE    HD2   1477   0.0186      1.008   ; qtot 5.9520
+ 1478         HC     98    ILE    HD3   1478   0.0186      1.008   ; qtot 5.9706
+ 1479          C     98    ILE      C   1479   0.5973     12.010   ; qtot 6.5679
+ 1480          O     98    ILE      O   1480  -0.5679     16.000   ; qtot 6.0000
+; residue   99 VAL rtp VAL q 0.0
+ 1481          N     99    VAL      N   1481  -0.4157     14.010   ; qtot 5.5843
+ 1482          H     99    VAL      H   1482   0.2719      1.008   ; qtot 5.8562
+ 1483         CT     99    VAL     CA   1483  -0.0875     12.010   ; qtot 5.7687
+ 1484         H1     99    VAL     HA   1484   0.0969      1.008   ; qtot 5.8656
+ 1485         CT     99    VAL     CB   1485   0.2985     12.010   ; qtot 6.1641
+ 1486         HC     99    VAL     HB   1486  -0.0297      1.008   ; qtot 6.1344
+ 1487         CT     99    VAL    CG1   1487  -0.3192     12.010   ; qtot 5.8152
+ 1488         HC     99    VAL   HG11   1488   0.0791      1.008   ; qtot 5.8943
+ 1489         HC     99    VAL   HG12   1489   0.0791      1.008   ; qtot 5.9734
+ 1490         HC     99    VAL   HG13   1490   0.0791      1.008   ; qtot 6.0525
+ 1491         CT     99    VAL    CG2   1491  -0.3192     12.010   ; qtot 5.7333
+ 1492         HC     99    VAL   HG21   1492   0.0791      1.008   ; qtot 5.8124
+ 1493         HC     99    VAL   HG22   1493   0.0791      1.008   ; qtot 5.8915
+ 1494         HC     99    VAL   HG23   1494   0.0791      1.008   ; qtot 5.9706
+ 1495          C     99    VAL      C   1495   0.5973     12.010   ; qtot 6.5679
+ 1496          O     99    VAL      O   1496  -0.5679     16.000   ; qtot 6.0000
+; residue  100 SER rtp SER q 0.0
+ 1497          N    100    SER      N   1497  -0.4157     14.010   ; qtot 5.5843
+ 1498          H    100    SER      H   1498   0.2719      1.008   ; qtot 5.8562
+ 1499         CT    100    SER     CA   1499  -0.0249     12.010   ; qtot 5.8313
+ 1500         H1    100    SER     HA   1500   0.0843      1.008   ; qtot 5.9156
+ 1501         CT    100    SER     CB   1501   0.2117     12.010   ; qtot 6.1273
+ 1502         H1    100    SER    HB1   1502   0.0352      1.008   ; qtot 6.1625
+ 1503         H1    100    SER    HB2   1503   0.0352      1.008   ; qtot 6.1977
+ 1504         OH    100    SER     OG   1504  -0.6546     16.000   ; qtot 5.5431
+ 1505         HO    100    SER     HG   1505   0.4275      1.008   ; qtot 5.9706
+ 1506          C    100    SER      C   1506   0.5973     12.010   ; qtot 6.5679
+ 1507          O    100    SER      O   1507  -0.5679     16.000   ; qtot 6.0000
+; residue  101 ASP rtp ASP q -1.0
+ 1508          N    101    ASP      N   1508  -0.5163     14.010   ; qtot 5.4837
+ 1509          H    101    ASP      H   1509   0.2936      1.008   ; qtot 5.7773
+ 1510         CT    101    ASP     CA   1510   0.0381     12.010   ; qtot 5.8154
+ 1511         H1    101    ASP     HA   1511   0.0880      1.008   ; qtot 5.9034
+ 1512         CT    101    ASP     CB   1512  -0.0303     12.010   ; qtot 5.8731
+ 1513         HC    101    ASP    HB1   1513  -0.0122      1.008   ; qtot 5.8609
+ 1514         HC    101    ASP    HB2   1514  -0.0122      1.008   ; qtot 5.8487
+ 1515          C    101    ASP     CG   1515   0.7994     12.010   ; qtot 6.6481
+ 1516         O2    101    ASP    OD1   1516  -0.8014     16.000   ; qtot 5.8467
+ 1517         O2    101    ASP    OD2   1517  -0.8014     16.000   ; qtot 5.0453
+ 1518          C    101    ASP      C   1518   0.5366     12.010   ; qtot 5.5819
+ 1519          O    101    ASP      O   1519  -0.5819     16.000   ; qtot 5.0000
+; residue  102 GLY rtp GLY q 0.0
+ 1520          N    102    GLY      N   1520  -0.4157     14.010   ; qtot 4.5843
+ 1521          H    102    GLY      H   1521   0.2719      1.008   ; qtot 4.8562
+ 1522         CT    102    GLY     CA   1522  -0.0252     12.010   ; qtot 4.8310
+ 1523         H1    102    GLY    HA1   1523   0.0698      1.008   ; qtot 4.9008
+ 1524         H1    102    GLY    HA2   1524   0.0698      1.008   ; qtot 4.9706
+ 1525          C    102    GLY      C   1525   0.5973     12.010   ; qtot 5.5679
+ 1526          O    102    GLY      O   1526  -0.5679     16.000   ; qtot 5.0000
+; residue  103 ASN rtp ASN q 0.0
+ 1527          N    103    ASN      N   1527  -0.4157     14.010   ; qtot 4.5843
+ 1528          H    103    ASN      H   1528   0.2719      1.008   ; qtot 4.8562
+ 1529         CT    103    ASN     CA   1529   0.0143     12.010   ; qtot 4.8705
+ 1530         H1    103    ASN     HA   1530   0.1048      1.008   ; qtot 4.9753
+ 1531         CT    103    ASN     CB   1531  -0.2041     12.010   ; qtot 4.7712
+ 1532         HC    103    ASN    HB1   1532   0.0797      1.008   ; qtot 4.8509
+ 1533         HC    103    ASN    HB2   1533   0.0797      1.008   ; qtot 4.9306
+ 1534          C    103    ASN     CG   1534   0.7130     12.010   ; qtot 5.6436
+ 1535          O    103    ASN    OD1   1535  -0.5931     16.000   ; qtot 5.0505
+ 1536          N    103    ASN    ND2   1536  -0.9191     14.010   ; qtot 4.1314
+ 1537          H    103    ASN   HD21   1537   0.4196      1.008   ; qtot 4.5510
+ 1538          H    103    ASN   HD22   1538   0.4196      1.008   ; qtot 4.9706
+ 1539          C    103    ASN      C   1539   0.5973     12.010   ; qtot 5.5679
+ 1540          O    103    ASN      O   1540  -0.5679     16.000   ; qtot 5.0000
+; residue  104 GLY rtp GLY q 0.0
+ 1541          N    104    GLY      N   1541  -0.4157     14.010   ; qtot 4.5843
+ 1542          H    104    GLY      H   1542   0.2719      1.008   ; qtot 4.8562
+ 1543         CT    104    GLY     CA   1543  -0.0252     12.010   ; qtot 4.8310
+ 1544         H1    104    GLY    HA1   1544   0.0698      1.008   ; qtot 4.9008
+ 1545         H1    104    GLY    HA2   1545   0.0698      1.008   ; qtot 4.9706
+ 1546          C    104    GLY      C   1546   0.5973     12.010   ; qtot 5.5679
+ 1547          O    104    GLY      O   1547  -0.5679     16.000   ; qtot 5.0000
+; residue  105 MET rtp MET q 0.0
+ 1548          N    105    MET      N   1548  -0.4157     14.010   ; qtot 4.5843
+ 1549          H    105    MET      H   1549   0.2719      1.008   ; qtot 4.8562
+ 1550         CT    105    MET     CA   1550  -0.0237     12.010   ; qtot 4.8325
+ 1551         H1    105    MET     HA   1551   0.0880      1.008   ; qtot 4.9205
+ 1552         CT    105    MET     CB   1552   0.0342     12.010   ; qtot 4.9547
+ 1553         HC    105    MET    HB1   1553   0.0241      1.008   ; qtot 4.9788
+ 1554         HC    105    MET    HB2   1554   0.0241      1.008   ; qtot 5.0029
+ 1555         CT    105    MET     CG   1555   0.0018     12.010   ; qtot 5.0047
+ 1556         H1    105    MET    HG1   1556   0.0440      1.008   ; qtot 5.0487
+ 1557         H1    105    MET    HG2   1557   0.0440      1.008   ; qtot 5.0927
+ 1558          S    105    MET     SD   1558  -0.2737     32.060   ; qtot 4.8190
+ 1559         CT    105    MET     CE   1559  -0.0536     12.010   ; qtot 4.7654
+ 1560         H1    105    MET    HE1   1560   0.0684      1.008   ; qtot 4.8338
+ 1561         H1    105    MET    HE2   1561   0.0684      1.008   ; qtot 4.9022
+ 1562         H1    105    MET    HE3   1562   0.0684      1.008   ; qtot 4.9706
+ 1563          C    105    MET      C   1563   0.5973     12.010   ; qtot 5.5679
+ 1564          O    105    MET      O   1564  -0.5679     16.000   ; qtot 5.0000
+; residue  106 ASN rtp ASN q 0.0
+ 1565          N    106    ASN      N   1565  -0.4157     14.010   ; qtot 4.5843
+ 1566          H    106    ASN      H   1566   0.2719      1.008   ; qtot 4.8562
+ 1567         CT    106    ASN     CA   1567   0.0143     12.010   ; qtot 4.8705
+ 1568         H1    106    ASN     HA   1568   0.1048      1.008   ; qtot 4.9753
+ 1569         CT    106    ASN     CB   1569  -0.2041     12.010   ; qtot 4.7712
+ 1570         HC    106    ASN    HB1   1570   0.0797      1.008   ; qtot 4.8509
+ 1571         HC    106    ASN    HB2   1571   0.0797      1.008   ; qtot 4.9306
+ 1572          C    106    ASN     CG   1572   0.7130     12.010   ; qtot 5.6436
+ 1573          O    106    ASN    OD1   1573  -0.5931     16.000   ; qtot 5.0505
+ 1574          N    106    ASN    ND2   1574  -0.9191     14.010   ; qtot 4.1314
+ 1575          H    106    ASN   HD21   1575   0.4196      1.008   ; qtot 4.5510
+ 1576          H    106    ASN   HD22   1576   0.4196      1.008   ; qtot 4.9706
+ 1577          C    106    ASN      C   1577   0.5973     12.010   ; qtot 5.5679
+ 1578          O    106    ASN      O   1578  -0.5679     16.000   ; qtot 5.0000
+; residue  107 ALA rtp ALA q 0.0
+ 1579          N    107    ALA      N   1579  -0.4157     14.010   ; qtot 4.5843
+ 1580          H    107    ALA      H   1580   0.2719      1.008   ; qtot 4.8562
+ 1581         CT    107    ALA     CA   1581   0.0337     12.010   ; qtot 4.8899
+ 1582         H1    107    ALA     HA   1582   0.0823      1.008   ; qtot 4.9722
+ 1583         CT    107    ALA     CB   1583  -0.1825     12.010   ; qtot 4.7897
+ 1584         HC    107    ALA    HB1   1584   0.0603      1.008   ; qtot 4.8500
+ 1585         HC    107    ALA    HB2   1585   0.0603      1.008   ; qtot 4.9103
+ 1586         HC    107    ALA    HB3   1586   0.0603      1.008   ; qtot 4.9706
+ 1587          C    107    ALA      C   1587   0.5973     12.010   ; qtot 5.5679
+ 1588          O    107    ALA      O   1588  -0.5679     16.000   ; qtot 5.0000
+; residue  108 TRP rtp TRP q 0.0
+ 1589          N    108    TRP      N   1589  -0.4157     14.010   ; qtot 4.5843
+ 1590          H    108    TRP      H   1590   0.2719      1.008   ; qtot 4.8562
+ 1591         CT    108    TRP     CA   1591  -0.0275     12.010   ; qtot 4.8287
+ 1592         H1    108    TRP     HA   1592   0.1123      1.008   ; qtot 4.9410
+ 1593         CT    108    TRP     CB   1593  -0.0050     12.010   ; qtot 4.9360
+ 1594         HC    108    TRP    HB1   1594   0.0339      1.008   ; qtot 4.9699
+ 1595         HC    108    TRP    HB2   1595   0.0339      1.008   ; qtot 5.0038
+ 1596         C*    108    TRP     CG   1596  -0.1415     12.010   ; qtot 4.8623
+ 1597         CW    108    TRP    CD1   1597  -0.1638     12.010   ; qtot 4.6985
+ 1598         H4    108    TRP    HD1   1598   0.2062      1.008   ; qtot 4.9047
+ 1599         NA    108    TRP    NE1   1599  -0.3418     14.010   ; qtot 4.5629
+ 1600          H    108    TRP    HE1   1600   0.3412      1.008   ; qtot 4.9041
+ 1601         CN    108    TRP    CE2   1601   0.1380     12.010   ; qtot 5.0421
+ 1602         CA    108    TRP    CZ2   1602  -0.2601     12.010   ; qtot 4.7820
+ 1603         HA    108    TRP    HZ2   1603   0.1572      1.008   ; qtot 4.9392
+ 1604         CA    108    TRP    CH2   1604  -0.1134     12.010   ; qtot 4.8258
+ 1605         HA    108    TRP    HH2   1605   0.1417      1.008   ; qtot 4.9675
+ 1606         CA    108    TRP    CZ3   1606  -0.1972     12.010   ; qtot 4.7703
+ 1607         HA    108    TRP    HZ3   1607   0.1447      1.008   ; qtot 4.9150
+ 1608         CA    108    TRP    CE3   1608  -0.2387     12.010   ; qtot 4.6763
+ 1609         HA    108    TRP    HE3   1609   0.1700      1.008   ; qtot 4.8463
+ 1610         CB    108    TRP    CD2   1610   0.1243     12.010   ; qtot 4.9706
+ 1611          C    108    TRP      C   1611   0.5973     12.010   ; qtot 5.5679
+ 1612          O    108    TRP      O   1612  -0.5679     16.000   ; qtot 5.0000
+; residue  109 VAL rtp VAL q 0.0
+ 1613          N    109    VAL      N   1613  -0.4157     14.010   ; qtot 4.5843
+ 1614          H    109    VAL      H   1614   0.2719      1.008   ; qtot 4.8562
+ 1615         CT    109    VAL     CA   1615  -0.0875     12.010   ; qtot 4.7687
+ 1616         H1    109    VAL     HA   1616   0.0969      1.008   ; qtot 4.8656
+ 1617         CT    109    VAL     CB   1617   0.2985     12.010   ; qtot 5.1641
+ 1618         HC    109    VAL     HB   1618  -0.0297      1.008   ; qtot 5.1344
+ 1619         CT    109    VAL    CG1   1619  -0.3192     12.010   ; qtot 4.8152
+ 1620         HC    109    VAL   HG11   1620   0.0791      1.008   ; qtot 4.8943
+ 1621         HC    109    VAL   HG12   1621   0.0791      1.008   ; qtot 4.9734
+ 1622         HC    109    VAL   HG13   1622   0.0791      1.008   ; qtot 5.0525
+ 1623         CT    109    VAL    CG2   1623  -0.3192     12.010   ; qtot 4.7333
+ 1624         HC    109    VAL   HG21   1624   0.0791      1.008   ; qtot 4.8124
+ 1625         HC    109    VAL   HG22   1625   0.0791      1.008   ; qtot 4.8915
+ 1626         HC    109    VAL   HG23   1626   0.0791      1.008   ; qtot 4.9706
+ 1627          C    109    VAL      C   1627   0.5973     12.010   ; qtot 5.5679
+ 1628          O    109    VAL      O   1628  -0.5679     16.000   ; qtot 5.0000
+; residue  110 ALA rtp ALA q 0.0
+ 1629          N    110    ALA      N   1629  -0.4157     14.010   ; qtot 4.5843
+ 1630          H    110    ALA      H   1630   0.2719      1.008   ; qtot 4.8562
+ 1631         CT    110    ALA     CA   1631   0.0337     12.010   ; qtot 4.8899
+ 1632         H1    110    ALA     HA   1632   0.0823      1.008   ; qtot 4.9722
+ 1633         CT    110    ALA     CB   1633  -0.1825     12.010   ; qtot 4.7897
+ 1634         HC    110    ALA    HB1   1634   0.0603      1.008   ; qtot 4.8500
+ 1635         HC    110    ALA    HB2   1635   0.0603      1.008   ; qtot 4.9103
+ 1636         HC    110    ALA    HB3   1636   0.0603      1.008   ; qtot 4.9706
+ 1637          C    110    ALA      C   1637   0.5973     12.010   ; qtot 5.5679
+ 1638          O    110    ALA      O   1638  -0.5679     16.000   ; qtot 5.0000
+; residue  111 TRP rtp TRP q 0.0
+ 1639          N    111    TRP      N   1639  -0.4157     14.010   ; qtot 4.5843
+ 1640          H    111    TRP      H   1640   0.2719      1.008   ; qtot 4.8562
+ 1641         CT    111    TRP     CA   1641  -0.0275     12.010   ; qtot 4.8287
+ 1642         H1    111    TRP     HA   1642   0.1123      1.008   ; qtot 4.9410
+ 1643         CT    111    TRP     CB   1643  -0.0050     12.010   ; qtot 4.9360
+ 1644         HC    111    TRP    HB1   1644   0.0339      1.008   ; qtot 4.9699
+ 1645         HC    111    TRP    HB2   1645   0.0339      1.008   ; qtot 5.0038
+ 1646         C*    111    TRP     CG   1646  -0.1415     12.010   ; qtot 4.8623
+ 1647         CW    111    TRP    CD1   1647  -0.1638     12.010   ; qtot 4.6985
+ 1648         H4    111    TRP    HD1   1648   0.2062      1.008   ; qtot 4.9047
+ 1649         NA    111    TRP    NE1   1649  -0.3418     14.010   ; qtot 4.5629
+ 1650          H    111    TRP    HE1   1650   0.3412      1.008   ; qtot 4.9041
+ 1651         CN    111    TRP    CE2   1651   0.1380     12.010   ; qtot 5.0421
+ 1652         CA    111    TRP    CZ2   1652  -0.2601     12.010   ; qtot 4.7820
+ 1653         HA    111    TRP    HZ2   1653   0.1572      1.008   ; qtot 4.9392
+ 1654         CA    111    TRP    CH2   1654  -0.1134     12.010   ; qtot 4.8258
+ 1655         HA    111    TRP    HH2   1655   0.1417      1.008   ; qtot 4.9675
+ 1656         CA    111    TRP    CZ3   1656  -0.1972     12.010   ; qtot 4.7703
+ 1657         HA    111    TRP    HZ3   1657   0.1447      1.008   ; qtot 4.9150
+ 1658         CA    111    TRP    CE3   1658  -0.2387     12.010   ; qtot 4.6763
+ 1659         HA    111    TRP    HE3   1659   0.1700      1.008   ; qtot 4.8463
+ 1660         CB    111    TRP    CD2   1660   0.1243     12.010   ; qtot 4.9706
+ 1661          C    111    TRP      C   1661   0.5973     12.010   ; qtot 5.5679
+ 1662          O    111    TRP      O   1662  -0.5679     16.000   ; qtot 5.0000
+; residue  112 ARG rtp ARG q 1.0
+ 1663          N    112    ARG      N   1663  -0.3479     14.010   ; qtot 4.6521
+ 1664          H    112    ARG      H   1664   0.2747      1.008   ; qtot 4.9268
+ 1665         CT    112    ARG     CA   1665  -0.2637     12.010   ; qtot 4.6631
+ 1666         H1    112    ARG     HA   1666   0.1560      1.008   ; qtot 4.8191
+ 1667         CT    112    ARG     CB   1667  -0.0007     12.010   ; qtot 4.8184
+ 1668         HC    112    ARG    HB1   1668   0.0327      1.008   ; qtot 4.8511
+ 1669         HC    112    ARG    HB2   1669   0.0327      1.008   ; qtot 4.8838
+ 1670         CT    112    ARG     CG   1670   0.0390     12.010   ; qtot 4.9228
+ 1671         HC    112    ARG    HG1   1671   0.0285      1.008   ; qtot 4.9513
+ 1672         HC    112    ARG    HG2   1672   0.0285      1.008   ; qtot 4.9798
+ 1673         CT    112    ARG     CD   1673   0.0486     12.010   ; qtot 5.0284
+ 1674         H1    112    ARG    HD1   1674   0.0687      1.008   ; qtot 5.0971
+ 1675         H1    112    ARG    HD2   1675   0.0687      1.008   ; qtot 5.1658
+ 1676         N2    112    ARG     NE   1676  -0.5295     14.010   ; qtot 4.6363
+ 1677          H    112    ARG     HE   1677   0.3456      1.008   ; qtot 4.9819
+ 1678         CA    112    ARG     CZ   1678   0.8076     12.010   ; qtot 5.7895
+ 1679         N2    112    ARG    NH1   1679  -0.8627     14.010   ; qtot 4.9268
+ 1680          H    112    ARG   HH11   1680   0.4478      1.008   ; qtot 5.3746
+ 1681          H    112    ARG   HH12   1681   0.4478      1.008   ; qtot 5.8224
+ 1682         N2    112    ARG    NH2   1682  -0.8627     14.010   ; qtot 4.9597
+ 1683          H    112    ARG   HH21   1683   0.4478      1.008   ; qtot 5.4075
+ 1684          H    112    ARG   HH22   1684   0.4478      1.008   ; qtot 5.8553
+ 1685          C    112    ARG      C   1685   0.7341     12.010   ; qtot 6.5894
+ 1686          O    112    ARG      O   1686  -0.5894     16.000   ; qtot 6.0000
+; residue  113 ASN rtp ASN q 0.0
+ 1687          N    113    ASN      N   1687  -0.4157     14.010   ; qtot 5.5843
+ 1688          H    113    ASN      H   1688   0.2719      1.008   ; qtot 5.8562
+ 1689         CT    113    ASN     CA   1689   0.0143     12.010   ; qtot 5.8705
+ 1690         H1    113    ASN     HA   1690   0.1048      1.008   ; qtot 5.9753
+ 1691         CT    113    ASN     CB   1691  -0.2041     12.010   ; qtot 5.7712
+ 1692         HC    113    ASN    HB1   1692   0.0797      1.008   ; qtot 5.8509
+ 1693         HC    113    ASN    HB2   1693   0.0797      1.008   ; qtot 5.9306
+ 1694          C    113    ASN     CG   1694   0.7130     12.010   ; qtot 6.6436
+ 1695          O    113    ASN    OD1   1695  -0.5931     16.000   ; qtot 6.0505
+ 1696          N    113    ASN    ND2   1696  -0.9191     14.010   ; qtot 5.1314
+ 1697          H    113    ASN   HD21   1697   0.4196      1.008   ; qtot 5.5510
+ 1698          H    113    ASN   HD22   1698   0.4196      1.008   ; qtot 5.9706
+ 1699          C    113    ASN      C   1699   0.5973     12.010   ; qtot 6.5679
+ 1700          O    113    ASN      O   1700  -0.5679     16.000   ; qtot 6.0000
+; residue  114 ARG rtp ARG q 1.0
+ 1701          N    114    ARG      N   1701  -0.3479     14.010   ; qtot 5.6521
+ 1702          H    114    ARG      H   1702   0.2747      1.008   ; qtot 5.9268
+ 1703         CT    114    ARG     CA   1703  -0.2637     12.010   ; qtot 5.6631
+ 1704         H1    114    ARG     HA   1704   0.1560      1.008   ; qtot 5.8191
+ 1705         CT    114    ARG     CB   1705  -0.0007     12.010   ; qtot 5.8184
+ 1706         HC    114    ARG    HB1   1706   0.0327      1.008   ; qtot 5.8511
+ 1707         HC    114    ARG    HB2   1707   0.0327      1.008   ; qtot 5.8838
+ 1708         CT    114    ARG     CG   1708   0.0390     12.010   ; qtot 5.9228
+ 1709         HC    114    ARG    HG1   1709   0.0285      1.008   ; qtot 5.9513
+ 1710         HC    114    ARG    HG2   1710   0.0285      1.008   ; qtot 5.9798
+ 1711         CT    114    ARG     CD   1711   0.0486     12.010   ; qtot 6.0284
+ 1712         H1    114    ARG    HD1   1712   0.0687      1.008   ; qtot 6.0971
+ 1713         H1    114    ARG    HD2   1713   0.0687      1.008   ; qtot 6.1658
+ 1714         N2    114    ARG     NE   1714  -0.5295     14.010   ; qtot 5.6363
+ 1715          H    114    ARG     HE   1715   0.3456      1.008   ; qtot 5.9819
+ 1716         CA    114    ARG     CZ   1716   0.8076     12.010   ; qtot 6.7895
+ 1717         N2    114    ARG    NH1   1717  -0.8627     14.010   ; qtot 5.9268
+ 1718          H    114    ARG   HH11   1718   0.4478      1.008   ; qtot 6.3746
+ 1719          H    114    ARG   HH12   1719   0.4478      1.008   ; qtot 6.8224
+ 1720         N2    114    ARG    NH2   1720  -0.8627     14.010   ; qtot 5.9597
+ 1721          H    114    ARG   HH21   1721   0.4478      1.008   ; qtot 6.4075
+ 1722          H    114    ARG   HH22   1722   0.4478      1.008   ; qtot 6.8553
+ 1723          C    114    ARG      C   1723   0.7341     12.010   ; qtot 7.5894
+ 1724          O    114    ARG      O   1724  -0.5894     16.000   ; qtot 7.0000
+; residue  115 CYS rtp CYS q 0.0
+ 1725          N    115    CYS      N   1725  -0.4157     14.010   ; qtot 6.5843
+ 1726          H    115    CYS      H   1726   0.2719      1.008   ; qtot 6.8562
+ 1727         CT    115    CYS     CA   1727   0.0429     12.010   ; qtot 6.8991
+ 1728         H1    115    CYS     HA   1728   0.0766      1.008   ; qtot 6.9757
+ 1729         CT    115    CYS     CB   1729  -0.0790     12.010   ; qtot 6.8967
+ 1730         H1    115    CYS    HB1   1730   0.0910      1.008   ; qtot 6.9877
+ 1731         H1    115    CYS    HB2   1731   0.0910      1.008   ; qtot 7.0787
+ 1732          S    115    CYS     SG   1732  -0.1081     32.060   ; qtot 6.9706
+ 1733          C    115    CYS      C   1733   0.5973     12.010   ; qtot 7.5679
+ 1734          O    115    CYS      O   1734  -0.5679     16.000   ; qtot 7.0000
+; residue  116 LYS rtp LYS q 1.0
+ 1735          N    116    LYS      N   1735  -0.3479     14.010   ; qtot 6.6521
+ 1736          H    116    LYS      H   1736   0.2747      1.008   ; qtot 6.9268
+ 1737         CT    116    LYS     CA   1737  -0.2400     12.010   ; qtot 6.6868
+ 1738         H1    116    LYS     HA   1738   0.1426      1.008   ; qtot 6.8294
+ 1739         CT    116    LYS     CB   1739  -0.0094     12.010   ; qtot 6.8200
+ 1740         HC    116    LYS    HB1   1740   0.0362      1.008   ; qtot 6.8562
+ 1741         HC    116    LYS    HB2   1741   0.0362      1.008   ; qtot 6.8924
+ 1742         CT    116    LYS     CG   1742   0.0187     12.010   ; qtot 6.9111
+ 1743         HC    116    LYS    HG1   1743   0.0103      1.008   ; qtot 6.9214
+ 1744         HC    116    LYS    HG2   1744   0.0103      1.008   ; qtot 6.9317
+ 1745         CT    116    LYS     CD   1745  -0.0479     12.010   ; qtot 6.8838
+ 1746         HC    116    LYS    HD1   1746   0.0621      1.008   ; qtot 6.9459
+ 1747         HC    116    LYS    HD2   1747   0.0621      1.008   ; qtot 7.0080
+ 1748         CT    116    LYS     CE   1748  -0.0143     12.010   ; qtot 6.9937
+ 1749         HP    116    LYS    HE1   1749   0.1135      1.008   ; qtot 7.1072
+ 1750         HP    116    LYS    HE2   1750   0.1135      1.008   ; qtot 7.2207
+ 1751         N3    116    LYS     NZ   1751  -0.3854     14.010   ; qtot 6.8353
+ 1752          H    116    LYS    HZ1   1752   0.3400      1.008   ; qtot 7.1753
+ 1753          H    116    LYS    HZ2   1753   0.3400      1.008   ; qtot 7.5153
+ 1754          H    116    LYS    HZ3   1754   0.3400      1.008   ; qtot 7.8553
+ 1755          C    116    LYS      C   1755   0.7341     12.010   ; qtot 8.5894
+ 1756          O    116    LYS      O   1756  -0.5894     16.000   ; qtot 8.0000
+; residue  117 GLY rtp GLY q 0.0
+ 1757          N    117    GLY      N   1757  -0.4157     14.010   ; qtot 7.5843
+ 1758          H    117    GLY      H   1758   0.2719      1.008   ; qtot 7.8562
+ 1759         CT    117    GLY     CA   1759  -0.0252     12.010   ; qtot 7.8310
+ 1760         H1    117    GLY    HA1   1760   0.0698      1.008   ; qtot 7.9008
+ 1761         H1    117    GLY    HA2   1761   0.0698      1.008   ; qtot 7.9706
+ 1762          C    117    GLY      C   1762   0.5973     12.010   ; qtot 8.5679
+ 1763          O    117    GLY      O   1763  -0.5679     16.000   ; qtot 8.0000
+; residue  118 THR rtp THR q 0.0
+ 1764          N    118    THR      N   1764  -0.4157     14.010   ; qtot 7.5843
+ 1765          H    118    THR      H   1765   0.2719      1.008   ; qtot 7.8562
+ 1766         CT    118    THR     CA   1766  -0.0389     12.010   ; qtot 7.8173
+ 1767         H1    118    THR     HA   1767   0.1007      1.008   ; qtot 7.9180
+ 1768         CT    118    THR     CB   1768   0.3654     12.010   ; qtot 8.2834
+ 1769         H1    118    THR     HB   1769   0.0043      1.008   ; qtot 8.2877
+ 1770         CT    118    THR    CG2   1770  -0.2438     12.010   ; qtot 8.0439
+ 1771         HC    118    THR   HG21   1771   0.0642      1.008   ; qtot 8.1081
+ 1772         HC    118    THR   HG22   1772   0.0642      1.008   ; qtot 8.1723
+ 1773         HC    118    THR   HG23   1773   0.0642      1.008   ; qtot 8.2365
+ 1774         OH    118    THR    OG1   1774  -0.6761     16.000   ; qtot 7.5604
+ 1775         HO    118    THR    HG1   1775   0.4102      1.008   ; qtot 7.9706
+ 1776          C    118    THR      C   1776   0.5973     12.010   ; qtot 8.5679
+ 1777          O    118    THR      O   1777  -0.5679     16.000   ; qtot 8.0000
+; residue  119 ASP rtp ASP q -1.0
+ 1778          N    119    ASP      N   1778  -0.5163     14.010   ; qtot 7.4837
+ 1779          H    119    ASP      H   1779   0.2936      1.008   ; qtot 7.7773
+ 1780         CT    119    ASP     CA   1780   0.0381     12.010   ; qtot 7.8154
+ 1781         H1    119    ASP     HA   1781   0.0880      1.008   ; qtot 7.9034
+ 1782         CT    119    ASP     CB   1782  -0.0303     12.010   ; qtot 7.8731
+ 1783         HC    119    ASP    HB1   1783  -0.0122      1.008   ; qtot 7.8609
+ 1784         HC    119    ASP    HB2   1784  -0.0122      1.008   ; qtot 7.8487
+ 1785          C    119    ASP     CG   1785   0.7994     12.010   ; qtot 8.6481
+ 1786         O2    119    ASP    OD1   1786  -0.8014     16.000   ; qtot 7.8467
+ 1787         O2    119    ASP    OD2   1787  -0.8014     16.000   ; qtot 7.0453
+ 1788          C    119    ASP      C   1788   0.5366     12.010   ; qtot 7.5819
+ 1789          O    119    ASP      O   1789  -0.5819     16.000   ; qtot 7.0000
+; residue  120 VAL rtp VAL q 0.0
+ 1790          N    120    VAL      N   1790  -0.4157     14.010   ; qtot 6.5843
+ 1791          H    120    VAL      H   1791   0.2719      1.008   ; qtot 6.8562
+ 1792         CT    120    VAL     CA   1792  -0.0875     12.010   ; qtot 6.7687
+ 1793         H1    120    VAL     HA   1793   0.0969      1.008   ; qtot 6.8656
+ 1794         CT    120    VAL     CB   1794   0.2985     12.010   ; qtot 7.1641
+ 1795         HC    120    VAL     HB   1795  -0.0297      1.008   ; qtot 7.1344
+ 1796         CT    120    VAL    CG1   1796  -0.3192     12.010   ; qtot 6.8152
+ 1797         HC    120    VAL   HG11   1797   0.0791      1.008   ; qtot 6.8943
+ 1798         HC    120    VAL   HG12   1798   0.0791      1.008   ; qtot 6.9734
+ 1799         HC    120    VAL   HG13   1799   0.0791      1.008   ; qtot 7.0525
+ 1800         CT    120    VAL    CG2   1800  -0.3192     12.010   ; qtot 6.7333
+ 1801         HC    120    VAL   HG21   1801   0.0791      1.008   ; qtot 6.8124
+ 1802         HC    120    VAL   HG22   1802   0.0791      1.008   ; qtot 6.8915
+ 1803         HC    120    VAL   HG23   1803   0.0791      1.008   ; qtot 6.9706
+ 1804          C    120    VAL      C   1804   0.5973     12.010   ; qtot 7.5679
+ 1805          O    120    VAL      O   1805  -0.5679     16.000   ; qtot 7.0000
+; residue  121 GLN rtp GLN q 0.0
+ 1806          N    121    GLN      N   1806  -0.4157     14.010   ; qtot 6.5843
+ 1807          H    121    GLN      H   1807   0.2719      1.008   ; qtot 6.8562
+ 1808         CT    121    GLN     CA   1808  -0.0031     12.010   ; qtot 6.8531
+ 1809         H1    121    GLN     HA   1809   0.0850      1.008   ; qtot 6.9381
+ 1810         CT    121    GLN     CB   1810  -0.0036     12.010   ; qtot 6.9345
+ 1811         HC    121    GLN    HB1   1811   0.0171      1.008   ; qtot 6.9516
+ 1812         HC    121    GLN    HB2   1812   0.0171      1.008   ; qtot 6.9687
+ 1813         CT    121    GLN     CG   1813  -0.0645     12.010   ; qtot 6.9042
+ 1814         HC    121    GLN    HG1   1814   0.0352      1.008   ; qtot 6.9394
+ 1815         HC    121    GLN    HG2   1815   0.0352      1.008   ; qtot 6.9746
+ 1816          C    121    GLN     CD   1816   0.6951     12.010   ; qtot 7.6697
+ 1817          O    121    GLN    OE1   1817  -0.6086     16.000   ; qtot 7.0611
+ 1818          N    121    GLN    NE2   1818  -0.9407     14.010   ; qtot 6.1204
+ 1819          H    121    GLN   HE21   1819   0.4251      1.008   ; qtot 6.5455
+ 1820          H    121    GLN   HE22   1820   0.4251      1.008   ; qtot 6.9706
+ 1821          C    121    GLN      C   1821   0.5973     12.010   ; qtot 7.5679
+ 1822          O    121    GLN      O   1822  -0.5679     16.000   ; qtot 7.0000
+; residue  122 ALA rtp ALA q 0.0
+ 1823          N    122    ALA      N   1823  -0.4157     14.010   ; qtot 6.5843
+ 1824          H    122    ALA      H   1824   0.2719      1.008   ; qtot 6.8562
+ 1825         CT    122    ALA     CA   1825   0.0337     12.010   ; qtot 6.8899
+ 1826         H1    122    ALA     HA   1826   0.0823      1.008   ; qtot 6.9722
+ 1827         CT    122    ALA     CB   1827  -0.1825     12.010   ; qtot 6.7897
+ 1828         HC    122    ALA    HB1   1828   0.0603      1.008   ; qtot 6.8500
+ 1829         HC    122    ALA    HB2   1829   0.0603      1.008   ; qtot 6.9103
+ 1830         HC    122    ALA    HB3   1830   0.0603      1.008   ; qtot 6.9706
+ 1831          C    122    ALA      C   1831   0.5973     12.010   ; qtot 7.5679
+ 1832          O    122    ALA      O   1832  -0.5679     16.000   ; qtot 7.0000
+; residue  123 TRP rtp TRP q 0.0
+ 1833          N    123    TRP      N   1833  -0.4157     14.010   ; qtot 6.5843
+ 1834          H    123    TRP      H   1834   0.2719      1.008   ; qtot 6.8562
+ 1835         CT    123    TRP     CA   1835  -0.0275     12.010   ; qtot 6.8287
+ 1836         H1    123    TRP     HA   1836   0.1123      1.008   ; qtot 6.9410
+ 1837         CT    123    TRP     CB   1837  -0.0050     12.010   ; qtot 6.9360
+ 1838         HC    123    TRP    HB1   1838   0.0339      1.008   ; qtot 6.9699
+ 1839         HC    123    TRP    HB2   1839   0.0339      1.008   ; qtot 7.0038
+ 1840         C*    123    TRP     CG   1840  -0.1415     12.010   ; qtot 6.8623
+ 1841         CW    123    TRP    CD1   1841  -0.1638     12.010   ; qtot 6.6985
+ 1842         H4    123    TRP    HD1   1842   0.2062      1.008   ; qtot 6.9047
+ 1843         NA    123    TRP    NE1   1843  -0.3418     14.010   ; qtot 6.5629
+ 1844          H    123    TRP    HE1   1844   0.3412      1.008   ; qtot 6.9041
+ 1845         CN    123    TRP    CE2   1845   0.1380     12.010   ; qtot 7.0421
+ 1846         CA    123    TRP    CZ2   1846  -0.2601     12.010   ; qtot 6.7820
+ 1847         HA    123    TRP    HZ2   1847   0.1572      1.008   ; qtot 6.9392
+ 1848         CA    123    TRP    CH2   1848  -0.1134     12.010   ; qtot 6.8258
+ 1849         HA    123    TRP    HH2   1849   0.1417      1.008   ; qtot 6.9675
+ 1850         CA    123    TRP    CZ3   1850  -0.1972     12.010   ; qtot 6.7703
+ 1851         HA    123    TRP    HZ3   1851   0.1447      1.008   ; qtot 6.9150
+ 1852         CA    123    TRP    CE3   1852  -0.2387     12.010   ; qtot 6.6763
+ 1853         HA    123    TRP    HE3   1853   0.1700      1.008   ; qtot 6.8463
+ 1854         CB    123    TRP    CD2   1854   0.1243     12.010   ; qtot 6.9706
+ 1855          C    123    TRP      C   1855   0.5973     12.010   ; qtot 7.5679
+ 1856          O    123    TRP      O   1856  -0.5679     16.000   ; qtot 7.0000
+; residue  124 ILE rtp ILE q 0.0
+ 1857          N    124    ILE      N   1857  -0.4157     14.010   ; qtot 6.5843
+ 1858          H    124    ILE      H   1858   0.2719      1.008   ; qtot 6.8562
+ 1859         CT    124    ILE     CA   1859  -0.0597     12.010   ; qtot 6.7965
+ 1860         H1    124    ILE     HA   1860   0.0869      1.008   ; qtot 6.8834
+ 1861         CT    124    ILE     CB   1861   0.1303     12.010   ; qtot 7.0137
+ 1862         HC    124    ILE     HB   1862   0.0187      1.008   ; qtot 7.0324
+ 1863         CT    124    ILE    CG2   1863  -0.3204     12.010   ; qtot 6.7120
+ 1864         HC    124    ILE   HG21   1864   0.0882      1.008   ; qtot 6.8002
+ 1865         HC    124    ILE   HG22   1865   0.0882      1.008   ; qtot 6.8884
+ 1866         HC    124    ILE   HG23   1866   0.0882      1.008   ; qtot 6.9766
+ 1867         CT    124    ILE    CG1   1867  -0.0430     12.010   ; qtot 6.9336
+ 1868         HC    124    ILE   HG11   1868   0.0236      1.008   ; qtot 6.9572
+ 1869         HC    124    ILE   HG12   1869   0.0236      1.008   ; qtot 6.9808
+ 1870         CT    124    ILE     CD   1870  -0.0660     12.010   ; qtot 6.9148
+ 1871         HC    124    ILE    HD1   1871   0.0186      1.008   ; qtot 6.9334
+ 1872         HC    124    ILE    HD2   1872   0.0186      1.008   ; qtot 6.9520
+ 1873         HC    124    ILE    HD3   1873   0.0186      1.008   ; qtot 6.9706
+ 1874          C    124    ILE      C   1874   0.5973     12.010   ; qtot 7.5679
+ 1875          O    124    ILE      O   1875  -0.5679     16.000   ; qtot 7.0000
+; residue  125 ARG rtp ARG q 1.0
+ 1876          N    125    ARG      N   1876  -0.3479     14.010   ; qtot 6.6521
+ 1877          H    125    ARG      H   1877   0.2747      1.008   ; qtot 6.9268
+ 1878         CT    125    ARG     CA   1878  -0.2637     12.010   ; qtot 6.6631
+ 1879         H1    125    ARG     HA   1879   0.1560      1.008   ; qtot 6.8191
+ 1880         CT    125    ARG     CB   1880  -0.0007     12.010   ; qtot 6.8184
+ 1881         HC    125    ARG    HB1   1881   0.0327      1.008   ; qtot 6.8511
+ 1882         HC    125    ARG    HB2   1882   0.0327      1.008   ; qtot 6.8838
+ 1883         CT    125    ARG     CG   1883   0.0390     12.010   ; qtot 6.9228
+ 1884         HC    125    ARG    HG1   1884   0.0285      1.008   ; qtot 6.9513
+ 1885         HC    125    ARG    HG2   1885   0.0285      1.008   ; qtot 6.9798
+ 1886         CT    125    ARG     CD   1886   0.0486     12.010   ; qtot 7.0284
+ 1887         H1    125    ARG    HD1   1887   0.0687      1.008   ; qtot 7.0971
+ 1888         H1    125    ARG    HD2   1888   0.0687      1.008   ; qtot 7.1658
+ 1889         N2    125    ARG     NE   1889  -0.5295     14.010   ; qtot 6.6363
+ 1890          H    125    ARG     HE   1890   0.3456      1.008   ; qtot 6.9819
+ 1891         CA    125    ARG     CZ   1891   0.8076     12.010   ; qtot 7.7895
+ 1892         N2    125    ARG    NH1   1892  -0.8627     14.010   ; qtot 6.9268
+ 1893          H    125    ARG   HH11   1893   0.4478      1.008   ; qtot 7.3746
+ 1894          H    125    ARG   HH12   1894   0.4478      1.008   ; qtot 7.8224
+ 1895         N2    125    ARG    NH2   1895  -0.8627     14.010   ; qtot 6.9597
+ 1896          H    125    ARG   HH21   1896   0.4478      1.008   ; qtot 7.4075
+ 1897          H    125    ARG   HH22   1897   0.4478      1.008   ; qtot 7.8553
+ 1898          C    125    ARG      C   1898   0.7341     12.010   ; qtot 8.5894
+ 1899          O    125    ARG      O   1899  -0.5894     16.000   ; qtot 8.0000
+; residue  126 GLY rtp GLY q 0.0
+ 1900          N    126    GLY      N   1900  -0.4157     14.010   ; qtot 7.5843
+ 1901          H    126    GLY      H   1901   0.2719      1.008   ; qtot 7.8562
+ 1902         CT    126    GLY     CA   1902  -0.0252     12.010   ; qtot 7.8310
+ 1903         H1    126    GLY    HA1   1903   0.0698      1.008   ; qtot 7.9008
+ 1904         H1    126    GLY    HA2   1904   0.0698      1.008   ; qtot 7.9706
+ 1905          C    126    GLY      C   1905   0.5973     12.010   ; qtot 8.5679
+ 1906          O    126    GLY      O   1906  -0.5679     16.000   ; qtot 8.0000
+; residue  127 CYS rtp CYS q 0.0
+ 1907          N    127    CYS      N   1907  -0.4157     14.010   ; qtot 7.5843
+ 1908          H    127    CYS      H   1908   0.2719      1.008   ; qtot 7.8562
+ 1909         CT    127    CYS     CA   1909   0.0429     12.010   ; qtot 7.8991
+ 1910         H1    127    CYS     HA   1910   0.0766      1.008   ; qtot 7.9757
+ 1911         CT    127    CYS     CB   1911  -0.0790     12.010   ; qtot 7.8967
+ 1912         H1    127    CYS    HB1   1912   0.0910      1.008   ; qtot 7.9877
+ 1913         H1    127    CYS    HB2   1913   0.0910      1.008   ; qtot 8.0787
+ 1914          S    127    CYS     SG   1914  -0.1081     32.060   ; qtot 7.9706
+ 1915          C    127    CYS      C   1915   0.5973     12.010   ; qtot 8.5679
+ 1916          O    127    CYS      O   1916  -0.5679     16.000   ; qtot 8.0000
+; residue  128 ARG rtp ARG q 1.0
+ 1917          N    128    ARG      N   1917  -0.3479     14.010   ; qtot 7.6521
+ 1918          H    128    ARG      H   1918   0.2747      1.008   ; qtot 7.9268
+ 1919         CT    128    ARG     CA   1919  -0.2637     12.010   ; qtot 7.6631
+ 1920         H1    128    ARG     HA   1920   0.1560      1.008   ; qtot 7.8191
+ 1921         CT    128    ARG     CB   1921  -0.0007     12.010   ; qtot 7.8184
+ 1922         HC    128    ARG    HB1   1922   0.0327      1.008   ; qtot 7.8511
+ 1923         HC    128    ARG    HB2   1923   0.0327      1.008   ; qtot 7.8838
+ 1924         CT    128    ARG     CG   1924   0.0390     12.010   ; qtot 7.9228
+ 1925         HC    128    ARG    HG1   1925   0.0285      1.008   ; qtot 7.9513
+ 1926         HC    128    ARG    HG2   1926   0.0285      1.008   ; qtot 7.9798
+ 1927         CT    128    ARG     CD   1927   0.0486     12.010   ; qtot 8.0284
+ 1928         H1    128    ARG    HD1   1928   0.0687      1.008   ; qtot 8.0971
+ 1929         H1    128    ARG    HD2   1929   0.0687      1.008   ; qtot 8.1658
+ 1930         N2    128    ARG     NE   1930  -0.5295     14.010   ; qtot 7.6363
+ 1931          H    128    ARG     HE   1931   0.3456      1.008   ; qtot 7.9819
+ 1932         CA    128    ARG     CZ   1932   0.8076     12.010   ; qtot 8.7895
+ 1933         N2    128    ARG    NH1   1933  -0.8627     14.010   ; qtot 7.9268
+ 1934          H    128    ARG   HH11   1934   0.4478      1.008   ; qtot 8.3746
+ 1935          H    128    ARG   HH12   1935   0.4478      1.008   ; qtot 8.8224
+ 1936         N2    128    ARG    NH2   1936  -0.8627     14.010   ; qtot 7.9597
+ 1937          H    128    ARG   HH21   1937   0.4478      1.008   ; qtot 8.4075
+ 1938          H    128    ARG   HH22   1938   0.4478      1.008   ; qtot 8.8553
+ 1939          C    128    ARG      C   1939   0.7341     12.010   ; qtot 9.5894
+ 1940          O    128    ARG      O   1940  -0.5894     16.000   ; qtot 9.0000
+; residue  129 LEU rtp LEU q -1.0
+ 1941          N    129    LEU      N   1941  -0.3821     14.010   ; qtot 8.6179
+ 1942          H    129    LEU      H   1942   0.2681      1.008   ; qtot 8.8860
+ 1943         CT    129    LEU     CA   1943  -0.2847     12.010   ; qtot 8.6013
+ 1944         H1    129    LEU     HA   1944   0.1346      1.008   ; qtot 8.7359
+ 1945         CT    129    LEU     CB   1945  -0.2469     12.010   ; qtot 8.4890
+ 1946         HC    129    LEU    HB1   1946   0.0974      1.008   ; qtot 8.5864
+ 1947         HC    129    LEU    HB2   1947   0.0974      1.008   ; qtot 8.6838
+ 1948         CT    129    LEU     CG   1948   0.3706     12.010   ; qtot 9.0544
+ 1949         HC    129    LEU     HG   1949  -0.0374      1.008   ; qtot 9.0170
+ 1950         CT    129    LEU    CD1   1950  -0.4163     12.010   ; qtot 8.6007
+ 1951         HC    129    LEU   HD11   1951   0.1038      1.008   ; qtot 8.7045
+ 1952         HC    129    LEU   HD12   1952   0.1038      1.008   ; qtot 8.8083
+ 1953         HC    129    LEU   HD13   1953   0.1038      1.008   ; qtot 8.9121
+ 1954         CT    129    LEU    CD2   1954  -0.4163     12.010   ; qtot 8.4958
+ 1955         HC    129    LEU   HD21   1955   0.1038      1.008   ; qtot 8.5996
+ 1956         HC    129    LEU   HD22   1956   0.1038      1.008   ; qtot 8.7034
+ 1957         HC    129    LEU   HD23   1957   0.1038      1.008   ; qtot 8.8072
+ 1958          C    129    LEU      C   1958   0.8326     12.010   ; qtot 9.6398
+ 1959         O2    129    LEU    OC1   1959  -0.8199     16.000   ; qtot 8.8199
+ 1960         O2    129    LEU    OC2   1960  -0.8199     16.000   ; qtot 8.0000
+
+[ bonds ]
+;    ai     aj funct         c0         c1         c2         c3
+      1      2     1
+      1      3     1
+      1      4     1
+      1      5     1
+      5      6     1
+      5      7     1
+      5     23     1
+      7      8     1
+      7      9     1
+      7     10     1
+     10     11     1
+     10     12     1
+     10     13     1
+     13     14     1
+     13     15     1
+     13     16     1
+     16     17     1
+     16     18     1
+     16     19     1
+     19     20     1
+     19     21     1
+     19     22     1
+     23     24     1
+     23     25     1
+     25     26     1
+     25     27     1
+     27     28     1
+     27     29     1
+     27     39     1
+     29     30     1
+     29     31     1
+     29     35     1
+     31     32     1
+     31     33     1
+     31     34     1
+     35     36     1
+     35     37     1
+     35     38     1
+     39     40     1
+     39     41     1
+     41     42     1
+     41     43     1
+     43     44     1
+     43     45     1
+     43     59     1
+     45     46     1
+     45     47     1
+     45     48     1
+     48     49     1
+     48     57     1
+     49     50     1
+     49     51     1
+     51     52     1
+     51     53     1
+     53     54     1
+     53     55     1
+     55     56     1
+     55     57     1
+     57     58     1
+     59     60     1
+     59     61     1
+     61     62     1
+     61     63     1
+     63     64     1
+     63     65     1
+     63     66     1
+     66     67     1
+     66     68     1
+     68     69     1
+     68     70     1
+     70     71     1
+     70     72     1
+     70     90     1
+     72     73     1
+     72     74     1
+     72     75     1
+     75     76     1
+     75     77     1
+     75     78     1
+     78     79     1
+     78     80     1
+     78     81     1
+     81     82     1
+     81     83     1
+     83     84     1
+     83     87     1
+     84     85     1
+     84     86     1
+     87     88     1
+     87     89     1
+     90     91     1
+     90     92     1
+     92     93     1
+     92     94     1
+     94     95     1
+     94     96     1
+     94    100     1
+     96     97     1
+     96     98     1
+     96     99     1
+     99   1914     1
+    100    101     1
+    100    102     1
+    102    103     1
+    102    104     1
+    104    105     1
+    104    106     1
+    104    115     1
+    106    107     1
+    106    108     1
+    106    109     1
+    109    110     1
+    109    111     1
+    109    112     1
+    112    113     1
+    112    114     1
+    115    116     1
+    115    117     1
+    117    118     1
+    117    119     1
+    119    120     1
+    119    121     1
+    119    134     1
+    121    122     1
+    121    123     1
+    121    124     1
+    124    125     1
+    124    126     1
+    124    130     1
+    126    127     1
+    126    128     1
+    126    129     1
+    130    131     1
+    130    132     1
+    130    133     1
+    134    135     1
+    134    136     1
+    136    137     1
+    136    138     1
+    138    139     1
+    138    140     1
+    138    144     1
+    140    141     1
+    140    142     1
+    140    143     1
+    144    145     1
+    144    146     1
+    146    147     1
+    146    148     1
+    148    149     1
+    148    150     1
+    148    154     1
+    150    151     1
+    150    152     1
+    150    153     1
+    154    155     1
+    154    156     1
+    156    157     1
+    156    158     1
+    158    159     1
+    158    160     1
+    158    164     1
+    160    161     1
+    160    162     1
+    160    163     1
+    164    165     1
+    164    166     1
+    166    167     1
+    166    168     1
+    168    169     1
+    168    170     1
+    168    181     1
+    170    171     1
+    170    172     1
+    170    173     1
+    173    174     1
+    173    175     1
+    173    176     1
+    176    177     1
+    177    178     1
+    177    179     1
+    177    180     1
+    181    182     1
+    181    183     1
+    183    184     1
+    183    185     1
+    185    186     1
+    185    187     1
+    185    203     1
+    187    188     1
+    187    189     1
+    187    190     1
+    190    191     1
+    190    192     1
+    190    193     1
+    193    194     1
+    193    195     1
+    193    196     1
+    196    197     1
+    196    198     1
+    196    199     1
+    199    200     1
+    199    201     1
+    199    202     1
+    203    204     1
+    203    205     1
+    205    206     1
+    205    207     1
+    207    208     1
+    207    209     1
+    207    227     1
+    209    210     1
+    209    211     1
+    209    212     1
+    212    213     1
+    212    214     1
+    212    215     1
+    215    216     1
+    215    217     1
+    215    218     1
+    218    219     1
+    218    220     1
+    220    221     1
+    220    224     1
+    221    222     1
+    221    223     1
+    224    225     1
+    224    226     1
+    227    228     1
+    227    229     1
+    229    230     1
+    229    231     1
+    231    232     1
+    231    233     1
+    231    244     1
+    233    234     1
+    233    235     1
+    233    236     1
+    236    237     1
+    236    242     1
+    237    238     1
+    238    239     1
+    238    240     1
+    240    241     1
+    240    242     1
+    242    243     1
+    244    245     1
+    244    246     1
+    246    247     1
+    246    248     1
+    248    249     1
+    248    250     1
+    248    251     1
+    251    252     1
+    251    253     1
+    253    254     1
+    253    255     1
+    255    256     1
+    255    257     1
+    255    270     1
+    257    258     1
+    257    259     1
+    257    260     1
+    260    261     1
+    260    262     1
+    260    266     1
+    262    263     1
+    262    264     1
+    262    265     1
+    266    267     1
+    266    268     1
+    266    269     1
+    270    271     1
+    270    272     1
+    272    273     1
+    272    274     1
+    274    275     1
+    274    276     1
+    274    282     1
+    276    277     1
+    276    278     1
+    276    279     1
+    279    280     1
+    279    281     1
+    282    283     1
+    282    284     1
+    284    285     1
+    284    286     1
+    286    287     1
+    286    288     1
+    286    296     1
+    288    289     1
+    288    290     1
+    288    291     1
+    291    292     1
+    291    293     1
+    293    294     1
+    293    295     1
+    296    297     1
+    296    298     1
+    298    299     1
+    298    300     1
+    300    301     1
+    300    302     1
+    300    317     1
+    302    303     1
+    302    304     1
+    302    305     1
+    305    306     1
+    305    315     1
+    306    307     1
+    306    308     1
+    308    309     1
+    308    310     1
+    310    311     1
+    310    313     1
+    311    312     1
+    313    314     1
+    313    315     1
+    315    316     1
+    317    318     1
+    317    319     1
+    319    320     1
+    319    321     1
+    321    322     1
+    321    323     1
+    321    341     1
+    323    324     1
+    323    325     1
+    323    326     1
+    326    327     1
+    326    328     1
+    326    329     1
+    329    330     1
+    329    331     1
+    329    332     1
+    332    333     1
+    332    334     1
+    334    335     1
+    334    338     1
+    335    336     1
+    335    337     1
+    338    339     1
+    338    340     1
+    341    342     1
+    341    343     1
+    343    344     1
+    343    345     1
+    345    346     1
+    345    347     1
+    345    348     1
+    348    349     1
+    348    350     1
+    350    351     1
+    350    352     1
+    352    353     1
+    352    354     1
+    352    369     1
+    354    355     1
+    354    356     1
+    354    357     1
+    357    358     1
+    357    367     1
+    358    359     1
+    358    360     1
+    360    361     1
+    360    362     1
+    362    363     1
+    362    365     1
+    363    364     1
+    365    366     1
+    365    367     1
+    367    368     1
+    369    370     1
+    369    371     1
+    371    372     1
+    371    373     1
+    373    374     1
+    373    375     1
+    373    380     1
+    375    376     1
+    375    377     1
+    375    378     1
+    378    379     1
+    380    381     1
+    380    382     1
+    382    383     1
+    382    384     1
+    384    385     1
+    384    386     1
+    384    399     1
+    386    387     1
+    386    388     1
+    386    389     1
+    389    390     1
+    389    391     1
+    389    395     1
+    391    392     1
+    391    393     1
+    391    394     1
+    395    396     1
+    395    397     1
+    395    398     1
+    399    400     1
+    399    401     1
+    401    402     1
+    401    403     1
+    403    404     1
+    403    405     1
+    403    406     1
+    406    407     1
+    406    408     1
+    408    409     1
+    408    410     1
+    410    411     1
+    410    412     1
+    410    420     1
+    412    413     1
+    412    414     1
+    412    415     1
+    415    416     1
+    415    417     1
+    417    418     1
+    417    419     1
+    420    421     1
+    420    422     1
+    422    423     1
+    422    424     1
+    424    425     1
+    424    426     1
+    424    444     1
+    426    427     1
+    426    428     1
+    426    429     1
+    429    430     1
+    429    443     1
+    430    431     1
+    430    432     1
+    432    433     1
+    432    434     1
+    434    435     1
+    434    443     1
+    435    436     1
+    435    437     1
+    437    438     1
+    437    439     1
+    439    440     1
+    439    441     1
+    441    442     1
+    441    443     1
+    444    445     1
+    444    446     1
+    446    447     1
+    446    448     1
+    448    449     1
+    448    450     1
+    448    460     1
+    450    451     1
+    450    452     1
+    450    456     1
+    452    453     1
+    452    454     1
+    452    455     1
+    456    457     1
+    456    458     1
+    456    459     1
+    460    461     1
+    460    462     1
+    462    463     1
+    462    464     1
+    464    465     1
+    464    466     1
+    464    470     1
+    466    467     1
+    466    468     1
+    466    469     1
+    469   1732     1
+    470    471     1
+    470    472     1
+    472    473     1
+    472    474     1
+    474    475     1
+    474    476     1
+    474    480     1
+    476    477     1
+    476    478     1
+    476    479     1
+    480    481     1
+    480    482     1
+    482    483     1
+    482    484     1
+    484    485     1
+    484    486     1
+    484    490     1
+    486    487     1
+    486    488     1
+    486    489     1
+    490    491     1
+    490    492     1
+    492    493     1
+    492    494     1
+    494    495     1
+    494    496     1
+    494    512     1
+    496    497     1
+    496    498     1
+    496    499     1
+    499    500     1
+    499    501     1
+    499    502     1
+    502    503     1
+    502    504     1
+    502    505     1
+    505    506     1
+    505    507     1
+    505    508     1
+    508    509     1
+    508    510     1
+    508    511     1
+    512    513     1
+    512    514     1
+    514    515     1
+    514    516     1
+    516    517     1
+    516    518     1
+    516    532     1
+    518    519     1
+    518    520     1
+    518    521     1
+    521    522     1
+    521    530     1
+    522    523     1
+    522    524     1
+    524    525     1
+    524    526     1
+    526    527     1
+    526    528     1
+    528    529     1
+    528    530     1
+    530    531     1
+    532    533     1
+    532    534     1
+    534    535     1
+    534    536     1
+    536    537     1
+    536    538     1
+    536    547     1
+    538    539     1
+    538    540     1
+    538    541     1
+    541    542     1
+    541    543     1
+    541    544     1
+    544    545     1
+    544    546     1
+    547    548     1
+    547    549     1
+    549    550     1
+    549    551     1
+    551    552     1
+    551    553     1
+    551    558     1
+    553    554     1
+    553    555     1
+    553    556     1
+    556    557     1
+    558    559     1
+    558    560     1
+    560    561     1
+    560    562     1
+    562    563     1
+    562    564     1
+    562    572     1
+    564    565     1
+    564    566     1
+    564    567     1
+    567    568     1
+    567    569     1
+    569    570     1
+    569    571     1
+    572    573     1
+    572    574     1
+    574    575     1
+    574    576     1
+    576    577     1
+    576    578     1
+    576    592     1
+    578    579     1
+    578    580     1
+    578    581     1
+    581    582     1
+    581    590     1
+    582    583     1
+    582    584     1
+    584    585     1
+    584    586     1
+    586    587     1
+    586    588     1
+    588    589     1
+    588    590     1
+    590    591     1
+    592    593     1
+    592    594     1
+    594    595     1
+    594    596     1
+    596    597     1
+    596    598     1
+    596    606     1
+    598    599     1
+    598    600     1
+    598    601     1
+    601    602     1
+    601    603     1
+    603    604     1
+    603    605     1
+    606    607     1
+    606    608     1
+    608    609     1
+    608    610     1
+    610    611     1
+    610    612     1
+    610    620     1
+    612    613     1
+    612    614     1
+    612    618     1
+    614    615     1
+    614    616     1
+    614    617     1
+    618    619     1
+    620    621     1
+    620    622     1
+    622    623     1
+    622    624     1
+    624    625     1
+    624    626     1
+    624    637     1
+    626    627     1
+    626    628     1
+    626    629     1
+    629    630     1
+    629    631     1
+    629    632     1
+    632    633     1
+    632    634     1
+    634    635     1
+    634    636     1
+    637    638     1
+    637    639     1
+    639    640     1
+    639    641     1
+    641    642     1
+    641    643     1
+    641    647     1
+    643    644     1
+    643    645     1
+    643    646     1
+    647    648     1
+    647    649     1
+    649    650     1
+    649    651     1
+    651    652     1
+    651    653     1
+    651    661     1
+    653    654     1
+    653    655     1
+    653    659     1
+    655    656     1
+    655    657     1
+    655    658     1
+    659    660     1
+    661    662     1
+    661    663     1
+    663    664     1
+    663    665     1
+    665    666     1
+    665    667     1
+    665    675     1
+    667    668     1
+    667    669     1
+    667    670     1
+    670    671     1
+    670    672     1
+    672    673     1
+    672    674     1
+    675    676     1
+    675    677     1
+    677    678     1
+    677    679     1
+    679    680     1
+    679    681     1
+    679    699     1
+    681    682     1
+    681    683     1
+    681    684     1
+    684    685     1
+    684    686     1
+    684    687     1
+    687    688     1
+    687    689     1
+    687    690     1
+    690    691     1
+    690    692     1
+    692    693     1
+    692    696     1
+    693    694     1
+    693    695     1
+    696    697     1
+    696    698     1
+    699    700     1
+    699    701     1
+    701    702     1
+    701    703     1
+    703    704     1
+    703    705     1
+    703    713     1
+    705    706     1
+    705    707     1
+    705    708     1
+    708    709     1
+    708    710     1
+    710    711     1
+    710    712     1
+    713    714     1
+    713    715     1
+    715    716     1
+    715    717     1
+    717    718     1
+    717    719     1
+    717    727     1
+    719    720     1
+    719    721     1
+    719    725     1
+    721    722     1
+    721    723     1
+    721    724     1
+    725    726     1
+    727    728     1
+    727    729     1
+    729    730     1
+    729    731     1
+    731    732     1
+    731    733     1
+    731    739     1
+    733    734     1
+    733    735     1
+    733    736     1
+    736    737     1
+    736    738     1
+    739    740     1
+    739    741     1
+    741    742     1
+    741    743     1
+    743    744     1
+    743    745     1
+    743    746     1
+    746    747     1
+    746    748     1
+    748    749     1
+    748    750     1
+    750    751     1
+    750    752     1
+    750    757     1
+    752    753     1
+    752    754     1
+    752    755     1
+    755    756     1
+    757    758     1
+    757    759     1
+    759    760     1
+    759    761     1
+    761    762     1
+    761    763     1
+    761    771     1
+    763    764     1
+    763    765     1
+    763    769     1
+    765    766     1
+    765    767     1
+    765    768     1
+    769    770     1
+    771    772     1
+    771    773     1
+    773    774     1
+    773    775     1
+    775    776     1
+    775    777     1
+    775    783     1
+    777    778     1
+    777    779     1
+    777    780     1
+    780    781     1
+    780    782     1
+    783    784     1
+    783    785     1
+    785    786     1
+    785    787     1
+    787    788     1
+    787    789     1
+    787    804     1
+    789    790     1
+    789    791     1
+    789    792     1
+    792    793     1
+    792    802     1
+    793    794     1
+    793    795     1
+    795    796     1
+    795    797     1
+    797    798     1
+    797    800     1
+    798    799     1
+    800    801     1
+    800    802     1
+    802    803     1
+    804    805     1
+    804    806     1
+    806    807     1
+    806    808     1
+    808    809     1
+    808    810     1
+    808    811     1
+    811    812     1
+    811    813     1
+    813    814     1
+    813    815     1
+    815    816     1
+    815    817     1
+    815    830     1
+    817    818     1
+    817    819     1
+    817    823     1
+    819    820     1
+    819    821     1
+    819    822     1
+    823    824     1
+    823    825     1
+    823    826     1
+    826    827     1
+    826    828     1
+    826    829     1
+    830    831     1
+    830    832     1
+    832    833     1
+    832    834     1
+    834    835     1
+    834    836     1
+    834    849     1
+    836    837     1
+    836    838     1
+    836    839     1
+    839    840     1
+    839    841     1
+    839    845     1
+    841    842     1
+    841    843     1
+    841    844     1
+    845    846     1
+    845    847     1
+    845    848     1
+    849    850     1
+    849    851     1
+    851    852     1
+    851    853     1
+    853    854     1
+    853    855     1
+    853    866     1
+    855    856     1
+    855    857     1
+    855    858     1
+    858    859     1
+    858    860     1
+    858    861     1
+    861    862     1
+    861    863     1
+    863    864     1
+    863    865     1
+    866    867     1
+    866    868     1
+    868    869     1
+    868    870     1
+    870    871     1
+    870    872     1
+    870    885     1
+    872    873     1
+    872    874     1
+    872    878     1
+    874    875     1
+    874    876     1
+    874    877     1
+    878    879     1
+    878    880     1
+    878    881     1
+    881    882     1
+    881    883     1
+    881    884     1
+    885    886     1
+    885    887     1
+    887    888     1
+    887    889     1
+    889    890     1
+    889    891     1
+    889    899     1
+    891    892     1
+    891    893     1
+    891    894     1
+    894    895     1
+    894    896     1
+    896    897     1
+    896    898     1
+    899    900     1
+    899    901     1
+    901    902     1
+    901    903     1
+    903    904     1
+    903    905     1
+    903    910     1
+    905    906     1
+    905    907     1
+    905    908     1
+    908    909     1
+    910    911     1
+    910    912     1
+    912    913     1
+    912    914     1
+    914    915     1
+    914    916     1
+    914    934     1
+    916    917     1
+    916    918     1
+    916    919     1
+    919    920     1
+    919    921     1
+    919    922     1
+    922    923     1
+    922    924     1
+    922    925     1
+    925    926     1
+    925    927     1
+    927    928     1
+    927    931     1
+    928    929     1
+    928    930     1
+    931    932     1
+    931    933     1
+    934    935     1
+    934    936     1
+    936    937     1
+    936    938     1
+    938    939     1
+    938    940     1
+    938    958     1
+    940    941     1
+    940    942     1
+    940    943     1
+    943    944     1
+    943    957     1
+    944    945     1
+    944    946     1
+    946    947     1
+    946    948     1
+    948    949     1
+    948    957     1
+    949    950     1
+    949    951     1
+    951    952     1
+    951    953     1
+    953    954     1
+    953    955     1
+    955    956     1
+    955    957     1
+    958    959     1
+    958    960     1
+    960    961     1
+    960    962     1
+    962    963     1
+    962    964     1
+    962    982     1
+    964    965     1
+    964    966     1
+    964    967     1
+    967    968     1
+    967    981     1
+    968    969     1
+    968    970     1
+    970    971     1
+    970    972     1
+    972    973     1
+    972    981     1
+    973    974     1
+    973    975     1
+    975    976     1
+    975    977     1
+    977    978     1
+    977    979     1
+    979    980     1
+    979    981     1
+    982    983     1
+    982    984     1
+    984    985     1
+    984    986     1
+    986    987     1
+    986    988     1
+    986    992     1
+    988    989     1
+    988    990     1
+    988    991     1
+    991   1218     1
+    992    993     1
+    992    994     1
+    994    995     1
+    994    996     1
+    996    997     1
+    996    998     1
+    996   1006     1
+    998    999     1
+    998   1000     1
+    998   1001     1
+   1001   1002     1
+   1001   1003     1
+   1003   1004     1
+   1003   1005     1
+   1006   1007     1
+   1006   1008     1
+   1008   1009     1
+   1008   1010     1
+   1010   1011     1
+   1010   1012     1
+   1010   1018     1
+   1012   1013     1
+   1012   1014     1
+   1012   1015     1
+   1015   1016     1
+   1015   1017     1
+   1018   1019     1
+   1018   1020     1
+   1020   1021     1
+   1020   1022     1
+   1022   1023     1
+   1022   1024     1
+   1022   1025     1
+   1025   1026     1
+   1025   1027     1
+   1027   1028     1
+   1027   1029     1
+   1029   1030     1
+   1029   1031     1
+   1029   1049     1
+   1031   1032     1
+   1031   1033     1
+   1031   1034     1
+   1034   1035     1
+   1034   1036     1
+   1034   1037     1
+   1037   1038     1
+   1037   1039     1
+   1037   1040     1
+   1040   1041     1
+   1040   1042     1
+   1042   1043     1
+   1042   1046     1
+   1043   1044     1
+   1043   1045     1
+   1046   1047     1
+   1046   1048     1
+   1049   1050     1
+   1049   1051     1
+   1051   1052     1
+   1051   1053     1
+   1053   1054     1
+   1053   1055     1
+   1053   1063     1
+   1055   1056     1
+   1055   1057     1
+   1055   1061     1
+   1057   1058     1
+   1057   1059     1
+   1057   1060     1
+   1061   1062     1
+   1063   1064     1
+   1063   1065     1
+   1065   1066     1
+   1065   1075     1
+   1066   1067     1
+   1066   1068     1
+   1066   1069     1
+   1069   1070     1
+   1069   1071     1
+   1069   1072     1
+   1072   1073     1
+   1072   1074     1
+   1072   1075     1
+   1075   1076     1
+   1075   1077     1
+   1077   1078     1
+   1077   1079     1
+   1079   1080     1
+   1079   1081     1
+   1081   1082     1
+   1081   1083     1
+   1081   1084     1
+   1084   1085     1
+   1084   1086     1
+   1086   1087     1
+   1086   1088     1
+   1088   1089     1
+   1088   1090     1
+   1088   1095     1
+   1090   1091     1
+   1090   1092     1
+   1090   1093     1
+   1093   1094     1
+   1095   1096     1
+   1095   1097     1
+   1097   1098     1
+   1097   1099     1
+   1099   1100     1
+   1099   1101     1
+   1099   1119     1
+   1101   1102     1
+   1101   1103     1
+   1101   1104     1
+   1104   1105     1
+   1104   1106     1
+   1104   1107     1
+   1107   1108     1
+   1107   1109     1
+   1107   1110     1
+   1110   1111     1
+   1110   1112     1
+   1112   1113     1
+   1112   1116     1
+   1113   1114     1
+   1113   1115     1
+   1116   1117     1
+   1116   1118     1
+   1119   1120     1
+   1119   1121     1
+   1121   1122     1
+   1121   1123     1
+   1123   1124     1
+   1123   1125     1
+   1123   1133     1
+   1125   1126     1
+   1125   1127     1
+   1125   1128     1
+   1128   1129     1
+   1128   1130     1
+   1130   1131     1
+   1130   1132     1
+   1133   1134     1
+   1133   1135     1
+   1135   1136     1
+   1135   1137     1
+   1137   1138     1
+   1137   1139     1
+   1137   1152     1
+   1139   1140     1
+   1139   1141     1
+   1139   1142     1
+   1142   1143     1
+   1142   1144     1
+   1142   1148     1
+   1144   1145     1
+   1144   1146     1
+   1144   1147     1
+   1148   1149     1
+   1148   1150     1
+   1148   1151     1
+   1152   1153     1
+   1152   1154     1
+   1154   1155     1
+   1154   1156     1
+   1156   1157     1
+   1156   1158     1
+   1156   1162     1
+   1158   1159     1
+   1158   1160     1
+   1158   1161     1
+   1161   1405     1
+   1162   1163     1
+   1162   1164     1
+   1164   1165     1
+   1164   1166     1
+   1166   1167     1
+   1166   1168     1
+   1166   1176     1
+   1168   1169     1
+   1168   1170     1
+   1168   1171     1
+   1171   1172     1
+   1171   1173     1
+   1173   1174     1
+   1173   1175     1
+   1176   1177     1
+   1176   1178     1
+   1178   1179     1
+   1178   1180     1
+   1180   1181     1
+   1180   1182     1
+   1180   1195     1
+   1182   1183     1
+   1182   1184     1
+   1182   1188     1
+   1184   1185     1
+   1184   1186     1
+   1184   1187     1
+   1188   1189     1
+   1188   1190     1
+   1188   1191     1
+   1191   1192     1
+   1191   1193     1
+   1191   1194     1
+   1195   1196     1
+   1195   1197     1
+   1197   1198     1
+   1197   1207     1
+   1198   1199     1
+   1198   1200     1
+   1198   1201     1
+   1201   1202     1
+   1201   1203     1
+   1201   1204     1
+   1204   1205     1
+   1204   1206     1
+   1204   1207     1
+   1207   1208     1
+   1207   1209     1
+   1209   1210     1
+   1209   1211     1
+   1211   1212     1
+   1211   1213     1
+   1213   1214     1
+   1213   1215     1
+   1213   1219     1
+   1215   1216     1
+   1215   1217     1
+   1215   1218     1
+   1219   1220     1
+   1219   1221     1
+   1221   1222     1
+   1221   1223     1
+   1223   1224     1
+   1223   1225     1
+   1223   1230     1
+   1225   1226     1
+   1225   1227     1
+   1225   1228     1
+   1228   1229     1
+   1230   1231     1
+   1230   1232     1
+   1232   1233     1
+   1232   1234     1
+   1234   1235     1
+   1234   1236     1
+   1234   1240     1
+   1236   1237     1
+   1236   1238     1
+   1236   1239     1
+   1240   1241     1
+   1240   1242     1
+   1242   1243     1
+   1242   1244     1
+   1244   1245     1
+   1244   1246     1
+   1244   1259     1
+   1246   1247     1
+   1246   1248     1
+   1246   1249     1
+   1249   1250     1
+   1249   1251     1
+   1249   1255     1
+   1251   1252     1
+   1251   1253     1
+   1251   1254     1
+   1255   1256     1
+   1255   1257     1
+   1255   1258     1
+   1259   1260     1
+   1259   1261     1
+   1261   1262     1
+   1261   1263     1
+   1263   1264     1
+   1263   1265     1
+   1263   1278     1
+   1265   1266     1
+   1265   1267     1
+   1265   1268     1
+   1268   1269     1
+   1268   1270     1
+   1268   1274     1
+   1270   1271     1
+   1270   1272     1
+   1270   1273     1
+   1274   1275     1
+   1274   1276     1
+   1274   1277     1
+   1278   1279     1
+   1278   1280     1
+   1280   1281     1
+   1280   1282     1
+   1282   1283     1
+   1282   1284     1
+   1282   1289     1
+   1284   1285     1
+   1284   1286     1
+   1284   1287     1
+   1287   1288     1
+   1289   1290     1
+   1289   1291     1
+   1291   1292     1
+   1291   1293     1
+   1293   1294     1
+   1293   1295     1
+   1293   1300     1
+   1295   1296     1
+   1295   1297     1
+   1295   1298     1
+   1298   1299     1
+   1300   1301     1
+   1300   1302     1
+   1302   1303     1
+   1302   1304     1
+   1304   1305     1
+   1304   1306     1
+   1304   1312     1
+   1306   1307     1
+   1306   1308     1
+   1306   1309     1
+   1309   1310     1
+   1309   1311     1
+   1312   1313     1
+   1312   1314     1
+   1314   1315     1
+   1314   1316     1
+   1316   1317     1
+   1316   1318     1
+   1316   1331     1
+   1318   1319     1
+   1318   1320     1
+   1318   1324     1
+   1320   1321     1
+   1320   1322     1
+   1320   1323     1
+   1324   1325     1
+   1324   1326     1
+   1324   1327     1
+   1327   1328     1
+   1327   1329     1
+   1327   1330     1
+   1331   1332     1
+   1331   1333     1
+   1333   1334     1
+   1333   1335     1
+   1335   1336     1
+   1335   1337     1
+   1335   1345     1
+   1337   1338     1
+   1337   1339     1
+   1337   1343     1
+   1339   1340     1
+   1339   1341     1
+   1339   1342     1
+   1343   1344     1
+   1345   1346     1
+   1345   1347     1
+   1347   1348     1
+   1347   1349     1
+   1349   1350     1
+   1349   1351     1
+   1349   1355     1
+   1351   1352     1
+   1351   1353     1
+   1351   1354     1
+   1355   1356     1
+   1355   1357     1
+   1357   1358     1
+   1357   1359     1
+   1359   1360     1
+   1359   1361     1
+   1359   1366     1
+   1361   1362     1
+   1361   1363     1
+   1361   1364     1
+   1364   1365     1
+   1366   1367     1
+   1366   1368     1
+   1368   1369     1
+   1368   1370     1
+   1370   1371     1
+   1370   1372     1
+   1370   1382     1
+   1372   1373     1
+   1372   1374     1
+   1372   1378     1
+   1374   1375     1
+   1374   1376     1
+   1374   1377     1
+   1378   1379     1
+   1378   1380     1
+   1378   1381     1
+   1382   1383     1
+   1382   1384     1
+   1384   1385     1
+   1384   1386     1
+   1386   1387     1
+   1386   1388     1
+   1386   1396     1
+   1388   1389     1
+   1388   1390     1
+   1388   1391     1
+   1391   1392     1
+   1391   1393     1
+   1393   1394     1
+   1393   1395     1
+   1396   1397     1
+   1396   1398     1
+   1398   1399     1
+   1398   1400     1
+   1400   1401     1
+   1400   1402     1
+   1400   1406     1
+   1402   1403     1
+   1402   1404     1
+   1402   1405     1
+   1406   1407     1
+   1406   1408     1
+   1408   1409     1
+   1408   1410     1
+   1410   1411     1
+   1410   1412     1
+   1410   1416     1
+   1412   1413     1
+   1412   1414     1
+   1412   1415     1
+   1416   1417     1
+   1416   1418     1
+   1418   1419     1
+   1418   1420     1
+   1420   1421     1
+   1420   1422     1
+   1420   1438     1
+   1422   1423     1
+   1422   1424     1
+   1422   1425     1
+   1425   1426     1
+   1425   1427     1
+   1425   1428     1
+   1428   1429     1
+   1428   1430     1
+   1428   1431     1
+   1431   1432     1
+   1431   1433     1
+   1431   1434     1
+   1434   1435     1
+   1434   1436     1
+   1434   1437     1
+   1438   1439     1
+   1438   1440     1
+   1440   1441     1
+   1440   1442     1
+   1442   1443     1
+   1442   1444     1
+   1442   1460     1
+   1444   1445     1
+   1444   1446     1
+   1444   1447     1
+   1447   1448     1
+   1447   1449     1
+   1447   1450     1
+   1450   1451     1
+   1450   1452     1
+   1450   1453     1
+   1453   1454     1
+   1453   1455     1
+   1453   1456     1
+   1456   1457     1
+   1456   1458     1
+   1456   1459     1
+   1460   1461     1
+   1460   1462     1
+   1462   1463     1
+   1462   1464     1
+   1464   1465     1
+   1464   1466     1
+   1464   1479     1
+   1466   1467     1
+   1466   1468     1
+   1466   1472     1
+   1468   1469     1
+   1468   1470     1
+   1468   1471     1
+   1472   1473     1
+   1472   1474     1
+   1472   1475     1
+   1475   1476     1
+   1475   1477     1
+   1475   1478     1
+   1479   1480     1
+   1479   1481     1
+   1481   1482     1
+   1481   1483     1
+   1483   1484     1
+   1483   1485     1
+   1483   1495     1
+   1485   1486     1
+   1485   1487     1
+   1485   1491     1
+   1487   1488     1
+   1487   1489     1
+   1487   1490     1
+   1491   1492     1
+   1491   1493     1
+   1491   1494     1
+   1495   1496     1
+   1495   1497     1
+   1497   1498     1
+   1497   1499     1
+   1499   1500     1
+   1499   1501     1
+   1499   1506     1
+   1501   1502     1
+   1501   1503     1
+   1501   1504     1
+   1504   1505     1
+   1506   1507     1
+   1506   1508     1
+   1508   1509     1
+   1508   1510     1
+   1510   1511     1
+   1510   1512     1
+   1510   1518     1
+   1512   1513     1
+   1512   1514     1
+   1512   1515     1
+   1515   1516     1
+   1515   1517     1
+   1518   1519     1
+   1518   1520     1
+   1520   1521     1
+   1520   1522     1
+   1522   1523     1
+   1522   1524     1
+   1522   1525     1
+   1525   1526     1
+   1525   1527     1
+   1527   1528     1
+   1527   1529     1
+   1529   1530     1
+   1529   1531     1
+   1529   1539     1
+   1531   1532     1
+   1531   1533     1
+   1531   1534     1
+   1534   1535     1
+   1534   1536     1
+   1536   1537     1
+   1536   1538     1
+   1539   1540     1
+   1539   1541     1
+   1541   1542     1
+   1541   1543     1
+   1543   1544     1
+   1543   1545     1
+   1543   1546     1
+   1546   1547     1
+   1546   1548     1
+   1548   1549     1
+   1548   1550     1
+   1550   1551     1
+   1550   1552     1
+   1550   1563     1
+   1552   1553     1
+   1552   1554     1
+   1552   1555     1
+   1555   1556     1
+   1555   1557     1
+   1555   1558     1
+   1558   1559     1
+   1559   1560     1
+   1559   1561     1
+   1559   1562     1
+   1563   1564     1
+   1563   1565     1
+   1565   1566     1
+   1565   1567     1
+   1567   1568     1
+   1567   1569     1
+   1567   1577     1
+   1569   1570     1
+   1569   1571     1
+   1569   1572     1
+   1572   1573     1
+   1572   1574     1
+   1574   1575     1
+   1574   1576     1
+   1577   1578     1
+   1577   1579     1
+   1579   1580     1
+   1579   1581     1
+   1581   1582     1
+   1581   1583     1
+   1581   1587     1
+   1583   1584     1
+   1583   1585     1
+   1583   1586     1
+   1587   1588     1
+   1587   1589     1
+   1589   1590     1
+   1589   1591     1
+   1591   1592     1
+   1591   1593     1
+   1591   1611     1
+   1593   1594     1
+   1593   1595     1
+   1593   1596     1
+   1596   1597     1
+   1596   1610     1
+   1597   1598     1
+   1597   1599     1
+   1599   1600     1
+   1599   1601     1
+   1601   1602     1
+   1601   1610     1
+   1602   1603     1
+   1602   1604     1
+   1604   1605     1
+   1604   1606     1
+   1606   1607     1
+   1606   1608     1
+   1608   1609     1
+   1608   1610     1
+   1611   1612     1
+   1611   1613     1
+   1613   1614     1
+   1613   1615     1
+   1615   1616     1
+   1615   1617     1
+   1615   1627     1
+   1617   1618     1
+   1617   1619     1
+   1617   1623     1
+   1619   1620     1
+   1619   1621     1
+   1619   1622     1
+   1623   1624     1
+   1623   1625     1
+   1623   1626     1
+   1627   1628     1
+   1627   1629     1
+   1629   1630     1
+   1629   1631     1
+   1631   1632     1
+   1631   1633     1
+   1631   1637     1
+   1633   1634     1
+   1633   1635     1
+   1633   1636     1
+   1637   1638     1
+   1637   1639     1
+   1639   1640     1
+   1639   1641     1
+   1641   1642     1
+   1641   1643     1
+   1641   1661     1
+   1643   1644     1
+   1643   1645     1
+   1643   1646     1
+   1646   1647     1
+   1646   1660     1
+   1647   1648     1
+   1647   1649     1
+   1649   1650     1
+   1649   1651     1
+   1651   1652     1
+   1651   1660     1
+   1652   1653     1
+   1652   1654     1
+   1654   1655     1
+   1654   1656     1
+   1656   1657     1
+   1656   1658     1
+   1658   1659     1
+   1658   1660     1
+   1661   1662     1
+   1661   1663     1
+   1663   1664     1
+   1663   1665     1
+   1665   1666     1
+   1665   1667     1
+   1665   1685     1
+   1667   1668     1
+   1667   1669     1
+   1667   1670     1
+   1670   1671     1
+   1670   1672     1
+   1670   1673     1
+   1673   1674     1
+   1673   1675     1
+   1673   1676     1
+   1676   1677     1
+   1676   1678     1
+   1678   1679     1
+   1678   1682     1
+   1679   1680     1
+   1679   1681     1
+   1682   1683     1
+   1682   1684     1
+   1685   1686     1
+   1685   1687     1
+   1687   1688     1
+   1687   1689     1
+   1689   1690     1
+   1689   1691     1
+   1689   1699     1
+   1691   1692     1
+   1691   1693     1
+   1691   1694     1
+   1694   1695     1
+   1694   1696     1
+   1696   1697     1
+   1696   1698     1
+   1699   1700     1
+   1699   1701     1
+   1701   1702     1
+   1701   1703     1
+   1703   1704     1
+   1703   1705     1
+   1703   1723     1
+   1705   1706     1
+   1705   1707     1
+   1705   1708     1
+   1708   1709     1
+   1708   1710     1
+   1708   1711     1
+   1711   1712     1
+   1711   1713     1
+   1711   1714     1
+   1714   1715     1
+   1714   1716     1
+   1716   1717     1
+   1716   1720     1
+   1717   1718     1
+   1717   1719     1
+   1720   1721     1
+   1720   1722     1
+   1723   1724     1
+   1723   1725     1
+   1725   1726     1
+   1725   1727     1
+   1727   1728     1
+   1727   1729     1
+   1727   1733     1
+   1729   1730     1
+   1729   1731     1
+   1729   1732     1
+   1733   1734     1
+   1733   1735     1
+   1735   1736     1
+   1735   1737     1
+   1737   1738     1
+   1737   1739     1
+   1737   1755     1
+   1739   1740     1
+   1739   1741     1
+   1739   1742     1
+   1742   1743     1
+   1742   1744     1
+   1742   1745     1
+   1745   1746     1
+   1745   1747     1
+   1745   1748     1
+   1748   1749     1
+   1748   1750     1
+   1748   1751     1
+   1751   1752     1
+   1751   1753     1
+   1751   1754     1
+   1755   1756     1
+   1755   1757     1
+   1757   1758     1
+   1757   1759     1
+   1759   1760     1
+   1759   1761     1
+   1759   1762     1
+   1762   1763     1
+   1762   1764     1
+   1764   1765     1
+   1764   1766     1
+   1766   1767     1
+   1766   1768     1
+   1766   1776     1
+   1768   1769     1
+   1768   1770     1
+   1768   1774     1
+   1770   1771     1
+   1770   1772     1
+   1770   1773     1
+   1774   1775     1
+   1776   1777     1
+   1776   1778     1
+   1778   1779     1
+   1778   1780     1
+   1780   1781     1
+   1780   1782     1
+   1780   1788     1
+   1782   1783     1
+   1782   1784     1
+   1782   1785     1
+   1785   1786     1
+   1785   1787     1
+   1788   1789     1
+   1788   1790     1
+   1790   1791     1
+   1790   1792     1
+   1792   1793     1
+   1792   1794     1
+   1792   1804     1
+   1794   1795     1
+   1794   1796     1
+   1794   1800     1
+   1796   1797     1
+   1796   1798     1
+   1796   1799     1
+   1800   1801     1
+   1800   1802     1
+   1800   1803     1
+   1804   1805     1
+   1804   1806     1
+   1806   1807     1
+   1806   1808     1
+   1808   1809     1
+   1808   1810     1
+   1808   1821     1
+   1810   1811     1
+   1810   1812     1
+   1810   1813     1
+   1813   1814     1
+   1813   1815     1
+   1813   1816     1
+   1816   1817     1
+   1816   1818     1
+   1818   1819     1
+   1818   1820     1
+   1821   1822     1
+   1821   1823     1
+   1823   1824     1
+   1823   1825     1
+   1825   1826     1
+   1825   1827     1
+   1825   1831     1
+   1827   1828     1
+   1827   1829     1
+   1827   1830     1
+   1831   1832     1
+   1831   1833     1
+   1833   1834     1
+   1833   1835     1
+   1835   1836     1
+   1835   1837     1
+   1835   1855     1
+   1837   1838     1
+   1837   1839     1
+   1837   1840     1
+   1840   1841     1
+   1840   1854     1
+   1841   1842     1
+   1841   1843     1
+   1843   1844     1
+   1843   1845     1
+   1845   1846     1
+   1845   1854     1
+   1846   1847     1
+   1846   1848     1
+   1848   1849     1
+   1848   1850     1
+   1850   1851     1
+   1850   1852     1
+   1852   1853     1
+   1852   1854     1
+   1855   1856     1
+   1855   1857     1
+   1857   1858     1
+   1857   1859     1
+   1859   1860     1
+   1859   1861     1
+   1859   1874     1
+   1861   1862     1
+   1861   1863     1
+   1861   1867     1
+   1863   1864     1
+   1863   1865     1
+   1863   1866     1
+   1867   1868     1
+   1867   1869     1
+   1867   1870     1
+   1870   1871     1
+   1870   1872     1
+   1870   1873     1
+   1874   1875     1
+   1874   1876     1
+   1876   1877     1
+   1876   1878     1
+   1878   1879     1
+   1878   1880     1
+   1878   1898     1
+   1880   1881     1
+   1880   1882     1
+   1880   1883     1
+   1883   1884     1
+   1883   1885     1
+   1883   1886     1
+   1886   1887     1
+   1886   1888     1
+   1886   1889     1
+   1889   1890     1
+   1889   1891     1
+   1891   1892     1
+   1891   1895     1
+   1892   1893     1
+   1892   1894     1
+   1895   1896     1
+   1895   1897     1
+   1898   1899     1
+   1898   1900     1
+   1900   1901     1
+   1900   1902     1
+   1902   1903     1
+   1902   1904     1
+   1902   1905     1
+   1905   1906     1
+   1905   1907     1
+   1907   1908     1
+   1907   1909     1
+   1909   1910     1
+   1909   1911     1
+   1909   1915     1
+   1911   1912     1
+   1911   1913     1
+   1911   1914     1
+   1915   1916     1
+   1915   1917     1
+   1917   1918     1
+   1917   1919     1
+   1919   1920     1
+   1919   1921     1
+   1919   1939     1
+   1921   1922     1
+   1921   1923     1
+   1921   1924     1
+   1924   1925     1
+   1924   1926     1
+   1924   1927     1
+   1927   1928     1
+   1927   1929     1
+   1927   1930     1
+   1930   1931     1
+   1930   1932     1
+   1932   1933     1
+   1932   1936     1
+   1933   1934     1
+   1933   1935     1
+   1936   1937     1
+   1936   1938     1
+   1939   1940     1
+   1939   1941     1
+   1941   1942     1
+   1941   1943     1
+   1943   1944     1
+   1943   1945     1
+   1943   1958     1
+   1945   1946     1
+   1945   1947     1
+   1945   1948     1
+   1948   1949     1
+   1948   1950     1
+   1948   1954     1
+   1950   1951     1
+   1950   1952     1
+   1950   1953     1
+   1954   1955     1
+   1954   1956     1
+   1954   1957     1
+   1958   1959     1
+   1958   1960     1
+
+[ pairs ]
+;    ai     aj funct         c0         c1         c2         c3
+      1      8     1
+      1      9     1
+      1     10     1
+      1     24     1
+      1     25     1
+      2      6     1
+      2      7     1
+      2     23     1
+      3      6     1
+      3      7     1
+      3     23     1
+      4      6     1
+      4      7     1
+      4     23     1
+      5     11     1
+      5     12     1
+      5     13     1
+      5     26     1
+      5     27     1
+      6      8     1
+      6      9     1
+      6     10     1
+      6     24     1
+      6     25     1
+      7     14     1
+      7     15     1
+      7     16     1
+      7     24     1
+      7     25     1
+      8     11     1
+      8     12     1
+      8     13     1
+      8     23     1
+      9     11     1
+      9     12     1
+      9     13     1
+      9     23     1
+     10     17     1
+     10     18     1
+     10     19     1
+     10     23     1
+     11     14     1
+     11     15     1
+     11     16     1
+     12     14     1
+     12     15     1
+     12     16     1
+     13     20     1
+     13     21     1
+     13     22     1
+     14     17     1
+     14     18     1
+     14     19     1
+     15     17     1
+     15     18     1
+     15     19     1
+     17     20     1
+     17     21     1
+     17     22     1
+     18     20     1
+     18     21     1
+     18     22     1
+     23     28     1
+     23     29     1
+     23     39     1
+     24     26     1
+     24     27     1
+     25     30     1
+     25     31     1
+     25     35     1
+     25     40     1
+     25     41     1
+     26     28     1
+     26     29     1
+     26     39     1
+     27     32     1
+     27     33     1
+     27     34     1
+     27     36     1
+     27     37     1
+     27     38     1
+     27     42     1
+     27     43     1
+     28     30     1
+     28     31     1
+     28     35     1
+     28     40     1
+     28     41     1
+     29     40     1
+     29     41     1
+     30     32     1
+     30     33     1
+     30     34     1
+     30     36     1
+     30     37     1
+     30     38     1
+     30     39     1
+     31     36     1
+     31     37     1
+     31     38     1
+     31     39     1
+     32     35     1
+     33     35     1
+     34     35     1
+     35     39     1
+     39     44     1
+     39     45     1
+     39     59     1
+     40     42     1
+     40     43     1
+     41     46     1
+     41     47     1
+     41     48     1
+     41     60     1
+     41     61     1
+     42     44     1
+     42     45     1
+     42     59     1
+     43     49     1
+     43     57     1
+     43     62     1
+     43     63     1
+     44     46     1
+     44     47     1
+     44     48     1
+     44     60     1
+     44     61     1
+     45     50     1
+     45     51     1
+     45     55     1
+     45     58     1
+     45     60     1
+     45     61     1
+     46     49     1
+     46     57     1
+     46     59     1
+     47     49     1
+     47     57     1
+     47     59     1
+     48     52     1
+     48     53     1
+     48     56     1
+     48     59     1
+     49     54     1
+     49     55     1
+     49     58     1
+     50     52     1
+     50     53     1
+     50     57     1
+     51     56     1
+     51     57     1
+     52     54     1
+     52     55     1
+     53     58     1
+     54     56     1
+     54     57     1
+     56     58     1
+     59     64     1
+     59     65     1
+     59     66     1
+     60     62     1
+     60     63     1
+     61     67     1
+     61     68     1
+     62     64     1
+     62     65     1
+     62     66     1
+     63     69     1
+     63     70     1
+     64     67     1
+     64     68     1
+     65     67     1
+     65     68     1
+     66     71     1
+     66     72     1
+     66     90     1
+     67     69     1
+     67     70     1
+     68     73     1
+     68     74     1
+     68     75     1
+     68     91     1
+     68     92     1
+     69     71     1
+     69     72     1
+     69     90     1
+     70     76     1
+     70     77     1
+     70     78     1
+     70     93     1
+     70     94     1
+     71     73     1
+     71     74     1
+     71     75     1
+     71     91     1
+     71     92     1
+     72     79     1
+     72     80     1
+     72     81     1
+     72     91     1
+     72     92     1
+     73     76     1
+     73     77     1
+     73     78     1
+     73     90     1
+     74     76     1
+     74     77     1
+     74     78     1
+     74     90     1
+     75     82     1
+     75     83     1
+     75     90     1
+     76     79     1
+     76     80     1
+     76     81     1
+     77     79     1
+     77     80     1
+     77     81     1
+     78     84     1
+     78     87     1
+     79     82     1
+     79     83     1
+     80     82     1
+     80     83     1
+     81     85     1
+     81     86     1
+     81     88     1
+     81     89     1
+     82     84     1
+     82     87     1
+     84     88     1
+     84     89     1
+     85     87     1
+     86     87     1
+     90     95     1
+     90     96     1
+     90    100     1
+     91     93     1
+     91     94     1
+     92     97     1
+     92     98     1
+     92     99     1
+     92    101     1
+     92    102     1
+     93     95     1
+     93     96     1
+     93    100     1
+     94    103     1
+     94    104     1
+     94   1914     1
+     95     97     1
+     95     98     1
+     95     99     1
+     95    101     1
+     95    102     1
+     96    101     1
+     96    102     1
+     96   1911     1
+     97    100     1
+     97   1914     1
+     98    100     1
+     98   1914     1
+     99    100     1
+     99   1909     1
+     99   1912     1
+     99   1913     1
+    100    105     1
+    100    106     1
+    100    115     1
+    101    103     1
+    101    104     1
+    102    107     1
+    102    108     1
+    102    109     1
+    102    116     1
+    102    117     1
+    103    105     1
+    103    106     1
+    103    115     1
+    104    110     1
+    104    111     1
+    104    112     1
+    104    118     1
+    104    119     1
+    105    107     1
+    105    108     1
+    105    109     1
+    105    116     1
+    105    117     1
+    106    113     1
+    106    114     1
+    106    116     1
+    106    117     1
+    107    110     1
+    107    111     1
+    107    112     1
+    107    115     1
+    108    110     1
+    108    111     1
+    108    112     1
+    108    115     1
+    109    115     1
+    110    113     1
+    110    114     1
+    111    113     1
+    111    114     1
+    115    120     1
+    115    121     1
+    115    134     1
+    116    118     1
+    116    119     1
+    117    122     1
+    117    123     1
+    117    124     1
+    117    135     1
+    117    136     1
+    118    120     1
+    118    121     1
+    118    134     1
+    119    125     1
+    119    126     1
+    119    130     1
+    119    137     1
+    119    138     1
+    120    122     1
+    120    123     1
+    120    124     1
+    120    135     1
+    120    136     1
+    121    127     1
+    121    128     1
+    121    129     1
+    121    131     1
+    121    132     1
+    121    133     1
+    121    135     1
+    121    136     1
+    122    125     1
+    122    126     1
+    122    130     1
+    122    134     1
+    123    125     1
+    123    126     1
+    123    130     1
+    123    134     1
+    124    134     1
+    125    127     1
+    125    128     1
+    125    129     1
+    125    131     1
+    125    132     1
+    125    133     1
+    126    131     1
+    126    132     1
+    126    133     1
+    127    130     1
+    128    130     1
+    129    130     1
+    134    139     1
+    134    140     1
+    134    144     1
+    135    137     1
+    135    138     1
+    136    141     1
+    136    142     1
+    136    143     1
+    136    145     1
+    136    146     1
+    137    139     1
+    137    140     1
+    137    144     1
+    138    147     1
+    138    148     1
+    139    141     1
+    139    142     1
+    139    143     1
+    139    145     1
+    139    146     1
+    140    145     1
+    140    146     1
+    141    144     1
+    142    144     1
+    143    144     1
+    144    149     1
+    144    150     1
+    144    154     1
+    145    147     1
+    145    148     1
+    146    151     1
+    146    152     1
+    146    153     1
+    146    155     1
+    146    156     1
+    147    149     1
+    147    150     1
+    147    154     1
+    148    157     1
+    148    158     1
+    149    151     1
+    149    152     1
+    149    153     1
+    149    155     1
+    149    156     1
+    150    155     1
+    150    156     1
+    151    154     1
+    152    154     1
+    153    154     1
+    154    159     1
+    154    160     1
+    154    164     1
+    155    157     1
+    155    158     1
+    156    161     1
+    156    162     1
+    156    163     1
+    156    165     1
+    156    166     1
+    157    159     1
+    157    160     1
+    157    164     1
+    158    167     1
+    158    168     1
+    159    161     1
+    159    162     1
+    159    163     1
+    159    165     1
+    159    166     1
+    160    165     1
+    160    166     1
+    161    164     1
+    162    164     1
+    163    164     1
+    164    169     1
+    164    170     1
+    164    181     1
+    165    167     1
+    165    168     1
+    166    171     1
+    166    172     1
+    166    173     1
+    166    182     1
+    166    183     1
+    167    169     1
+    167    170     1
+    167    181     1
+    168    174     1
+    168    175     1
+    168    176     1
+    168    184     1
+    168    185     1
+    169    171     1
+    169    172     1
+    169    173     1
+    169    182     1
+    169    183     1
+    170    177     1
+    170    182     1
+    170    183     1
+    171    174     1
+    171    175     1
+    171    176     1
+    171    181     1
+    172    174     1
+    172    175     1
+    172    176     1
+    172    181     1
+    173    178     1
+    173    179     1
+    173    180     1
+    173    181     1
+    174    177     1
+    175    177     1
+    181    186     1
+    181    187     1
+    181    203     1
+    182    184     1
+    182    185     1
+    183    188     1
+    183    189     1
+    183    190     1
+    183    204     1
+    183    205     1
+    184    186     1
+    184    187     1
+    184    203     1
+    185    191     1
+    185    192     1
+    185    193     1
+    185    206     1
+    185    207     1
+    186    188     1
+    186    189     1
+    186    190     1
+    186    204     1
+    186    205     1
+    187    194     1
+    187    195     1
+    187    196     1
+    187    204     1
+    187    205     1
+    188    191     1
+    188    192     1
+    188    193     1
+    188    203     1
+    189    191     1
+    189    192     1
+    189    193     1
+    189    203     1
+    190    197     1
+    190    198     1
+    190    199     1
+    190    203     1
+    191    194     1
+    191    195     1
+    191    196     1
+    192    194     1
+    192    195     1
+    192    196     1
+    193    200     1
+    193    201     1
+    193    202     1
+    194    197     1
+    194    198     1
+    194    199     1
+    195    197     1
+    195    198     1
+    195    199     1
+    197    200     1
+    197    201     1
+    197    202     1
+    198    200     1
+    198    201     1
+    198    202     1
+    203    208     1
+    203    209     1
+    203    227     1
+    204    206     1
+    204    207     1
+    205    210     1
+    205    211     1
+    205    212     1
+    205    228     1
+    205    229     1
+    206    208     1
+    206    209     1
+    206    227     1
+    207    213     1
+    207    214     1
+    207    215     1
+    207    230     1
+    207    231     1
+    208    210     1
+    208    211     1
+    208    212     1
+    208    228     1
+    208    229     1
+    209    216     1
+    209    217     1
+    209    218     1
+    209    228     1
+    209    229     1
+    210    213     1
+    210    214     1
+    210    215     1
+    210    227     1
+    211    213     1
+    211    214     1
+    211    215     1
+    211    227     1
+    212    219     1
+    212    220     1
+    212    227     1
+    213    216     1
+    213    217     1
+    213    218     1
+    214    216     1
+    214    217     1
+    214    218     1
+    215    221     1
+    215    224     1
+    216    219     1
+    216    220     1
+    217    219     1
+    217    220     1
+    218    222     1
+    218    223     1
+    218    225     1
+    218    226     1
+    219    221     1
+    219    224     1
+    221    225     1
+    221    226     1
+    222    224     1
+    223    224     1
+    227    232     1
+    227    233     1
+    227    244     1
+    228    230     1
+    228    231     1
+    229    234     1
+    229    235     1
+    229    236     1
+    229    245     1
+    229    246     1
+    230    232     1
+    230    233     1
+    230    244     1
+    231    237     1
+    231    242     1
+    231    247     1
+    231    248     1
+    232    234     1
+    232    235     1
+    232    236     1
+    232    245     1
+    232    246     1
+    233    238     1
+    233    240     1
+    233    243     1
+    233    245     1
+    233    246     1
+    234    237     1
+    234    242     1
+    234    244     1
+    235    237     1
+    235    242     1
+    235    244     1
+    236    239     1
+    236    241     1
+    236    244     1
+    237    241     1
+    237    243     1
+    238    243     1
+    239    241     1
+    239    242     1
+    241    243     1
+    244    249     1
+    244    250     1
+    244    251     1
+    245    247     1
+    245    248     1
+    246    252     1
+    246    253     1
+    247    249     1
+    247    250     1
+    247    251     1
+    248    254     1
+    248    255     1
+    249    252     1
+    249    253     1
+    250    252     1
+    250    253     1
+    251    256     1
+    251    257     1
+    251    270     1
+    252    254     1
+    252    255     1
+    253    258     1
+    253    259     1
+    253    260     1
+    253    271     1
+    253    272     1
+    254    256     1
+    254    257     1
+    254    270     1
+    255    261     1
+    255    262     1
+    255    266     1
+    255    273     1
+    255    274     1
+    256    258     1
+    256    259     1
+    256    260     1
+    256    271     1
+    256    272     1
+    257    263     1
+    257    264     1
+    257    265     1
+    257    267     1
+    257    268     1
+    257    269     1
+    257    271     1
+    257    272     1
+    258    261     1
+    258    262     1
+    258    266     1
+    258    270     1
+    259    261     1
+    259    262     1
+    259    266     1
+    259    270     1
+    260    270     1
+    261    263     1
+    261    264     1
+    261    265     1
+    261    267     1
+    261    268     1
+    261    269     1
+    262    267     1
+    262    268     1
+    262    269     1
+    263    266     1
+    264    266     1
+    265    266     1
+    270    275     1
+    270    276     1
+    270    282     1
+    271    273     1
+    271    274     1
+    272    277     1
+    272    278     1
+    272    279     1
+    272    283     1
+    272    284     1
+    273    275     1
+    273    276     1
+    273    282     1
+    274    280     1
+    274    281     1
+    274    285     1
+    274    286     1
+    275    277     1
+    275    278     1
+    275    279     1
+    275    283     1
+    275    284     1
+    276    283     1
+    276    284     1
+    277    280     1
+    277    281     1
+    277    282     1
+    278    280     1
+    278    281     1
+    278    282     1
+    279    282     1
+    282    287     1
+    282    288     1
+    282    296     1
+    283    285     1
+    283    286     1
+    284    289     1
+    284    290     1
+    284    291     1
+    284    297     1
+    284    298     1
+    285    287     1
+    285    288     1
+    285    296     1
+    286    292     1
+    286    293     1
+    286    299     1
+    286    300     1
+    287    289     1
+    287    290     1
+    287    291     1
+    287    297     1
+    287    298     1
+    288    294     1
+    288    295     1
+    288    297     1
+    288    298     1
+    289    292     1
+    289    293     1
+    289    296     1
+    290    292     1
+    290    293     1
+    290    296     1
+    291    296     1
+    292    294     1
+    292    295     1
+    296    301     1
+    296    302     1
+    296    317     1
+    297    299     1
+    297    300     1
+    298    303     1
+    298    304     1
+    298    305     1
+    298    318     1
+    298    319     1
+    299    301     1
+    299    302     1
+    299    317     1
+    300    306     1
+    300    315     1
+    300    320     1
+    300    321     1
+    301    303     1
+    301    304     1
+    301    305     1
+    301    318     1
+    301    319     1
+    302    307     1
+    302    308     1
+    302    313     1
+    302    316     1
+    302    318     1
+    302    319     1
+    303    306     1
+    303    315     1
+    303    317     1
+    304    306     1
+    304    315     1
+    304    317     1
+    305    309     1
+    305    310     1
+    305    314     1
+    305    317     1
+    306    311     1
+    306    313     1
+    306    316     1
+    307    309     1
+    307    310     1
+    307    315     1
+    308    312     1
+    308    314     1
+    308    315     1
+    309    311     1
+    309    313     1
+    310    316     1
+    311    314     1
+    311    315     1
+    312    313     1
+    314    316     1
+    317    322     1
+    317    323     1
+    317    341     1
+    318    320     1
+    318    321     1
+    319    324     1
+    319    325     1
+    319    326     1
+    319    342     1
+    319    343     1
+    320    322     1
+    320    323     1
+    320    341     1
+    321    327     1
+    321    328     1
+    321    329     1
+    321    344     1
+    321    345     1
+    322    324     1
+    322    325     1
+    322    326     1
+    322    342     1
+    322    343     1
+    323    330     1
+    323    331     1
+    323    332     1
+    323    342     1
+    323    343     1
+    324    327     1
+    324    328     1
+    324    329     1
+    324    341     1
+    325    327     1
+    325    328     1
+    325    329     1
+    325    341     1
+    326    333     1
+    326    334     1
+    326    341     1
+    327    330     1
+    327    331     1
+    327    332     1
+    328    330     1
+    328    331     1
+    328    332     1
+    329    335     1
+    329    338     1
+    330    333     1
+    330    334     1
+    331    333     1
+    331    334     1
+    332    336     1
+    332    337     1
+    332    339     1
+    332    340     1
+    333    335     1
+    333    338     1
+    335    339     1
+    335    340     1
+    336    338     1
+    337    338     1
+    341    346     1
+    341    347     1
+    341    348     1
+    342    344     1
+    342    345     1
+    343    349     1
+    343    350     1
+    344    346     1
+    344    347     1
+    344    348     1
+    345    351     1
+    345    352     1
+    346    349     1
+    346    350     1
+    347    349     1
+    347    350     1
+    348    353     1
+    348    354     1
+    348    369     1
+    349    351     1
+    349    352     1
+    350    355     1
+    350    356     1
+    350    357     1
+    350    370     1
+    350    371     1
+    351    353     1
+    351    354     1
+    351    369     1
+    352    358     1
+    352    367     1
+    352    372     1
+    352    373     1
+    353    355     1
+    353    356     1
+    353    357     1
+    353    370     1
+    353    371     1
+    354    359     1
+    354    360     1
+    354    365     1
+    354    368     1
+    354    370     1
+    354    371     1
+    355    358     1
+    355    367     1
+    355    369     1
+    356    358     1
+    356    367     1
+    356    369     1
+    357    361     1
+    357    362     1
+    357    366     1
+    357    369     1
+    358    363     1
+    358    365     1
+    358    368     1
+    359    361     1
+    359    362     1
+    359    367     1
+    360    364     1
+    360    366     1
+    360    367     1
+    361    363     1
+    361    365     1
+    362    368     1
+    363    366     1
+    363    367     1
+    364    365     1
+    366    368     1
+    369    374     1
+    369    375     1
+    369    380     1
+    370    372     1
+    370    373     1
+    371    376     1
+    371    377     1
+    371    378     1
+    371    381     1
+    371    382     1
+    372    374     1
+    372    375     1
+    372    380     1
+    373    379     1
+    373    383     1
+    373    384     1
+    374    376     1
+    374    377     1
+    374    378     1
+    374    381     1
+    374    382     1
+    375    381     1
+    375    382     1
+    376    379     1
+    376    380     1
+    377    379     1
+    377    380     1
+    378    380     1
+    380    385     1
+    380    386     1
+    380    399     1
+    381    383     1
+    381    384     1
+    382    387     1
+    382    388     1
+    382    389     1
+    382    400     1
+    382    401     1
+    383    385     1
+    383    386     1
+    383    399     1
+    384    390     1
+    384    391     1
+    384    395     1
+    384    402     1
+    384    403     1
+    385    387     1
+    385    388     1
+    385    389     1
+    385    400     1
+    385    401     1
+    386    392     1
+    386    393     1
+    386    394     1
+    386    396     1
+    386    397     1
+    386    398     1
+    386    400     1
+    386    401     1
+    387    390     1
+    387    391     1
+    387    395     1
+    387    399     1
+    388    390     1
+    388    391     1
+    388    395     1
+    388    399     1
+    389    399     1
+    390    392     1
+    390    393     1
+    390    394     1
+    390    396     1
+    390    397     1
+    390    398     1
+    391    396     1
+    391    397     1
+    391    398     1
+    392    395     1
+    393    395     1
+    394    395     1
+    399    404     1
+    399    405     1
+    399    406     1
+    400    402     1
+    400    403     1
+    401    407     1
+    401    408     1
+    402    404     1
+    402    405     1
+    402    406     1
+    403    409     1
+    403    410     1
+    404    407     1
+    404    408     1
+    405    407     1
+    405    408     1
+    406    411     1
+    406    412     1
+    406    420     1
+    407    409     1
+    407    410     1
+    408    413     1
+    408    414     1
+    408    415     1
+    408    421     1
+    408    422     1
+    409    411     1
+    409    412     1
+    409    420     1
+    410    416     1
+    410    417     1
+    410    423     1
+    410    424     1
+    411    413     1
+    411    414     1
+    411    415     1
+    411    421     1
+    411    422     1
+    412    418     1
+    412    419     1
+    412    421     1
+    412    422     1
+    413    416     1
+    413    417     1
+    413    420     1
+    414    416     1
+    414    417     1
+    414    420     1
+    415    420     1
+    416    418     1
+    416    419     1
+    420    425     1
+    420    426     1
+    420    444     1
+    421    423     1
+    421    424     1
+    422    427     1
+    422    428     1
+    422    429     1
+    422    445     1
+    422    446     1
+    423    425     1
+    423    426     1
+    423    444     1
+    424    430     1
+    424    443     1
+    424    447     1
+    424    448     1
+    425    427     1
+    425    428     1
+    425    429     1
+    425    445     1
+    425    446     1
+    426    431     1
+    426    432     1
+    426    434     1
+    426    441     1
+    426    445     1
+    426    446     1
+    427    430     1
+    427    443     1
+    427    444     1
+    428    430     1
+    428    443     1
+    428    444     1
+    429    433     1
+    429    435     1
+    429    439     1
+    429    442     1
+    429    444     1
+    430    435     1
+    430    441     1
+    431    433     1
+    431    434     1
+    431    443     1
+    432    436     1
+    432    437     1
+    432    441     1
+    433    435     1
+    433    443     1
+    434    438     1
+    434    439     1
+    434    442     1
+    435    440     1
+    435    441     1
+    436    438     1
+    436    439     1
+    436    443     1
+    437    442     1
+    437    443     1
+    438    440     1
+    438    441     1
+    440    442     1
+    440    443     1
+    444    449     1
+    444    450     1
+    444    460     1
+    445    447     1
+    445    448     1
+    446    451     1
+    446    452     1
+    446    456     1
+    446    461     1
+    446    462     1
+    447    449     1
+    447    450     1
+    447    460     1
+    448    453     1
+    448    454     1
+    448    455     1
+    448    457     1
+    448    458     1
+    448    459     1
+    448    463     1
+    448    464     1
+    449    451     1
+    449    452     1
+    449    456     1
+    449    461     1
+    449    462     1
+    450    461     1
+    450    462     1
+    451    453     1
+    451    454     1
+    451    455     1
+    451    457     1
+    451    458     1
+    451    459     1
+    451    460     1
+    452    457     1
+    452    458     1
+    452    459     1
+    452    460     1
+    453    456     1
+    454    456     1
+    455    456     1
+    456    460     1
+    460    465     1
+    460    466     1
+    460    470     1
+    461    463     1
+    461    464     1
+    462    467     1
+    462    468     1
+    462    469     1
+    462    471     1
+    462    472     1
+    463    465     1
+    463    466     1
+    463    470     1
+    464    473     1
+    464    474     1
+    464   1732     1
+    465    467     1
+    465    468     1
+    465    469     1
+    465    471     1
+    465    472     1
+    466    471     1
+    466    472     1
+    466   1729     1
+    467    470     1
+    467   1732     1
+    468    470     1
+    468   1732     1
+    469    470     1
+    469   1727     1
+    469   1730     1
+    469   1731     1
+    470    475     1
+    470    476     1
+    470    480     1
+    471    473     1
+    471    474     1
+    472    477     1
+    472    478     1
+    472    479     1
+    472    481     1
+    472    482     1
+    473    475     1
+    473    476     1
+    473    480     1
+    474    483     1
+    474    484     1
+    475    477     1
+    475    478     1
+    475    479     1
+    475    481     1
+    475    482     1
+    476    481     1
+    476    482     1
+    477    480     1
+    478    480     1
+    479    480     1
+    480    485     1
+    480    486     1
+    480    490     1
+    481    483     1
+    481    484     1
+    482    487     1
+    482    488     1
+    482    489     1
+    482    491     1
+    482    492     1
+    483    485     1
+    483    486     1
+    483    490     1
+    484    493     1
+    484    494     1
+    485    487     1
+    485    488     1
+    485    489     1
+    485    491     1
+    485    492     1
+    486    491     1
+    486    492     1
+    487    490     1
+    488    490     1
+    489    490     1
+    490    495     1
+    490    496     1
+    490    512     1
+    491    493     1
+    491    494     1
+    492    497     1
+    492    498     1
+    492    499     1
+    492    513     1
+    492    514     1
+    493    495     1
+    493    496     1
+    493    512     1
+    494    500     1
+    494    501     1
+    494    502     1
+    494    515     1
+    494    516     1
+    495    497     1
+    495    498     1
+    495    499     1
+    495    513     1
+    495    514     1
+    496    503     1
+    496    504     1
+    496    505     1
+    496    513     1
+    496    514     1
+    497    500     1
+    497    501     1
+    497    502     1
+    497    512     1
+    498    500     1
+    498    501     1
+    498    502     1
+    498    512     1
+    499    506     1
+    499    507     1
+    499    508     1
+    499    512     1
+    500    503     1
+    500    504     1
+    500    505     1
+    501    503     1
+    501    504     1
+    501    505     1
+    502    509     1
+    502    510     1
+    502    511     1
+    503    506     1
+    503    507     1
+    503    508     1
+    504    506     1
+    504    507     1
+    504    508     1
+    506    509     1
+    506    510     1
+    506    511     1
+    507    509     1
+    507    510     1
+    507    511     1
+    512    517     1
+    512    518     1
+    512    532     1
+    513    515     1
+    513    516     1
+    514    519     1
+    514    520     1
+    514    521     1
+    514    533     1
+    514    534     1
+    515    517     1
+    515    518     1
+    515    532     1
+    516    522     1
+    516    530     1
+    516    535     1
+    516    536     1
+    517    519     1
+    517    520     1
+    517    521     1
+    517    533     1
+    517    534     1
+    518    523     1
+    518    524     1
+    518    528     1
+    518    531     1
+    518    533     1
+    518    534     1
+    519    522     1
+    519    530     1
+    519    532     1
+    520    522     1
+    520    530     1
+    520    532     1
+    521    525     1
+    521    526     1
+    521    529     1
+    521    532     1
+    522    527     1
+    522    528     1
+    522    531     1
+    523    525     1
+    523    526     1
+    523    530     1
+    524    529     1
+    524    530     1
+    525    527     1
+    525    528     1
+    526    531     1
+    527    529     1
+    527    530     1
+    529    531     1
+    532    537     1
+    532    538     1
+    532    547     1
+    533    535     1
+    533    536     1
+    534    539     1
+    534    540     1
+    534    541     1
+    534    548     1
+    534    549     1
+    535    537     1
+    535    538     1
+    535    547     1
+    536    542     1
+    536    543     1
+    536    544     1
+    536    550     1
+    536    551     1
+    537    539     1
+    537    540     1
+    537    541     1
+    537    548     1
+    537    549     1
+    538    545     1
+    538    546     1
+    538    548     1
+    538    549     1
+    539    542     1
+    539    543     1
+    539    544     1
+    539    547     1
+    540    542     1
+    540    543     1
+    540    544     1
+    540    547     1
+    541    547     1
+    542    545     1
+    542    546     1
+    543    545     1
+    543    546     1
+    547    552     1
+    547    553     1
+    547    558     1
+    548    550     1
+    548    551     1
+    549    554     1
+    549    555     1
+    549    556     1
+    549    559     1
+    549    560     1
+    550    552     1
+    550    553     1
+    550    558     1
+    551    557     1
+    551    561     1
+    551    562     1
+    552    554     1
+    552    555     1
+    552    556     1
+    552    559     1
+    552    560     1
+    553    559     1
+    553    560     1
+    554    557     1
+    554    558     1
+    555    557     1
+    555    558     1
+    556    558     1
+    558    563     1
+    558    564     1
+    558    572     1
+    559    561     1
+    559    562     1
+    560    565     1
+    560    566     1
+    560    567     1
+    560    573     1
+    560    574     1
+    561    563     1
+    561    564     1
+    561    572     1
+    562    568     1
+    562    569     1
+    562    575     1
+    562    576     1
+    563    565     1
+    563    566     1
+    563    567     1
+    563    573     1
+    563    574     1
+    564    570     1
+    564    571     1
+    564    573     1
+    564    574     1
+    565    568     1
+    565    569     1
+    565    572     1
+    566    568     1
+    566    569     1
+    566    572     1
+    567    572     1
+    568    570     1
+    568    571     1
+    572    577     1
+    572    578     1
+    572    592     1
+    573    575     1
+    573    576     1
+    574    579     1
+    574    580     1
+    574    581     1
+    574    593     1
+    574    594     1
+    575    577     1
+    575    578     1
+    575    592     1
+    576    582     1
+    576    590     1
+    576    595     1
+    576    596     1
+    577    579     1
+    577    580     1
+    577    581     1
+    577    593     1
+    577    594     1
+    578    583     1
+    578    584     1
+    578    588     1
+    578    591     1
+    578    593     1
+    578    594     1
+    579    582     1
+    579    590     1
+    579    592     1
+    580    582     1
+    580    590     1
+    580    592     1
+    581    585     1
+    581    586     1
+    581    589     1
+    581    592     1
+    582    587     1
+    582    588     1
+    582    591     1
+    583    585     1
+    583    586     1
+    583    590     1
+    584    589     1
+    584    590     1
+    585    587     1
+    585    588     1
+    586    591     1
+    587    589     1
+    587    590     1
+    589    591     1
+    592    597     1
+    592    598     1
+    592    606     1
+    593    595     1
+    593    596     1
+    594    599     1
+    594    600     1
+    594    601     1
+    594    607     1
+    594    608     1
+    595    597     1
+    595    598     1
+    595    606     1
+    596    602     1
+    596    603     1
+    596    609     1
+    596    610     1
+    597    599     1
+    597    600     1
+    597    601     1
+    597    607     1
+    597    608     1
+    598    604     1
+    598    605     1
+    598    607     1
+    598    608     1
+    599    602     1
+    599    603     1
+    599    606     1
+    600    602     1
+    600    603     1
+    600    606     1
+    601    606     1
+    602    604     1
+    602    605     1
+    606    611     1
+    606    612     1
+    606    620     1
+    607    609     1
+    607    610     1
+    608    613     1
+    608    614     1
+    608    618     1
+    608    621     1
+    608    622     1
+    609    611     1
+    609    612     1
+    609    620     1
+    610    615     1
+    610    616     1
+    610    617     1
+    610    619     1
+    610    623     1
+    610    624     1
+    611    613     1
+    611    614     1
+    611    618     1
+    611    621     1
+    611    622     1
+    612    621     1
+    612    622     1
+    613    615     1
+    613    616     1
+    613    617     1
+    613    619     1
+    613    620     1
+    614    619     1
+    614    620     1
+    615    618     1
+    616    618     1
+    617    618     1
+    618    620     1
+    620    625     1
+    620    626     1
+    620    637     1
+    621    623     1
+    621    624     1
+    622    627     1
+    622    628     1
+    622    629     1
+    622    638     1
+    622    639     1
+    623    625     1
+    623    626     1
+    623    637     1
+    624    630     1
+    624    631     1
+    624    632     1
+    624    640     1
+    624    641     1
+    625    627     1
+    625    628     1
+    625    629     1
+    625    638     1
+    625    639     1
+    626    633     1
+    626    634     1
+    626    638     1
+    626    639     1
+    627    630     1
+    627    631     1
+    627    632     1
+    627    637     1
+    628    630     1
+    628    631     1
+    628    632     1
+    628    637     1
+    629    635     1
+    629    636     1
+    629    637     1
+    630    633     1
+    630    634     1
+    631    633     1
+    631    634     1
+    633    635     1
+    633    636     1
+    637    642     1
+    637    643     1
+    637    647     1
+    638    640     1
+    638    641     1
+    639    644     1
+    639    645     1
+    639    646     1
+    639    648     1
+    639    649     1
+    640    642     1
+    640    643     1
+    640    647     1
+    641    650     1
+    641    651     1
+    642    644     1
+    642    645     1
+    642    646     1
+    642    648     1
+    642    649     1
+    643    648     1
+    643    649     1
+    644    647     1
+    645    647     1
+    646    647     1
+    647    652     1
+    647    653     1
+    647    661     1
+    648    650     1
+    648    651     1
+    649    654     1
+    649    655     1
+    649    659     1
+    649    662     1
+    649    663     1
+    650    652     1
+    650    653     1
+    650    661     1
+    651    656     1
+    651    657     1
+    651    658     1
+    651    660     1
+    651    664     1
+    651    665     1
+    652    654     1
+    652    655     1
+    652    659     1
+    652    662     1
+    652    663     1
+    653    662     1
+    653    663     1
+    654    656     1
+    654    657     1
+    654    658     1
+    654    660     1
+    654    661     1
+    655    660     1
+    655    661     1
+    656    659     1
+    657    659     1
+    658    659     1
+    659    661     1
+    661    666     1
+    661    667     1
+    661    675     1
+    662    664     1
+    662    665     1
+    663    668     1
+    663    669     1
+    663    670     1
+    663    676     1
+    663    677     1
+    664    666     1
+    664    667     1
+    664    675     1
+    665    671     1
+    665    672     1
+    665    678     1
+    665    679     1
+    666    668     1
+    666    669     1
+    666    670     1
+    666    676     1
+    666    677     1
+    667    673     1
+    667    674     1
+    667    676     1
+    667    677     1
+    668    671     1
+    668    672     1
+    668    675     1
+    669    671     1
+    669    672     1
+    669    675     1
+    670    675     1
+    671    673     1
+    671    674     1
+    675    680     1
+    675    681     1
+    675    699     1
+    676    678     1
+    676    679     1
+    677    682     1
+    677    683     1
+    677    684     1
+    677    700     1
+    677    701     1
+    678    680     1
+    678    681     1
+    678    699     1
+    679    685     1
+    679    686     1
+    679    687     1
+    679    702     1
+    679    703     1
+    680    682     1
+    680    683     1
+    680    684     1
+    680    700     1
+    680    701     1
+    681    688     1
+    681    689     1
+    681    690     1
+    681    700     1
+    681    701     1
+    682    685     1
+    682    686     1
+    682    687     1
+    682    699     1
+    683    685     1
+    683    686     1
+    683    687     1
+    683    699     1
+    684    691     1
+    684    692     1
+    684    699     1
+    685    688     1
+    685    689     1
+    685    690     1
+    686    688     1
+    686    689     1
+    686    690     1
+    687    693     1
+    687    696     1
+    688    691     1
+    688    692     1
+    689    691     1
+    689    692     1
+    690    694     1
+    690    695     1
+    690    697     1
+    690    698     1
+    691    693     1
+    691    696     1
+    693    697     1
+    693    698     1
+    694    696     1
+    695    696     1
+    699    704     1
+    699    705     1
+    699    713     1
+    700    702     1
+    700    703     1
+    701    706     1
+    701    707     1
+    701    708     1
+    701    714     1
+    701    715     1
+    702    704     1
+    702    705     1
+    702    713     1
+    703    709     1
+    703    710     1
+    703    716     1
+    703    717     1
+    704    706     1
+    704    707     1
+    704    708     1
+    704    714     1
+    704    715     1
+    705    711     1
+    705    712     1
+    705    714     1
+    705    715     1
+    706    709     1
+    706    710     1
+    706    713     1
+    707    709     1
+    707    710     1
+    707    713     1
+    708    713     1
+    709    711     1
+    709    712     1
+    713    718     1
+    713    719     1
+    713    727     1
+    714    716     1
+    714    717     1
+    715    720     1
+    715    721     1
+    715    725     1
+    715    728     1
+    715    729     1
+    716    718     1
+    716    719     1
+    716    727     1
+    717    722     1
+    717    723     1
+    717    724     1
+    717    726     1
+    717    730     1
+    717    731     1
+    718    720     1
+    718    721     1
+    718    725     1
+    718    728     1
+    718    729     1
+    719    728     1
+    719    729     1
+    720    722     1
+    720    723     1
+    720    724     1
+    720    726     1
+    720    727     1
+    721    726     1
+    721    727     1
+    722    725     1
+    723    725     1
+    724    725     1
+    725    727     1
+    727    732     1
+    727    733     1
+    727    739     1
+    728    730     1
+    728    731     1
+    729    734     1
+    729    735     1
+    729    736     1
+    729    740     1
+    729    741     1
+    730    732     1
+    730    733     1
+    730    739     1
+    731    737     1
+    731    738     1
+    731    742     1
+    731    743     1
+    732    734     1
+    732    735     1
+    732    736     1
+    732    740     1
+    732    741     1
+    733    740     1
+    733    741     1
+    734    737     1
+    734    738     1
+    734    739     1
+    735    737     1
+    735    738     1
+    735    739     1
+    736    739     1
+    739    744     1
+    739    745     1
+    739    746     1
+    740    742     1
+    740    743     1
+    741    747     1
+    741    748     1
+    742    744     1
+    742    745     1
+    742    746     1
+    743    749     1
+    743    750     1
+    744    747     1
+    744    748     1
+    745    747     1
+    745    748     1
+    746    751     1
+    746    752     1
+    746    757     1
+    747    749     1
+    747    750     1
+    748    753     1
+    748    754     1
+    748    755     1
+    748    758     1
+    748    759     1
+    749    751     1
+    749    752     1
+    749    757     1
+    750    756     1
+    750    760     1
+    750    761     1
+    751    753     1
+    751    754     1
+    751    755     1
+    751    758     1
+    751    759     1
+    752    758     1
+    752    759     1
+    753    756     1
+    753    757     1
+    754    756     1
+    754    757     1
+    755    757     1
+    757    762     1
+    757    763     1
+    757    771     1
+    758    760     1
+    758    761     1
+    759    764     1
+    759    765     1
+    759    769     1
+    759    772     1
+    759    773     1
+    760    762     1
+    760    763     1
+    760    771     1
+    761    766     1
+    761    767     1
+    761    768     1
+    761    770     1
+    761    774     1
+    761    775     1
+    762    764     1
+    762    765     1
+    762    769     1
+    762    772     1
+    762    773     1
+    763    772     1
+    763    773     1
+    764    766     1
+    764    767     1
+    764    768     1
+    764    770     1
+    764    771     1
+    765    770     1
+    765    771     1
+    766    769     1
+    767    769     1
+    768    769     1
+    769    771     1
+    771    776     1
+    771    777     1
+    771    783     1
+    772    774     1
+    772    775     1
+    773    778     1
+    773    779     1
+    773    780     1
+    773    784     1
+    773    785     1
+    774    776     1
+    774    777     1
+    774    783     1
+    775    781     1
+    775    782     1
+    775    786     1
+    775    787     1
+    776    778     1
+    776    779     1
+    776    780     1
+    776    784     1
+    776    785     1
+    777    784     1
+    777    785     1
+    778    781     1
+    778    782     1
+    778    783     1
+    779    781     1
+    779    782     1
+    779    783     1
+    780    783     1
+    783    788     1
+    783    789     1
+    783    804     1
+    784    786     1
+    784    787     1
+    785    790     1
+    785    791     1
+    785    792     1
+    785    805     1
+    785    806     1
+    786    788     1
+    786    789     1
+    786    804     1
+    787    793     1
+    787    802     1
+    787    807     1
+    787    808     1
+    788    790     1
+    788    791     1
+    788    792     1
+    788    805     1
+    788    806     1
+    789    794     1
+    789    795     1
+    789    800     1
+    789    803     1
+    789    805     1
+    789    806     1
+    790    793     1
+    790    802     1
+    790    804     1
+    791    793     1
+    791    802     1
+    791    804     1
+    792    796     1
+    792    797     1
+    792    801     1
+    792    804     1
+    793    798     1
+    793    800     1
+    793    803     1
+    794    796     1
+    794    797     1
+    794    802     1
+    795    799     1
+    795    801     1
+    795    802     1
+    796    798     1
+    796    800     1
+    797    803     1
+    798    801     1
+    798    802     1
+    799    800     1
+    801    803     1
+    804    809     1
+    804    810     1
+    804    811     1
+    805    807     1
+    805    808     1
+    806    812     1
+    806    813     1
+    807    809     1
+    807    810     1
+    807    811     1
+    808    814     1
+    808    815     1
+    809    812     1
+    809    813     1
+    810    812     1
+    810    813     1
+    811    816     1
+    811    817     1
+    811    830     1
+    812    814     1
+    812    815     1
+    813    818     1
+    813    819     1
+    813    823     1
+    813    831     1
+    813    832     1
+    814    816     1
+    814    817     1
+    814    830     1
+    815    820     1
+    815    821     1
+    815    822     1
+    815    824     1
+    815    825     1
+    815    826     1
+    815    833     1
+    815    834     1
+    816    818     1
+    816    819     1
+    816    823     1
+    816    831     1
+    816    832     1
+    817    827     1
+    817    828     1
+    817    829     1
+    817    831     1
+    817    832     1
+    818    820     1
+    818    821     1
+    818    822     1
+    818    824     1
+    818    825     1
+    818    826     1
+    818    830     1
+    819    824     1
+    819    825     1
+    819    826     1
+    819    830     1
+    820    823     1
+    821    823     1
+    822    823     1
+    823    830     1
+    824    827     1
+    824    828     1
+    824    829     1
+    825    827     1
+    825    828     1
+    825    829     1
+    830    835     1
+    830    836     1
+    830    849     1
+    831    833     1
+    831    834     1
+    832    837     1
+    832    838     1
+    832    839     1
+    832    850     1
+    832    851     1
+    833    835     1
+    833    836     1
+    833    849     1
+    834    840     1
+    834    841     1
+    834    845     1
+    834    852     1
+    834    853     1
+    835    837     1
+    835    838     1
+    835    839     1
+    835    850     1
+    835    851     1
+    836    842     1
+    836    843     1
+    836    844     1
+    836    846     1
+    836    847     1
+    836    848     1
+    836    850     1
+    836    851     1
+    837    840     1
+    837    841     1
+    837    845     1
+    837    849     1
+    838    840     1
+    838    841     1
+    838    845     1
+    838    849     1
+    839    849     1
+    840    842     1
+    840    843     1
+    840    844     1
+    840    846     1
+    840    847     1
+    840    848     1
+    841    846     1
+    841    847     1
+    841    848     1
+    842    845     1
+    843    845     1
+    844    845     1
+    849    854     1
+    849    855     1
+    849    866     1
+    850    852     1
+    850    853     1
+    851    856     1
+    851    857     1
+    851    858     1
+    851    867     1
+    851    868     1
+    852    854     1
+    852    855     1
+    852    866     1
+    853    859     1
+    853    860     1
+    853    861     1
+    853    869     1
+    853    870     1
+    854    856     1
+    854    857     1
+    854    858     1
+    854    867     1
+    854    868     1
+    855    862     1
+    855    863     1
+    855    867     1
+    855    868     1
+    856    859     1
+    856    860     1
+    856    861     1
+    856    866     1
+    857    859     1
+    857    860     1
+    857    861     1
+    857    866     1
+    858    864     1
+    858    865     1
+    858    866     1
+    859    862     1
+    859    863     1
+    860    862     1
+    860    863     1
+    862    864     1
+    862    865     1
+    866    871     1
+    866    872     1
+    866    885     1
+    867    869     1
+    867    870     1
+    868    873     1
+    868    874     1
+    868    878     1
+    868    886     1
+    868    887     1
+    869    871     1
+    869    872     1
+    869    885     1
+    870    875     1
+    870    876     1
+    870    877     1
+    870    879     1
+    870    880     1
+    870    881     1
+    870    888     1
+    870    889     1
+    871    873     1
+    871    874     1
+    871    878     1
+    871    886     1
+    871    887     1
+    872    882     1
+    872    883     1
+    872    884     1
+    872    886     1
+    872    887     1
+    873    875     1
+    873    876     1
+    873    877     1
+    873    879     1
+    873    880     1
+    873    881     1
+    873    885     1
+    874    879     1
+    874    880     1
+    874    881     1
+    874    885     1
+    875    878     1
+    876    878     1
+    877    878     1
+    878    885     1
+    879    882     1
+    879    883     1
+    879    884     1
+    880    882     1
+    880    883     1
+    880    884     1
+    885    890     1
+    885    891     1
+    885    899     1
+    886    888     1
+    886    889     1
+    887    892     1
+    887    893     1
+    887    894     1
+    887    900     1
+    887    901     1
+    888    890     1
+    888    891     1
+    888    899     1
+    889    895     1
+    889    896     1
+    889    902     1
+    889    903     1
+    890    892     1
+    890    893     1
+    890    894     1
+    890    900     1
+    890    901     1
+    891    897     1
+    891    898     1
+    891    900     1
+    891    901     1
+    892    895     1
+    892    896     1
+    892    899     1
+    893    895     1
+    893    896     1
+    893    899     1
+    894    899     1
+    895    897     1
+    895    898     1
+    899    904     1
+    899    905     1
+    899    910     1
+    900    902     1
+    900    903     1
+    901    906     1
+    901    907     1
+    901    908     1
+    901    911     1
+    901    912     1
+    902    904     1
+    902    905     1
+    902    910     1
+    903    909     1
+    903    913     1
+    903    914     1
+    904    906     1
+    904    907     1
+    904    908     1
+    904    911     1
+    904    912     1
+    905    911     1
+    905    912     1
+    906    909     1
+    906    910     1
+    907    909     1
+    907    910     1
+    908    910     1
+    910    915     1
+    910    916     1
+    910    934     1
+    911    913     1
+    911    914     1
+    912    917     1
+    912    918     1
+    912    919     1
+    912    935     1
+    912    936     1
+    913    915     1
+    913    916     1
+    913    934     1
+    914    920     1
+    914    921     1
+    914    922     1
+    914    937     1
+    914    938     1
+    915    917     1
+    915    918     1
+    915    919     1
+    915    935     1
+    915    936     1
+    916    923     1
+    916    924     1
+    916    925     1
+    916    935     1
+    916    936     1
+    917    920     1
+    917    921     1
+    917    922     1
+    917    934     1
+    918    920     1
+    918    921     1
+    918    922     1
+    918    934     1
+    919    926     1
+    919    927     1
+    919    934     1
+    920    923     1
+    920    924     1
+    920    925     1
+    921    923     1
+    921    924     1
+    921    925     1
+    922    928     1
+    922    931     1
+    923    926     1
+    923    927     1
+    924    926     1
+    924    927     1
+    925    929     1
+    925    930     1
+    925    932     1
+    925    933     1
+    926    928     1
+    926    931     1
+    928    932     1
+    928    933     1
+    929    931     1
+    930    931     1
+    934    939     1
+    934    940     1
+    934    958     1
+    935    937     1
+    935    938     1
+    936    941     1
+    936    942     1
+    936    943     1
+    936    959     1
+    936    960     1
+    937    939     1
+    937    940     1
+    937    958     1
+    938    944     1
+    938    957     1
+    938    961     1
+    938    962     1
+    939    941     1
+    939    942     1
+    939    943     1
+    939    959     1
+    939    960     1
+    940    945     1
+    940    946     1
+    940    948     1
+    940    955     1
+    940    959     1
+    940    960     1
+    941    944     1
+    941    957     1
+    941    958     1
+    942    944     1
+    942    957     1
+    942    958     1
+    943    947     1
+    943    949     1
+    943    953     1
+    943    956     1
+    943    958     1
+    944    949     1
+    944    955     1
+    945    947     1
+    945    948     1
+    945    957     1
+    946    950     1
+    946    951     1
+    946    955     1
+    947    949     1
+    947    957     1
+    948    952     1
+    948    953     1
+    948    956     1
+    949    954     1
+    949    955     1
+    950    952     1
+    950    953     1
+    950    957     1
+    951    956     1
+    951    957     1
+    952    954     1
+    952    955     1
+    954    956     1
+    954    957     1
+    958    963     1
+    958    964     1
+    958    982     1
+    959    961     1
+    959    962     1
+    960    965     1
+    960    966     1
+    960    967     1
+    960    983     1
+    960    984     1
+    961    963     1
+    961    964     1
+    961    982     1
+    962    968     1
+    962    981     1
+    962    985     1
+    962    986     1
+    963    965     1
+    963    966     1
+    963    967     1
+    963    983     1
+    963    984     1
+    964    969     1
+    964    970     1
+    964    972     1
+    964    979     1
+    964    983     1
+    964    984     1
+    965    968     1
+    965    981     1
+    965    982     1
+    966    968     1
+    966    981     1
+    966    982     1
+    967    971     1
+    967    973     1
+    967    977     1
+    967    980     1
+    967    982     1
+    968    973     1
+    968    979     1
+    969    971     1
+    969    972     1
+    969    981     1
+    970    974     1
+    970    975     1
+    970    979     1
+    971    973     1
+    971    981     1
+    972    976     1
+    972    977     1
+    972    980     1
+    973    978     1
+    973    979     1
+    974    976     1
+    974    977     1
+    974    981     1
+    975    980     1
+    975    981     1
+    976    978     1
+    976    979     1
+    978    980     1
+    978    981     1
+    982    987     1
+    982    988     1
+    982    992     1
+    983    985     1
+    983    986     1
+    984    989     1
+    984    990     1
+    984    991     1
+    984    993     1
+    984    994     1
+    985    987     1
+    985    988     1
+    985    992     1
+    986    995     1
+    986    996     1
+    986   1218     1
+    987    989     1
+    987    990     1
+    987    991     1
+    987    993     1
+    987    994     1
+    988    993     1
+    988    994     1
+    988   1215     1
+    989    992     1
+    989   1218     1
+    990    992     1
+    990   1218     1
+    991    992     1
+    991   1213     1
+    991   1216     1
+    991   1217     1
+    992    997     1
+    992    998     1
+    992   1006     1
+    993    995     1
+    993    996     1
+    994    999     1
+    994   1000     1
+    994   1001     1
+    994   1007     1
+    994   1008     1
+    995    997     1
+    995    998     1
+    995   1006     1
+    996   1002     1
+    996   1003     1
+    996   1009     1
+    996   1010     1
+    997    999     1
+    997   1000     1
+    997   1001     1
+    997   1007     1
+    997   1008     1
+    998   1004     1
+    998   1005     1
+    998   1007     1
+    998   1008     1
+    999   1002     1
+    999   1003     1
+    999   1006     1
+   1000   1002     1
+   1000   1003     1
+   1000   1006     1
+   1001   1006     1
+   1002   1004     1
+   1002   1005     1
+   1006   1011     1
+   1006   1012     1
+   1006   1018     1
+   1007   1009     1
+   1007   1010     1
+   1008   1013     1
+   1008   1014     1
+   1008   1015     1
+   1008   1019     1
+   1008   1020     1
+   1009   1011     1
+   1009   1012     1
+   1009   1018     1
+   1010   1016     1
+   1010   1017     1
+   1010   1021     1
+   1010   1022     1
+   1011   1013     1
+   1011   1014     1
+   1011   1015     1
+   1011   1019     1
+   1011   1020     1
+   1012   1019     1
+   1012   1020     1
+   1013   1016     1
+   1013   1017     1
+   1013   1018     1
+   1014   1016     1
+   1014   1017     1
+   1014   1018     1
+   1015   1018     1
+   1018   1023     1
+   1018   1024     1
+   1018   1025     1
+   1019   1021     1
+   1019   1022     1
+   1020   1026     1
+   1020   1027     1
+   1021   1023     1
+   1021   1024     1
+   1021   1025     1
+   1022   1028     1
+   1022   1029     1
+   1023   1026     1
+   1023   1027     1
+   1024   1026     1
+   1024   1027     1
+   1025   1030     1
+   1025   1031     1
+   1025   1049     1
+   1026   1028     1
+   1026   1029     1
+   1027   1032     1
+   1027   1033     1
+   1027   1034     1
+   1027   1050     1
+   1027   1051     1
+   1028   1030     1
+   1028   1031     1
+   1028   1049     1
+   1029   1035     1
+   1029   1036     1
+   1029   1037     1
+   1029   1052     1
+   1029   1053     1
+   1030   1032     1
+   1030   1033     1
+   1030   1034     1
+   1030   1050     1
+   1030   1051     1
+   1031   1038     1
+   1031   1039     1
+   1031   1040     1
+   1031   1050     1
+   1031   1051     1
+   1032   1035     1
+   1032   1036     1
+   1032   1037     1
+   1032   1049     1
+   1033   1035     1
+   1033   1036     1
+   1033   1037     1
+   1033   1049     1
+   1034   1041     1
+   1034   1042     1
+   1034   1049     1
+   1035   1038     1
+   1035   1039     1
+   1035   1040     1
+   1036   1038     1
+   1036   1039     1
+   1036   1040     1
+   1037   1043     1
+   1037   1046     1
+   1038   1041     1
+   1038   1042     1
+   1039   1041     1
+   1039   1042     1
+   1040   1044     1
+   1040   1045     1
+   1040   1047     1
+   1040   1048     1
+   1041   1043     1
+   1041   1046     1
+   1043   1047     1
+   1043   1048     1
+   1044   1046     1
+   1045   1046     1
+   1049   1054     1
+   1049   1055     1
+   1049   1063     1
+   1050   1052     1
+   1050   1053     1
+   1051   1056     1
+   1051   1057     1
+   1051   1061     1
+   1051   1064     1
+   1051   1065     1
+   1052   1054     1
+   1052   1055     1
+   1052   1063     1
+   1053   1058     1
+   1053   1059     1
+   1053   1060     1
+   1053   1062     1
+   1053   1066     1
+   1053   1075     1
+   1054   1056     1
+   1054   1057     1
+   1054   1061     1
+   1054   1064     1
+   1054   1065     1
+   1055   1064     1
+   1055   1065     1
+   1056   1058     1
+   1056   1059     1
+   1056   1060     1
+   1056   1062     1
+   1056   1063     1
+   1057   1062     1
+   1057   1063     1
+   1058   1061     1
+   1059   1061     1
+   1060   1061     1
+   1061   1063     1
+   1063   1067     1
+   1063   1068     1
+   1063   1069     1
+   1063   1072     1
+   1063   1076     1
+   1063   1077     1
+   1064   1066     1
+   1064   1075     1
+   1065   1070     1
+   1065   1071     1
+   1065   1073     1
+   1065   1074     1
+   1065   1078     1
+   1065   1079     1
+   1066   1073     1
+   1066   1074     1
+   1066   1076     1
+   1066   1077     1
+   1067   1070     1
+   1067   1071     1
+   1067   1072     1
+   1067   1075     1
+   1068   1070     1
+   1068   1071     1
+   1068   1072     1
+   1068   1075     1
+   1069   1076     1
+   1069   1077     1
+   1070   1073     1
+   1070   1074     1
+   1070   1075     1
+   1071   1073     1
+   1071   1074     1
+   1071   1075     1
+   1072   1078     1
+   1072   1079     1
+   1073   1076     1
+   1073   1077     1
+   1074   1076     1
+   1074   1077     1
+   1075   1080     1
+   1075   1081     1
+   1076   1078     1
+   1076   1079     1
+   1077   1082     1
+   1077   1083     1
+   1077   1084     1
+   1078   1080     1
+   1078   1081     1
+   1079   1085     1
+   1079   1086     1
+   1080   1082     1
+   1080   1083     1
+   1080   1084     1
+   1081   1087     1
+   1081   1088     1
+   1082   1085     1
+   1082   1086     1
+   1083   1085     1
+   1083   1086     1
+   1084   1089     1
+   1084   1090     1
+   1084   1095     1
+   1085   1087     1
+   1085   1088     1
+   1086   1091     1
+   1086   1092     1
+   1086   1093     1
+   1086   1096     1
+   1086   1097     1
+   1087   1089     1
+   1087   1090     1
+   1087   1095     1
+   1088   1094     1
+   1088   1098     1
+   1088   1099     1
+   1089   1091     1
+   1089   1092     1
+   1089   1093     1
+   1089   1096     1
+   1089   1097     1
+   1090   1096     1
+   1090   1097     1
+   1091   1094     1
+   1091   1095     1
+   1092   1094     1
+   1092   1095     1
+   1093   1095     1
+   1095   1100     1
+   1095   1101     1
+   1095   1119     1
+   1096   1098     1
+   1096   1099     1
+   1097   1102     1
+   1097   1103     1
+   1097   1104     1
+   1097   1120     1
+   1097   1121     1
+   1098   1100     1
+   1098   1101     1
+   1098   1119     1
+   1099   1105     1
+   1099   1106     1
+   1099   1107     1
+   1099   1122     1
+   1099   1123     1
+   1100   1102     1
+   1100   1103     1
+   1100   1104     1
+   1100   1120     1
+   1100   1121     1
+   1101   1108     1
+   1101   1109     1
+   1101   1110     1
+   1101   1120     1
+   1101   1121     1
+   1102   1105     1
+   1102   1106     1
+   1102   1107     1
+   1102   1119     1
+   1103   1105     1
+   1103   1106     1
+   1103   1107     1
+   1103   1119     1
+   1104   1111     1
+   1104   1112     1
+   1104   1119     1
+   1105   1108     1
+   1105   1109     1
+   1105   1110     1
+   1106   1108     1
+   1106   1109     1
+   1106   1110     1
+   1107   1113     1
+   1107   1116     1
+   1108   1111     1
+   1108   1112     1
+   1109   1111     1
+   1109   1112     1
+   1110   1114     1
+   1110   1115     1
+   1110   1117     1
+   1110   1118     1
+   1111   1113     1
+   1111   1116     1
+   1113   1117     1
+   1113   1118     1
+   1114   1116     1
+   1115   1116     1
+   1119   1124     1
+   1119   1125     1
+   1119   1133     1
+   1120   1122     1
+   1120   1123     1
+   1121   1126     1
+   1121   1127     1
+   1121   1128     1
+   1121   1134     1
+   1121   1135     1
+   1122   1124     1
+   1122   1125     1
+   1122   1133     1
+   1123   1129     1
+   1123   1130     1
+   1123   1136     1
+   1123   1137     1
+   1124   1126     1
+   1124   1127     1
+   1124   1128     1
+   1124   1134     1
+   1124   1135     1
+   1125   1131     1
+   1125   1132     1
+   1125   1134     1
+   1125   1135     1
+   1126   1129     1
+   1126   1130     1
+   1126   1133     1
+   1127   1129     1
+   1127   1130     1
+   1127   1133     1
+   1128   1133     1
+   1129   1131     1
+   1129   1132     1
+   1133   1138     1
+   1133   1139     1
+   1133   1152     1
+   1134   1136     1
+   1134   1137     1
+   1135   1140     1
+   1135   1141     1
+   1135   1142     1
+   1135   1153     1
+   1135   1154     1
+   1136   1138     1
+   1136   1139     1
+   1136   1152     1
+   1137   1143     1
+   1137   1144     1
+   1137   1148     1
+   1137   1155     1
+   1137   1156     1
+   1138   1140     1
+   1138   1141     1
+   1138   1142     1
+   1138   1153     1
+   1138   1154     1
+   1139   1145     1
+   1139   1146     1
+   1139   1147     1
+   1139   1149     1
+   1139   1150     1
+   1139   1151     1
+   1139   1153     1
+   1139   1154     1
+   1140   1143     1
+   1140   1144     1
+   1140   1148     1
+   1140   1152     1
+   1141   1143     1
+   1141   1144     1
+   1141   1148     1
+   1141   1152     1
+   1142   1152     1
+   1143   1145     1
+   1143   1146     1
+   1143   1147     1
+   1143   1149     1
+   1143   1150     1
+   1143   1151     1
+   1144   1149     1
+   1144   1150     1
+   1144   1151     1
+   1145   1148     1
+   1146   1148     1
+   1147   1148     1
+   1152   1157     1
+   1152   1158     1
+   1152   1162     1
+   1153   1155     1
+   1153   1156     1
+   1154   1159     1
+   1154   1160     1
+   1154   1161     1
+   1154   1163     1
+   1154   1164     1
+   1155   1157     1
+   1155   1158     1
+   1155   1162     1
+   1156   1165     1
+   1156   1166     1
+   1156   1405     1
+   1157   1159     1
+   1157   1160     1
+   1157   1161     1
+   1157   1163     1
+   1157   1164     1
+   1158   1163     1
+   1158   1164     1
+   1158   1402     1
+   1159   1162     1
+   1159   1405     1
+   1160   1162     1
+   1160   1405     1
+   1161   1162     1
+   1161   1400     1
+   1161   1403     1
+   1161   1404     1
+   1162   1167     1
+   1162   1168     1
+   1162   1176     1
+   1163   1165     1
+   1163   1166     1
+   1164   1169     1
+   1164   1170     1
+   1164   1171     1
+   1164   1177     1
+   1164   1178     1
+   1165   1167     1
+   1165   1168     1
+   1165   1176     1
+   1166   1172     1
+   1166   1173     1
+   1166   1179     1
+   1166   1180     1
+   1167   1169     1
+   1167   1170     1
+   1167   1171     1
+   1167   1177     1
+   1167   1178     1
+   1168   1174     1
+   1168   1175     1
+   1168   1177     1
+   1168   1178     1
+   1169   1172     1
+   1169   1173     1
+   1169   1176     1
+   1170   1172     1
+   1170   1173     1
+   1170   1176     1
+   1171   1176     1
+   1172   1174     1
+   1172   1175     1
+   1176   1181     1
+   1176   1182     1
+   1176   1195     1
+   1177   1179     1
+   1177   1180     1
+   1178   1183     1
+   1178   1184     1
+   1178   1188     1
+   1178   1196     1
+   1178   1197     1
+   1179   1181     1
+   1179   1182     1
+   1179   1195     1
+   1180   1185     1
+   1180   1186     1
+   1180   1187     1
+   1180   1189     1
+   1180   1190     1
+   1180   1191     1
+   1180   1198     1
+   1180   1207     1
+   1181   1183     1
+   1181   1184     1
+   1181   1188     1
+   1181   1196     1
+   1181   1197     1
+   1182   1192     1
+   1182   1193     1
+   1182   1194     1
+   1182   1196     1
+   1182   1197     1
+   1183   1185     1
+   1183   1186     1
+   1183   1187     1
+   1183   1189     1
+   1183   1190     1
+   1183   1191     1
+   1183   1195     1
+   1184   1189     1
+   1184   1190     1
+   1184   1191     1
+   1184   1195     1
+   1185   1188     1
+   1186   1188     1
+   1187   1188     1
+   1188   1195     1
+   1189   1192     1
+   1189   1193     1
+   1189   1194     1
+   1190   1192     1
+   1190   1193     1
+   1190   1194     1
+   1195   1199     1
+   1195   1200     1
+   1195   1201     1
+   1195   1204     1
+   1195   1208     1
+   1195   1209     1
+   1196   1198     1
+   1196   1207     1
+   1197   1202     1
+   1197   1203     1
+   1197   1205     1
+   1197   1206     1
+   1197   1210     1
+   1197   1211     1
+   1198   1205     1
+   1198   1206     1
+   1198   1208     1
+   1198   1209     1
+   1199   1202     1
+   1199   1203     1
+   1199   1204     1
+   1199   1207     1
+   1200   1202     1
+   1200   1203     1
+   1200   1204     1
+   1200   1207     1
+   1201   1208     1
+   1201   1209     1
+   1202   1205     1
+   1202   1206     1
+   1202   1207     1
+   1203   1205     1
+   1203   1206     1
+   1203   1207     1
+   1204   1210     1
+   1204   1211     1
+   1205   1208     1
+   1205   1209     1
+   1206   1208     1
+   1206   1209     1
+   1207   1212     1
+   1207   1213     1
+   1208   1210     1
+   1208   1211     1
+   1209   1214     1
+   1209   1215     1
+   1209   1219     1
+   1210   1212     1
+   1210   1213     1
+   1211   1216     1
+   1211   1217     1
+   1211   1218     1
+   1211   1220     1
+   1211   1221     1
+   1212   1214     1
+   1212   1215     1
+   1212   1219     1
+   1213   1222     1
+   1213   1223     1
+   1214   1216     1
+   1214   1217     1
+   1214   1218     1
+   1214   1220     1
+   1214   1221     1
+   1215   1220     1
+   1215   1221     1
+   1216   1219     1
+   1217   1219     1
+   1218   1219     1
+   1219   1224     1
+   1219   1225     1
+   1219   1230     1
+   1220   1222     1
+   1220   1223     1
+   1221   1226     1
+   1221   1227     1
+   1221   1228     1
+   1221   1231     1
+   1221   1232     1
+   1222   1224     1
+   1222   1225     1
+   1222   1230     1
+   1223   1229     1
+   1223   1233     1
+   1223   1234     1
+   1224   1226     1
+   1224   1227     1
+   1224   1228     1
+   1224   1231     1
+   1224   1232     1
+   1225   1231     1
+   1225   1232     1
+   1226   1229     1
+   1226   1230     1
+   1227   1229     1
+   1227   1230     1
+   1228   1230     1
+   1230   1235     1
+   1230   1236     1
+   1230   1240     1
+   1231   1233     1
+   1231   1234     1
+   1232   1237     1
+   1232   1238     1
+   1232   1239     1
+   1232   1241     1
+   1232   1242     1
+   1233   1235     1
+   1233   1236     1
+   1233   1240     1
+   1234   1243     1
+   1234   1244     1
+   1235   1237     1
+   1235   1238     1
+   1235   1239     1
+   1235   1241     1
+   1235   1242     1
+   1236   1241     1
+   1236   1242     1
+   1237   1240     1
+   1238   1240     1
+   1239   1240     1
+   1240   1245     1
+   1240   1246     1
+   1240   1259     1
+   1241   1243     1
+   1241   1244     1
+   1242   1247     1
+   1242   1248     1
+   1242   1249     1
+   1242   1260     1
+   1242   1261     1
+   1243   1245     1
+   1243   1246     1
+   1243   1259     1
+   1244   1250     1
+   1244   1251     1
+   1244   1255     1
+   1244   1262     1
+   1244   1263     1
+   1245   1247     1
+   1245   1248     1
+   1245   1249     1
+   1245   1260     1
+   1245   1261     1
+   1246   1252     1
+   1246   1253     1
+   1246   1254     1
+   1246   1256     1
+   1246   1257     1
+   1246   1258     1
+   1246   1260     1
+   1246   1261     1
+   1247   1250     1
+   1247   1251     1
+   1247   1255     1
+   1247   1259     1
+   1248   1250     1
+   1248   1251     1
+   1248   1255     1
+   1248   1259     1
+   1249   1259     1
+   1250   1252     1
+   1250   1253     1
+   1250   1254     1
+   1250   1256     1
+   1250   1257     1
+   1250   1258     1
+   1251   1256     1
+   1251   1257     1
+   1251   1258     1
+   1252   1255     1
+   1253   1255     1
+   1254   1255     1
+   1259   1264     1
+   1259   1265     1
+   1259   1278     1
+   1260   1262     1
+   1260   1263     1
+   1261   1266     1
+   1261   1267     1
+   1261   1268     1
+   1261   1279     1
+   1261   1280     1
+   1262   1264     1
+   1262   1265     1
+   1262   1278     1
+   1263   1269     1
+   1263   1270     1
+   1263   1274     1
+   1263   1281     1
+   1263   1282     1
+   1264   1266     1
+   1264   1267     1
+   1264   1268     1
+   1264   1279     1
+   1264   1280     1
+   1265   1271     1
+   1265   1272     1
+   1265   1273     1
+   1265   1275     1
+   1265   1276     1
+   1265   1277     1
+   1265   1279     1
+   1265   1280     1
+   1266   1269     1
+   1266   1270     1
+   1266   1274     1
+   1266   1278     1
+   1267   1269     1
+   1267   1270     1
+   1267   1274     1
+   1267   1278     1
+   1268   1278     1
+   1269   1271     1
+   1269   1272     1
+   1269   1273     1
+   1269   1275     1
+   1269   1276     1
+   1269   1277     1
+   1270   1275     1
+   1270   1276     1
+   1270   1277     1
+   1271   1274     1
+   1272   1274     1
+   1273   1274     1
+   1278   1283     1
+   1278   1284     1
+   1278   1289     1
+   1279   1281     1
+   1279   1282     1
+   1280   1285     1
+   1280   1286     1
+   1280   1287     1
+   1280   1290     1
+   1280   1291     1
+   1281   1283     1
+   1281   1284     1
+   1281   1289     1
+   1282   1288     1
+   1282   1292     1
+   1282   1293     1
+   1283   1285     1
+   1283   1286     1
+   1283   1287     1
+   1283   1290     1
+   1283   1291     1
+   1284   1290     1
+   1284   1291     1
+   1285   1288     1
+   1285   1289     1
+   1286   1288     1
+   1286   1289     1
+   1287   1289     1
+   1289   1294     1
+   1289   1295     1
+   1289   1300     1
+   1290   1292     1
+   1290   1293     1
+   1291   1296     1
+   1291   1297     1
+   1291   1298     1
+   1291   1301     1
+   1291   1302     1
+   1292   1294     1
+   1292   1295     1
+   1292   1300     1
+   1293   1299     1
+   1293   1303     1
+   1293   1304     1
+   1294   1296     1
+   1294   1297     1
+   1294   1298     1
+   1294   1301     1
+   1294   1302     1
+   1295   1301     1
+   1295   1302     1
+   1296   1299     1
+   1296   1300     1
+   1297   1299     1
+   1297   1300     1
+   1298   1300     1
+   1300   1305     1
+   1300   1306     1
+   1300   1312     1
+   1301   1303     1
+   1301   1304     1
+   1302   1307     1
+   1302   1308     1
+   1302   1309     1
+   1302   1313     1
+   1302   1314     1
+   1303   1305     1
+   1303   1306     1
+   1303   1312     1
+   1304   1310     1
+   1304   1311     1
+   1304   1315     1
+   1304   1316     1
+   1305   1307     1
+   1305   1308     1
+   1305   1309     1
+   1305   1313     1
+   1305   1314     1
+   1306   1313     1
+   1306   1314     1
+   1307   1310     1
+   1307   1311     1
+   1307   1312     1
+   1308   1310     1
+   1308   1311     1
+   1308   1312     1
+   1309   1312     1
+   1312   1317     1
+   1312   1318     1
+   1312   1331     1
+   1313   1315     1
+   1313   1316     1
+   1314   1319     1
+   1314   1320     1
+   1314   1324     1
+   1314   1332     1
+   1314   1333     1
+   1315   1317     1
+   1315   1318     1
+   1315   1331     1
+   1316   1321     1
+   1316   1322     1
+   1316   1323     1
+   1316   1325     1
+   1316   1326     1
+   1316   1327     1
+   1316   1334     1
+   1316   1335     1
+   1317   1319     1
+   1317   1320     1
+   1317   1324     1
+   1317   1332     1
+   1317   1333     1
+   1318   1328     1
+   1318   1329     1
+   1318   1330     1
+   1318   1332     1
+   1318   1333     1
+   1319   1321     1
+   1319   1322     1
+   1319   1323     1
+   1319   1325     1
+   1319   1326     1
+   1319   1327     1
+   1319   1331     1
+   1320   1325     1
+   1320   1326     1
+   1320   1327     1
+   1320   1331     1
+   1321   1324     1
+   1322   1324     1
+   1323   1324     1
+   1324   1331     1
+   1325   1328     1
+   1325   1329     1
+   1325   1330     1
+   1326   1328     1
+   1326   1329     1
+   1326   1330     1
+   1331   1336     1
+   1331   1337     1
+   1331   1345     1
+   1332   1334     1
+   1332   1335     1
+   1333   1338     1
+   1333   1339     1
+   1333   1343     1
+   1333   1346     1
+   1333   1347     1
+   1334   1336     1
+   1334   1337     1
+   1334   1345     1
+   1335   1340     1
+   1335   1341     1
+   1335   1342     1
+   1335   1344     1
+   1335   1348     1
+   1335   1349     1
+   1336   1338     1
+   1336   1339     1
+   1336   1343     1
+   1336   1346     1
+   1336   1347     1
+   1337   1346     1
+   1337   1347     1
+   1338   1340     1
+   1338   1341     1
+   1338   1342     1
+   1338   1344     1
+   1338   1345     1
+   1339   1344     1
+   1339   1345     1
+   1340   1343     1
+   1341   1343     1
+   1342   1343     1
+   1343   1345     1
+   1345   1350     1
+   1345   1351     1
+   1345   1355     1
+   1346   1348     1
+   1346   1349     1
+   1347   1352     1
+   1347   1353     1
+   1347   1354     1
+   1347   1356     1
+   1347   1357     1
+   1348   1350     1
+   1348   1351     1
+   1348   1355     1
+   1349   1358     1
+   1349   1359     1
+   1350   1352     1
+   1350   1353     1
+   1350   1354     1
+   1350   1356     1
+   1350   1357     1
+   1351   1356     1
+   1351   1357     1
+   1352   1355     1
+   1353   1355     1
+   1354   1355     1
+   1355   1360     1
+   1355   1361     1
+   1355   1366     1
+   1356   1358     1
+   1356   1359     1
+   1357   1362     1
+   1357   1363     1
+   1357   1364     1
+   1357   1367     1
+   1357   1368     1
+   1358   1360     1
+   1358   1361     1
+   1358   1366     1
+   1359   1365     1
+   1359   1369     1
+   1359   1370     1
+   1360   1362     1
+   1360   1363     1
+   1360   1364     1
+   1360   1367     1
+   1360   1368     1
+   1361   1367     1
+   1361   1368     1
+   1362   1365     1
+   1362   1366     1
+   1363   1365     1
+   1363   1366     1
+   1364   1366     1
+   1366   1371     1
+   1366   1372     1
+   1366   1382     1
+   1367   1369     1
+   1367   1370     1
+   1368   1373     1
+   1368   1374     1
+   1368   1378     1
+   1368   1383     1
+   1368   1384     1
+   1369   1371     1
+   1369   1372     1
+   1369   1382     1
+   1370   1375     1
+   1370   1376     1
+   1370   1377     1
+   1370   1379     1
+   1370   1380     1
+   1370   1381     1
+   1370   1385     1
+   1370   1386     1
+   1371   1373     1
+   1371   1374     1
+   1371   1378     1
+   1371   1383     1
+   1371   1384     1
+   1372   1383     1
+   1372   1384     1
+   1373   1375     1
+   1373   1376     1
+   1373   1377     1
+   1373   1379     1
+   1373   1380     1
+   1373   1381     1
+   1373   1382     1
+   1374   1379     1
+   1374   1380     1
+   1374   1381     1
+   1374   1382     1
+   1375   1378     1
+   1376   1378     1
+   1377   1378     1
+   1378   1382     1
+   1382   1387     1
+   1382   1388     1
+   1382   1396     1
+   1383   1385     1
+   1383   1386     1
+   1384   1389     1
+   1384   1390     1
+   1384   1391     1
+   1384   1397     1
+   1384   1398     1
+   1385   1387     1
+   1385   1388     1
+   1385   1396     1
+   1386   1392     1
+   1386   1393     1
+   1386   1399     1
+   1386   1400     1
+   1387   1389     1
+   1387   1390     1
+   1387   1391     1
+   1387   1397     1
+   1387   1398     1
+   1388   1394     1
+   1388   1395     1
+   1388   1397     1
+   1388   1398     1
+   1389   1392     1
+   1389   1393     1
+   1389   1396     1
+   1390   1392     1
+   1390   1393     1
+   1390   1396     1
+   1391   1396     1
+   1392   1394     1
+   1392   1395     1
+   1396   1401     1
+   1396   1402     1
+   1396   1406     1
+   1397   1399     1
+   1397   1400     1
+   1398   1403     1
+   1398   1404     1
+   1398   1405     1
+   1398   1407     1
+   1398   1408     1
+   1399   1401     1
+   1399   1402     1
+   1399   1406     1
+   1400   1409     1
+   1400   1410     1
+   1401   1403     1
+   1401   1404     1
+   1401   1405     1
+   1401   1407     1
+   1401   1408     1
+   1402   1407     1
+   1402   1408     1
+   1403   1406     1
+   1404   1406     1
+   1405   1406     1
+   1406   1411     1
+   1406   1412     1
+   1406   1416     1
+   1407   1409     1
+   1407   1410     1
+   1408   1413     1
+   1408   1414     1
+   1408   1415     1
+   1408   1417     1
+   1408   1418     1
+   1409   1411     1
+   1409   1412     1
+   1409   1416     1
+   1410   1419     1
+   1410   1420     1
+   1411   1413     1
+   1411   1414     1
+   1411   1415     1
+   1411   1417     1
+   1411   1418     1
+   1412   1417     1
+   1412   1418     1
+   1413   1416     1
+   1414   1416     1
+   1415   1416     1
+   1416   1421     1
+   1416   1422     1
+   1416   1438     1
+   1417   1419     1
+   1417   1420     1
+   1418   1423     1
+   1418   1424     1
+   1418   1425     1
+   1418   1439     1
+   1418   1440     1
+   1419   1421     1
+   1419   1422     1
+   1419   1438     1
+   1420   1426     1
+   1420   1427     1
+   1420   1428     1
+   1420   1441     1
+   1420   1442     1
+   1421   1423     1
+   1421   1424     1
+   1421   1425     1
+   1421   1439     1
+   1421   1440     1
+   1422   1429     1
+   1422   1430     1
+   1422   1431     1
+   1422   1439     1
+   1422   1440     1
+   1423   1426     1
+   1423   1427     1
+   1423   1428     1
+   1423   1438     1
+   1424   1426     1
+   1424   1427     1
+   1424   1428     1
+   1424   1438     1
+   1425   1432     1
+   1425   1433     1
+   1425   1434     1
+   1425   1438     1
+   1426   1429     1
+   1426   1430     1
+   1426   1431     1
+   1427   1429     1
+   1427   1430     1
+   1427   1431     1
+   1428   1435     1
+   1428   1436     1
+   1428   1437     1
+   1429   1432     1
+   1429   1433     1
+   1429   1434     1
+   1430   1432     1
+   1430   1433     1
+   1430   1434     1
+   1432   1435     1
+   1432   1436     1
+   1432   1437     1
+   1433   1435     1
+   1433   1436     1
+   1433   1437     1
+   1438   1443     1
+   1438   1444     1
+   1438   1460     1
+   1439   1441     1
+   1439   1442     1
+   1440   1445     1
+   1440   1446     1
+   1440   1447     1
+   1440   1461     1
+   1440   1462     1
+   1441   1443     1
+   1441   1444     1
+   1441   1460     1
+   1442   1448     1
+   1442   1449     1
+   1442   1450     1
+   1442   1463     1
+   1442   1464     1
+   1443   1445     1
+   1443   1446     1
+   1443   1447     1
+   1443   1461     1
+   1443   1462     1
+   1444   1451     1
+   1444   1452     1
+   1444   1453     1
+   1444   1461     1
+   1444   1462     1
+   1445   1448     1
+   1445   1449     1
+   1445   1450     1
+   1445   1460     1
+   1446   1448     1
+   1446   1449     1
+   1446   1450     1
+   1446   1460     1
+   1447   1454     1
+   1447   1455     1
+   1447   1456     1
+   1447   1460     1
+   1448   1451     1
+   1448   1452     1
+   1448   1453     1
+   1449   1451     1
+   1449   1452     1
+   1449   1453     1
+   1450   1457     1
+   1450   1458     1
+   1450   1459     1
+   1451   1454     1
+   1451   1455     1
+   1451   1456     1
+   1452   1454     1
+   1452   1455     1
+   1452   1456     1
+   1454   1457     1
+   1454   1458     1
+   1454   1459     1
+   1455   1457     1
+   1455   1458     1
+   1455   1459     1
+   1460   1465     1
+   1460   1466     1
+   1460   1479     1
+   1461   1463     1
+   1461   1464     1
+   1462   1467     1
+   1462   1468     1
+   1462   1472     1
+   1462   1480     1
+   1462   1481     1
+   1463   1465     1
+   1463   1466     1
+   1463   1479     1
+   1464   1469     1
+   1464   1470     1
+   1464   1471     1
+   1464   1473     1
+   1464   1474     1
+   1464   1475     1
+   1464   1482     1
+   1464   1483     1
+   1465   1467     1
+   1465   1468     1
+   1465   1472     1
+   1465   1480     1
+   1465   1481     1
+   1466   1476     1
+   1466   1477     1
+   1466   1478     1
+   1466   1480     1
+   1466   1481     1
+   1467   1469     1
+   1467   1470     1
+   1467   1471     1
+   1467   1473     1
+   1467   1474     1
+   1467   1475     1
+   1467   1479     1
+   1468   1473     1
+   1468   1474     1
+   1468   1475     1
+   1468   1479     1
+   1469   1472     1
+   1470   1472     1
+   1471   1472     1
+   1472   1479     1
+   1473   1476     1
+   1473   1477     1
+   1473   1478     1
+   1474   1476     1
+   1474   1477     1
+   1474   1478     1
+   1479   1484     1
+   1479   1485     1
+   1479   1495     1
+   1480   1482     1
+   1480   1483     1
+   1481   1486     1
+   1481   1487     1
+   1481   1491     1
+   1481   1496     1
+   1481   1497     1
+   1482   1484     1
+   1482   1485     1
+   1482   1495     1
+   1483   1488     1
+   1483   1489     1
+   1483   1490     1
+   1483   1492     1
+   1483   1493     1
+   1483   1494     1
+   1483   1498     1
+   1483   1499     1
+   1484   1486     1
+   1484   1487     1
+   1484   1491     1
+   1484   1496     1
+   1484   1497     1
+   1485   1496     1
+   1485   1497     1
+   1486   1488     1
+   1486   1489     1
+   1486   1490     1
+   1486   1492     1
+   1486   1493     1
+   1486   1494     1
+   1486   1495     1
+   1487   1492     1
+   1487   1493     1
+   1487   1494     1
+   1487   1495     1
+   1488   1491     1
+   1489   1491     1
+   1490   1491     1
+   1491   1495     1
+   1495   1500     1
+   1495   1501     1
+   1495   1506     1
+   1496   1498     1
+   1496   1499     1
+   1497   1502     1
+   1497   1503     1
+   1497   1504     1
+   1497   1507     1
+   1497   1508     1
+   1498   1500     1
+   1498   1501     1
+   1498   1506     1
+   1499   1505     1
+   1499   1509     1
+   1499   1510     1
+   1500   1502     1
+   1500   1503     1
+   1500   1504     1
+   1500   1507     1
+   1500   1508     1
+   1501   1507     1
+   1501   1508     1
+   1502   1505     1
+   1502   1506     1
+   1503   1505     1
+   1503   1506     1
+   1504   1506     1
+   1506   1511     1
+   1506   1512     1
+   1506   1518     1
+   1507   1509     1
+   1507   1510     1
+   1508   1513     1
+   1508   1514     1
+   1508   1515     1
+   1508   1519     1
+   1508   1520     1
+   1509   1511     1
+   1509   1512     1
+   1509   1518     1
+   1510   1516     1
+   1510   1517     1
+   1510   1521     1
+   1510   1522     1
+   1511   1513     1
+   1511   1514     1
+   1511   1515     1
+   1511   1519     1
+   1511   1520     1
+   1512   1519     1
+   1512   1520     1
+   1513   1516     1
+   1513   1517     1
+   1513   1518     1
+   1514   1516     1
+   1514   1517     1
+   1514   1518     1
+   1515   1518     1
+   1518   1523     1
+   1518   1524     1
+   1518   1525     1
+   1519   1521     1
+   1519   1522     1
+   1520   1526     1
+   1520   1527     1
+   1521   1523     1
+   1521   1524     1
+   1521   1525     1
+   1522   1528     1
+   1522   1529     1
+   1523   1526     1
+   1523   1527     1
+   1524   1526     1
+   1524   1527     1
+   1525   1530     1
+   1525   1531     1
+   1525   1539     1
+   1526   1528     1
+   1526   1529     1
+   1527   1532     1
+   1527   1533     1
+   1527   1534     1
+   1527   1540     1
+   1527   1541     1
+   1528   1530     1
+   1528   1531     1
+   1528   1539     1
+   1529   1535     1
+   1529   1536     1
+   1529   1542     1
+   1529   1543     1
+   1530   1532     1
+   1530   1533     1
+   1530   1534     1
+   1530   1540     1
+   1530   1541     1
+   1531   1537     1
+   1531   1538     1
+   1531   1540     1
+   1531   1541     1
+   1532   1535     1
+   1532   1536     1
+   1532   1539     1
+   1533   1535     1
+   1533   1536     1
+   1533   1539     1
+   1534   1539     1
+   1535   1537     1
+   1535   1538     1
+   1539   1544     1
+   1539   1545     1
+   1539   1546     1
+   1540   1542     1
+   1540   1543     1
+   1541   1547     1
+   1541   1548     1
+   1542   1544     1
+   1542   1545     1
+   1542   1546     1
+   1543   1549     1
+   1543   1550     1
+   1544   1547     1
+   1544   1548     1
+   1545   1547     1
+   1545   1548     1
+   1546   1551     1
+   1546   1552     1
+   1546   1563     1
+   1547   1549     1
+   1547   1550     1
+   1548   1553     1
+   1548   1554     1
+   1548   1555     1
+   1548   1564     1
+   1548   1565     1
+   1549   1551     1
+   1549   1552     1
+   1549   1563     1
+   1550   1556     1
+   1550   1557     1
+   1550   1558     1
+   1550   1566     1
+   1550   1567     1
+   1551   1553     1
+   1551   1554     1
+   1551   1555     1
+   1551   1564     1
+   1551   1565     1
+   1552   1559     1
+   1552   1564     1
+   1552   1565     1
+   1553   1556     1
+   1553   1557     1
+   1553   1558     1
+   1553   1563     1
+   1554   1556     1
+   1554   1557     1
+   1554   1558     1
+   1554   1563     1
+   1555   1560     1
+   1555   1561     1
+   1555   1562     1
+   1555   1563     1
+   1556   1559     1
+   1557   1559     1
+   1563   1568     1
+   1563   1569     1
+   1563   1577     1
+   1564   1566     1
+   1564   1567     1
+   1565   1570     1
+   1565   1571     1
+   1565   1572     1
+   1565   1578     1
+   1565   1579     1
+   1566   1568     1
+   1566   1569     1
+   1566   1577     1
+   1567   1573     1
+   1567   1574     1
+   1567   1580     1
+   1567   1581     1
+   1568   1570     1
+   1568   1571     1
+   1568   1572     1
+   1568   1578     1
+   1568   1579     1
+   1569   1575     1
+   1569   1576     1
+   1569   1578     1
+   1569   1579     1
+   1570   1573     1
+   1570   1574     1
+   1570   1577     1
+   1571   1573     1
+   1571   1574     1
+   1571   1577     1
+   1572   1577     1
+   1573   1575     1
+   1573   1576     1
+   1577   1582     1
+   1577   1583     1
+   1577   1587     1
+   1578   1580     1
+   1578   1581     1
+   1579   1584     1
+   1579   1585     1
+   1579   1586     1
+   1579   1588     1
+   1579   1589     1
+   1580   1582     1
+   1580   1583     1
+   1580   1587     1
+   1581   1590     1
+   1581   1591     1
+   1582   1584     1
+   1582   1585     1
+   1582   1586     1
+   1582   1588     1
+   1582   1589     1
+   1583   1588     1
+   1583   1589     1
+   1584   1587     1
+   1585   1587     1
+   1586   1587     1
+   1587   1592     1
+   1587   1593     1
+   1587   1611     1
+   1588   1590     1
+   1588   1591     1
+   1589   1594     1
+   1589   1595     1
+   1589   1596     1
+   1589   1612     1
+   1589   1613     1
+   1590   1592     1
+   1590   1593     1
+   1590   1611     1
+   1591   1597     1
+   1591   1610     1
+   1591   1614     1
+   1591   1615     1
+   1592   1594     1
+   1592   1595     1
+   1592   1596     1
+   1592   1612     1
+   1592   1613     1
+   1593   1598     1
+   1593   1599     1
+   1593   1601     1
+   1593   1608     1
+   1593   1612     1
+   1593   1613     1
+   1594   1597     1
+   1594   1610     1
+   1594   1611     1
+   1595   1597     1
+   1595   1610     1
+   1595   1611     1
+   1596   1600     1
+   1596   1602     1
+   1596   1606     1
+   1596   1609     1
+   1596   1611     1
+   1597   1602     1
+   1597   1608     1
+   1598   1600     1
+   1598   1601     1
+   1598   1610     1
+   1599   1603     1
+   1599   1604     1
+   1599   1608     1
+   1600   1602     1
+   1600   1610     1
+   1601   1605     1
+   1601   1606     1
+   1601   1609     1
+   1602   1607     1
+   1602   1608     1
+   1603   1605     1
+   1603   1606     1
+   1603   1610     1
+   1604   1609     1
+   1604   1610     1
+   1605   1607     1
+   1605   1608     1
+   1607   1609     1
+   1607   1610     1
+   1611   1616     1
+   1611   1617     1
+   1611   1627     1
+   1612   1614     1
+   1612   1615     1
+   1613   1618     1
+   1613   1619     1
+   1613   1623     1
+   1613   1628     1
+   1613   1629     1
+   1614   1616     1
+   1614   1617     1
+   1614   1627     1
+   1615   1620     1
+   1615   1621     1
+   1615   1622     1
+   1615   1624     1
+   1615   1625     1
+   1615   1626     1
+   1615   1630     1
+   1615   1631     1
+   1616   1618     1
+   1616   1619     1
+   1616   1623     1
+   1616   1628     1
+   1616   1629     1
+   1617   1628     1
+   1617   1629     1
+   1618   1620     1
+   1618   1621     1
+   1618   1622     1
+   1618   1624     1
+   1618   1625     1
+   1618   1626     1
+   1618   1627     1
+   1619   1624     1
+   1619   1625     1
+   1619   1626     1
+   1619   1627     1
+   1620   1623     1
+   1621   1623     1
+   1622   1623     1
+   1623   1627     1
+   1627   1632     1
+   1627   1633     1
+   1627   1637     1
+   1628   1630     1
+   1628   1631     1
+   1629   1634     1
+   1629   1635     1
+   1629   1636     1
+   1629   1638     1
+   1629   1639     1
+   1630   1632     1
+   1630   1633     1
+   1630   1637     1
+   1631   1640     1
+   1631   1641     1
+   1632   1634     1
+   1632   1635     1
+   1632   1636     1
+   1632   1638     1
+   1632   1639     1
+   1633   1638     1
+   1633   1639     1
+   1634   1637     1
+   1635   1637     1
+   1636   1637     1
+   1637   1642     1
+   1637   1643     1
+   1637   1661     1
+   1638   1640     1
+   1638   1641     1
+   1639   1644     1
+   1639   1645     1
+   1639   1646     1
+   1639   1662     1
+   1639   1663     1
+   1640   1642     1
+   1640   1643     1
+   1640   1661     1
+   1641   1647     1
+   1641   1660     1
+   1641   1664     1
+   1641   1665     1
+   1642   1644     1
+   1642   1645     1
+   1642   1646     1
+   1642   1662     1
+   1642   1663     1
+   1643   1648     1
+   1643   1649     1
+   1643   1651     1
+   1643   1658     1
+   1643   1662     1
+   1643   1663     1
+   1644   1647     1
+   1644   1660     1
+   1644   1661     1
+   1645   1647     1
+   1645   1660     1
+   1645   1661     1
+   1646   1650     1
+   1646   1652     1
+   1646   1656     1
+   1646   1659     1
+   1646   1661     1
+   1647   1652     1
+   1647   1658     1
+   1648   1650     1
+   1648   1651     1
+   1648   1660     1
+   1649   1653     1
+   1649   1654     1
+   1649   1658     1
+   1650   1652     1
+   1650   1660     1
+   1651   1655     1
+   1651   1656     1
+   1651   1659     1
+   1652   1657     1
+   1652   1658     1
+   1653   1655     1
+   1653   1656     1
+   1653   1660     1
+   1654   1659     1
+   1654   1660     1
+   1655   1657     1
+   1655   1658     1
+   1657   1659     1
+   1657   1660     1
+   1661   1666     1
+   1661   1667     1
+   1661   1685     1
+   1662   1664     1
+   1662   1665     1
+   1663   1668     1
+   1663   1669     1
+   1663   1670     1
+   1663   1686     1
+   1663   1687     1
+   1664   1666     1
+   1664   1667     1
+   1664   1685     1
+   1665   1671     1
+   1665   1672     1
+   1665   1673     1
+   1665   1688     1
+   1665   1689     1
+   1666   1668     1
+   1666   1669     1
+   1666   1670     1
+   1666   1686     1
+   1666   1687     1
+   1667   1674     1
+   1667   1675     1
+   1667   1676     1
+   1667   1686     1
+   1667   1687     1
+   1668   1671     1
+   1668   1672     1
+   1668   1673     1
+   1668   1685     1
+   1669   1671     1
+   1669   1672     1
+   1669   1673     1
+   1669   1685     1
+   1670   1677     1
+   1670   1678     1
+   1670   1685     1
+   1671   1674     1
+   1671   1675     1
+   1671   1676     1
+   1672   1674     1
+   1672   1675     1
+   1672   1676     1
+   1673   1679     1
+   1673   1682     1
+   1674   1677     1
+   1674   1678     1
+   1675   1677     1
+   1675   1678     1
+   1676   1680     1
+   1676   1681     1
+   1676   1683     1
+   1676   1684     1
+   1677   1679     1
+   1677   1682     1
+   1679   1683     1
+   1679   1684     1
+   1680   1682     1
+   1681   1682     1
+   1685   1690     1
+   1685   1691     1
+   1685   1699     1
+   1686   1688     1
+   1686   1689     1
+   1687   1692     1
+   1687   1693     1
+   1687   1694     1
+   1687   1700     1
+   1687   1701     1
+   1688   1690     1
+   1688   1691     1
+   1688   1699     1
+   1689   1695     1
+   1689   1696     1
+   1689   1702     1
+   1689   1703     1
+   1690   1692     1
+   1690   1693     1
+   1690   1694     1
+   1690   1700     1
+   1690   1701     1
+   1691   1697     1
+   1691   1698     1
+   1691   1700     1
+   1691   1701     1
+   1692   1695     1
+   1692   1696     1
+   1692   1699     1
+   1693   1695     1
+   1693   1696     1
+   1693   1699     1
+   1694   1699     1
+   1695   1697     1
+   1695   1698     1
+   1699   1704     1
+   1699   1705     1
+   1699   1723     1
+   1700   1702     1
+   1700   1703     1
+   1701   1706     1
+   1701   1707     1
+   1701   1708     1
+   1701   1724     1
+   1701   1725     1
+   1702   1704     1
+   1702   1705     1
+   1702   1723     1
+   1703   1709     1
+   1703   1710     1
+   1703   1711     1
+   1703   1726     1
+   1703   1727     1
+   1704   1706     1
+   1704   1707     1
+   1704   1708     1
+   1704   1724     1
+   1704   1725     1
+   1705   1712     1
+   1705   1713     1
+   1705   1714     1
+   1705   1724     1
+   1705   1725     1
+   1706   1709     1
+   1706   1710     1
+   1706   1711     1
+   1706   1723     1
+   1707   1709     1
+   1707   1710     1
+   1707   1711     1
+   1707   1723     1
+   1708   1715     1
+   1708   1716     1
+   1708   1723     1
+   1709   1712     1
+   1709   1713     1
+   1709   1714     1
+   1710   1712     1
+   1710   1713     1
+   1710   1714     1
+   1711   1717     1
+   1711   1720     1
+   1712   1715     1
+   1712   1716     1
+   1713   1715     1
+   1713   1716     1
+   1714   1718     1
+   1714   1719     1
+   1714   1721     1
+   1714   1722     1
+   1715   1717     1
+   1715   1720     1
+   1717   1721     1
+   1717   1722     1
+   1718   1720     1
+   1719   1720     1
+   1723   1728     1
+   1723   1729     1
+   1723   1733     1
+   1724   1726     1
+   1724   1727     1
+   1725   1730     1
+   1725   1731     1
+   1725   1732     1
+   1725   1734     1
+   1725   1735     1
+   1726   1728     1
+   1726   1729     1
+   1726   1733     1
+   1727   1736     1
+   1727   1737     1
+   1728   1730     1
+   1728   1731     1
+   1728   1732     1
+   1728   1734     1
+   1728   1735     1
+   1729   1734     1
+   1729   1735     1
+   1730   1733     1
+   1731   1733     1
+   1732   1733     1
+   1733   1738     1
+   1733   1739     1
+   1733   1755     1
+   1734   1736     1
+   1734   1737     1
+   1735   1740     1
+   1735   1741     1
+   1735   1742     1
+   1735   1756     1
+   1735   1757     1
+   1736   1738     1
+   1736   1739     1
+   1736   1755     1
+   1737   1743     1
+   1737   1744     1
+   1737   1745     1
+   1737   1758     1
+   1737   1759     1
+   1738   1740     1
+   1738   1741     1
+   1738   1742     1
+   1738   1756     1
+   1738   1757     1
+   1739   1746     1
+   1739   1747     1
+   1739   1748     1
+   1739   1756     1
+   1739   1757     1
+   1740   1743     1
+   1740   1744     1
+   1740   1745     1
+   1740   1755     1
+   1741   1743     1
+   1741   1744     1
+   1741   1745     1
+   1741   1755     1
+   1742   1749     1
+   1742   1750     1
+   1742   1751     1
+   1742   1755     1
+   1743   1746     1
+   1743   1747     1
+   1743   1748     1
+   1744   1746     1
+   1744   1747     1
+   1744   1748     1
+   1745   1752     1
+   1745   1753     1
+   1745   1754     1
+   1746   1749     1
+   1746   1750     1
+   1746   1751     1
+   1747   1749     1
+   1747   1750     1
+   1747   1751     1
+   1749   1752     1
+   1749   1753     1
+   1749   1754     1
+   1750   1752     1
+   1750   1753     1
+   1750   1754     1
+   1755   1760     1
+   1755   1761     1
+   1755   1762     1
+   1756   1758     1
+   1756   1759     1
+   1757   1763     1
+   1757   1764     1
+   1758   1760     1
+   1758   1761     1
+   1758   1762     1
+   1759   1765     1
+   1759   1766     1
+   1760   1763     1
+   1760   1764     1
+   1761   1763     1
+   1761   1764     1
+   1762   1767     1
+   1762   1768     1
+   1762   1776     1
+   1763   1765     1
+   1763   1766     1
+   1764   1769     1
+   1764   1770     1
+   1764   1774     1
+   1764   1777     1
+   1764   1778     1
+   1765   1767     1
+   1765   1768     1
+   1765   1776     1
+   1766   1771     1
+   1766   1772     1
+   1766   1773     1
+   1766   1775     1
+   1766   1779     1
+   1766   1780     1
+   1767   1769     1
+   1767   1770     1
+   1767   1774     1
+   1767   1777     1
+   1767   1778     1
+   1768   1777     1
+   1768   1778     1
+   1769   1771     1
+   1769   1772     1
+   1769   1773     1
+   1769   1775     1
+   1769   1776     1
+   1770   1775     1
+   1770   1776     1
+   1771   1774     1
+   1772   1774     1
+   1773   1774     1
+   1774   1776     1
+   1776   1781     1
+   1776   1782     1
+   1776   1788     1
+   1777   1779     1
+   1777   1780     1
+   1778   1783     1
+   1778   1784     1
+   1778   1785     1
+   1778   1789     1
+   1778   1790     1
+   1779   1781     1
+   1779   1782     1
+   1779   1788     1
+   1780   1786     1
+   1780   1787     1
+   1780   1791     1
+   1780   1792     1
+   1781   1783     1
+   1781   1784     1
+   1781   1785     1
+   1781   1789     1
+   1781   1790     1
+   1782   1789     1
+   1782   1790     1
+   1783   1786     1
+   1783   1787     1
+   1783   1788     1
+   1784   1786     1
+   1784   1787     1
+   1784   1788     1
+   1785   1788     1
+   1788   1793     1
+   1788   1794     1
+   1788   1804     1
+   1789   1791     1
+   1789   1792     1
+   1790   1795     1
+   1790   1796     1
+   1790   1800     1
+   1790   1805     1
+   1790   1806     1
+   1791   1793     1
+   1791   1794     1
+   1791   1804     1
+   1792   1797     1
+   1792   1798     1
+   1792   1799     1
+   1792   1801     1
+   1792   1802     1
+   1792   1803     1
+   1792   1807     1
+   1792   1808     1
+   1793   1795     1
+   1793   1796     1
+   1793   1800     1
+   1793   1805     1
+   1793   1806     1
+   1794   1805     1
+   1794   1806     1
+   1795   1797     1
+   1795   1798     1
+   1795   1799     1
+   1795   1801     1
+   1795   1802     1
+   1795   1803     1
+   1795   1804     1
+   1796   1801     1
+   1796   1802     1
+   1796   1803     1
+   1796   1804     1
+   1797   1800     1
+   1798   1800     1
+   1799   1800     1
+   1800   1804     1
+   1804   1809     1
+   1804   1810     1
+   1804   1821     1
+   1805   1807     1
+   1805   1808     1
+   1806   1811     1
+   1806   1812     1
+   1806   1813     1
+   1806   1822     1
+   1806   1823     1
+   1807   1809     1
+   1807   1810     1
+   1807   1821     1
+   1808   1814     1
+   1808   1815     1
+   1808   1816     1
+   1808   1824     1
+   1808   1825     1
+   1809   1811     1
+   1809   1812     1
+   1809   1813     1
+   1809   1822     1
+   1809   1823     1
+   1810   1817     1
+   1810   1818     1
+   1810   1822     1
+   1810   1823     1
+   1811   1814     1
+   1811   1815     1
+   1811   1816     1
+   1811   1821     1
+   1812   1814     1
+   1812   1815     1
+   1812   1816     1
+   1812   1821     1
+   1813   1819     1
+   1813   1820     1
+   1813   1821     1
+   1814   1817     1
+   1814   1818     1
+   1815   1817     1
+   1815   1818     1
+   1817   1819     1
+   1817   1820     1
+   1821   1826     1
+   1821   1827     1
+   1821   1831     1
+   1822   1824     1
+   1822   1825     1
+   1823   1828     1
+   1823   1829     1
+   1823   1830     1
+   1823   1832     1
+   1823   1833     1
+   1824   1826     1
+   1824   1827     1
+   1824   1831     1
+   1825   1834     1
+   1825   1835     1
+   1826   1828     1
+   1826   1829     1
+   1826   1830     1
+   1826   1832     1
+   1826   1833     1
+   1827   1832     1
+   1827   1833     1
+   1828   1831     1
+   1829   1831     1
+   1830   1831     1
+   1831   1836     1
+   1831   1837     1
+   1831   1855     1
+   1832   1834     1
+   1832   1835     1
+   1833   1838     1
+   1833   1839     1
+   1833   1840     1
+   1833   1856     1
+   1833   1857     1
+   1834   1836     1
+   1834   1837     1
+   1834   1855     1
+   1835   1841     1
+   1835   1854     1
+   1835   1858     1
+   1835   1859     1
+   1836   1838     1
+   1836   1839     1
+   1836   1840     1
+   1836   1856     1
+   1836   1857     1
+   1837   1842     1
+   1837   1843     1
+   1837   1845     1
+   1837   1852     1
+   1837   1856     1
+   1837   1857     1
+   1838   1841     1
+   1838   1854     1
+   1838   1855     1
+   1839   1841     1
+   1839   1854     1
+   1839   1855     1
+   1840   1844     1
+   1840   1846     1
+   1840   1850     1
+   1840   1853     1
+   1840   1855     1
+   1841   1846     1
+   1841   1852     1
+   1842   1844     1
+   1842   1845     1
+   1842   1854     1
+   1843   1847     1
+   1843   1848     1
+   1843   1852     1
+   1844   1846     1
+   1844   1854     1
+   1845   1849     1
+   1845   1850     1
+   1845   1853     1
+   1846   1851     1
+   1846   1852     1
+   1847   1849     1
+   1847   1850     1
+   1847   1854     1
+   1848   1853     1
+   1848   1854     1
+   1849   1851     1
+   1849   1852     1
+   1851   1853     1
+   1851   1854     1
+   1855   1860     1
+   1855   1861     1
+   1855   1874     1
+   1856   1858     1
+   1856   1859     1
+   1857   1862     1
+   1857   1863     1
+   1857   1867     1
+   1857   1875     1
+   1857   1876     1
+   1858   1860     1
+   1858   1861     1
+   1858   1874     1
+   1859   1864     1
+   1859   1865     1
+   1859   1866     1
+   1859   1868     1
+   1859   1869     1
+   1859   1870     1
+   1859   1877     1
+   1859   1878     1
+   1860   1862     1
+   1860   1863     1
+   1860   1867     1
+   1860   1875     1
+   1860   1876     1
+   1861   1871     1
+   1861   1872     1
+   1861   1873     1
+   1861   1875     1
+   1861   1876     1
+   1862   1864     1
+   1862   1865     1
+   1862   1866     1
+   1862   1868     1
+   1862   1869     1
+   1862   1870     1
+   1862   1874     1
+   1863   1868     1
+   1863   1869     1
+   1863   1870     1
+   1863   1874     1
+   1864   1867     1
+   1865   1867     1
+   1866   1867     1
+   1867   1874     1
+   1868   1871     1
+   1868   1872     1
+   1868   1873     1
+   1869   1871     1
+   1869   1872     1
+   1869   1873     1
+   1874   1879     1
+   1874   1880     1
+   1874   1898     1
+   1875   1877     1
+   1875   1878     1
+   1876   1881     1
+   1876   1882     1
+   1876   1883     1
+   1876   1899     1
+   1876   1900     1
+   1877   1879     1
+   1877   1880     1
+   1877   1898     1
+   1878   1884     1
+   1878   1885     1
+   1878   1886     1
+   1878   1901     1
+   1878   1902     1
+   1879   1881     1
+   1879   1882     1
+   1879   1883     1
+   1879   1899     1
+   1879   1900     1
+   1880   1887     1
+   1880   1888     1
+   1880   1889     1
+   1880   1899     1
+   1880   1900     1
+   1881   1884     1
+   1881   1885     1
+   1881   1886     1
+   1881   1898     1
+   1882   1884     1
+   1882   1885     1
+   1882   1886     1
+   1882   1898     1
+   1883   1890     1
+   1883   1891     1
+   1883   1898     1
+   1884   1887     1
+   1884   1888     1
+   1884   1889     1
+   1885   1887     1
+   1885   1888     1
+   1885   1889     1
+   1886   1892     1
+   1886   1895     1
+   1887   1890     1
+   1887   1891     1
+   1888   1890     1
+   1888   1891     1
+   1889   1893     1
+   1889   1894     1
+   1889   1896     1
+   1889   1897     1
+   1890   1892     1
+   1890   1895     1
+   1892   1896     1
+   1892   1897     1
+   1893   1895     1
+   1894   1895     1
+   1898   1903     1
+   1898   1904     1
+   1898   1905     1
+   1899   1901     1
+   1899   1902     1
+   1900   1906     1
+   1900   1907     1
+   1901   1903     1
+   1901   1904     1
+   1901   1905     1
+   1902   1908     1
+   1902   1909     1
+   1903   1906     1
+   1903   1907     1
+   1904   1906     1
+   1904   1907     1
+   1905   1910     1
+   1905   1911     1
+   1905   1915     1
+   1906   1908     1
+   1906   1909     1
+   1907   1912     1
+   1907   1913     1
+   1907   1914     1
+   1907   1916     1
+   1907   1917     1
+   1908   1910     1
+   1908   1911     1
+   1908   1915     1
+   1909   1918     1
+   1909   1919     1
+   1910   1912     1
+   1910   1913     1
+   1910   1914     1
+   1910   1916     1
+   1910   1917     1
+   1911   1916     1
+   1911   1917     1
+   1912   1915     1
+   1913   1915     1
+   1914   1915     1
+   1915   1920     1
+   1915   1921     1
+   1915   1939     1
+   1916   1918     1
+   1916   1919     1
+   1917   1922     1
+   1917   1923     1
+   1917   1924     1
+   1917   1940     1
+   1917   1941     1
+   1918   1920     1
+   1918   1921     1
+   1918   1939     1
+   1919   1925     1
+   1919   1926     1
+   1919   1927     1
+   1919   1942     1
+   1919   1943     1
+   1920   1922     1
+   1920   1923     1
+   1920   1924     1
+   1920   1940     1
+   1920   1941     1
+   1921   1928     1
+   1921   1929     1
+   1921   1930     1
+   1921   1940     1
+   1921   1941     1
+   1922   1925     1
+   1922   1926     1
+   1922   1927     1
+   1922   1939     1
+   1923   1925     1
+   1923   1926     1
+   1923   1927     1
+   1923   1939     1
+   1924   1931     1
+   1924   1932     1
+   1924   1939     1
+   1925   1928     1
+   1925   1929     1
+   1925   1930     1
+   1926   1928     1
+   1926   1929     1
+   1926   1930     1
+   1927   1933     1
+   1927   1936     1
+   1928   1931     1
+   1928   1932     1
+   1929   1931     1
+   1929   1932     1
+   1930   1934     1
+   1930   1935     1
+   1930   1937     1
+   1930   1938     1
+   1931   1933     1
+   1931   1936     1
+   1933   1937     1
+   1933   1938     1
+   1934   1936     1
+   1935   1936     1
+   1939   1944     1
+   1939   1945     1
+   1939   1958     1
+   1940   1942     1
+   1940   1943     1
+   1941   1946     1
+   1941   1947     1
+   1941   1948     1
+   1941   1959     1
+   1941   1960     1
+   1942   1944     1
+   1942   1945     1
+   1942   1958     1
+   1943   1949     1
+   1943   1950     1
+   1943   1954     1
+   1944   1946     1
+   1944   1947     1
+   1944   1948     1
+   1944   1959     1
+   1944   1960     1
+   1945   1951     1
+   1945   1952     1
+   1945   1953     1
+   1945   1955     1
+   1945   1956     1
+   1945   1957     1
+   1945   1959     1
+   1945   1960     1
+   1946   1949     1
+   1946   1950     1
+   1946   1954     1
+   1946   1958     1
+   1947   1949     1
+   1947   1950     1
+   1947   1954     1
+   1947   1958     1
+   1948   1958     1
+   1949   1951     1
+   1949   1952     1
+   1949   1953     1
+   1949   1955     1
+   1949   1956     1
+   1949   1957     1
+   1950   1955     1
+   1950   1956     1
+   1950   1957     1
+   1951   1954     1
+   1952   1954     1
+   1953   1954     1
+
+[ angles ]
+;    ai     aj     ak funct         c0         c1         c2         c3
+      2      1      3     1
+      2      1      4     1
+      2      1      5     1
+      3      1      4     1
+      3      1      5     1
+      4      1      5     1
+      1      5      6     1
+      1      5      7     1
+      1      5     23     1
+      6      5      7     1
+      6      5     23     1
+      7      5     23     1
+      5      7      8     1
+      5      7      9     1
+      5      7     10     1
+      8      7      9     1
+      8      7     10     1
+      9      7     10     1
+      7     10     11     1
+      7     10     12     1
+      7     10     13     1
+     11     10     12     1
+     11     10     13     1
+     12     10     13     1
+     10     13     14     1
+     10     13     15     1
+     10     13     16     1
+     14     13     15     1
+     14     13     16     1
+     15     13     16     1
+     13     16     17     1
+     13     16     18     1
+     13     16     19     1
+     17     16     18     1
+     17     16     19     1
+     18     16     19     1
+     16     19     20     1
+     16     19     21     1
+     16     19     22     1
+     20     19     21     1
+     20     19     22     1
+     21     19     22     1
+      5     23     24     1
+      5     23     25     1
+     24     23     25     1
+     23     25     26     1
+     23     25     27     1
+     26     25     27     1
+     25     27     28     1
+     25     27     29     1
+     25     27     39     1
+     28     27     29     1
+     28     27     39     1
+     29     27     39     1
+     27     29     30     1
+     27     29     31     1
+     27     29     35     1
+     30     29     31     1
+     30     29     35     1
+     31     29     35     1
+     29     31     32     1
+     29     31     33     1
+     29     31     34     1
+     32     31     33     1
+     32     31     34     1
+     33     31     34     1
+     29     35     36     1
+     29     35     37     1
+     29     35     38     1
+     36     35     37     1
+     36     35     38     1
+     37     35     38     1
+     27     39     40     1
+     27     39     41     1
+     40     39     41     1
+     39     41     42     1
+     39     41     43     1
+     42     41     43     1
+     41     43     44     1
+     41     43     45     1
+     41     43     59     1
+     44     43     45     1
+     44     43     59     1
+     45     43     59     1
+     43     45     46     1
+     43     45     47     1
+     43     45     48     1
+     46     45     47     1
+     46     45     48     1
+     47     45     48     1
+     45     48     49     1
+     45     48     57     1
+     49     48     57     1
+     48     49     50     1
+     48     49     51     1
+     50     49     51     1
+     49     51     52     1
+     49     51     53     1
+     52     51     53     1
+     51     53     54     1
+     51     53     55     1
+     54     53     55     1
+     53     55     56     1
+     53     55     57     1
+     56     55     57     1
+     48     57     55     1
+     48     57     58     1
+     55     57     58     1
+     43     59     60     1
+     43     59     61     1
+     60     59     61     1
+     59     61     62     1
+     59     61     63     1
+     62     61     63     1
+     61     63     64     1
+     61     63     65     1
+     61     63     66     1
+     64     63     65     1
+     64     63     66     1
+     65     63     66     1
+     63     66     67     1
+     63     66     68     1
+     67     66     68     1
+     66     68     69     1
+     66     68     70     1
+     69     68     70     1
+     68     70     71     1
+     68     70     72     1
+     68     70     90     1
+     71     70     72     1
+     71     70     90     1
+     72     70     90     1
+     70     72     73     1
+     70     72     74     1
+     70     72     75     1
+     73     72     74     1
+     73     72     75     1
+     74     72     75     1
+     72     75     76     1
+     72     75     77     1
+     72     75     78     1
+     76     75     77     1
+     76     75     78     1
+     77     75     78     1
+     75     78     79     1
+     75     78     80     1
+     75     78     81     1
+     79     78     80     1
+     79     78     81     1
+     80     78     81     1
+     78     81     82     1
+     78     81     83     1
+     82     81     83     1
+     81     83     84     1
+     81     83     87     1
+     84     83     87     1
+     83     84     85     1
+     83     84     86     1
+     85     84     86     1
+     83     87     88     1
+     83     87     89     1
+     88     87     89     1
+     70     90     91     1
+     70     90     92     1
+     91     90     92     1
+     90     92     93     1
+     90     92     94     1
+     93     92     94     1
+     92     94     95     1
+     92     94     96     1
+     92     94    100     1
+     95     94     96     1
+     95     94    100     1
+     96     94    100     1
+     94     96     97     1
+     94     96     98     1
+     94     96     99     1
+     97     96     98     1
+     97     96     99     1
+     98     96     99     1
+     96     99   1914     1
+     94    100    101     1
+     94    100    102     1
+    101    100    102     1
+    100    102    103     1
+    100    102    104     1
+    103    102    104     1
+    102    104    105     1
+    102    104    106     1
+    102    104    115     1
+    105    104    106     1
+    105    104    115     1
+    106    104    115     1
+    104    106    107     1
+    104    106    108     1
+    104    106    109     1
+    107    106    108     1
+    107    106    109     1
+    108    106    109     1
+    106    109    110     1
+    106    109    111     1
+    106    109    112     1
+    110    109    111     1
+    110    109    112     1
+    111    109    112     1
+    109    112    113     1
+    109    112    114     1
+    113    112    114     1
+    104    115    116     1
+    104    115    117     1
+    116    115    117     1
+    115    117    118     1
+    115    117    119     1
+    118    117    119     1
+    117    119    120     1
+    117    119    121     1
+    117    119    134     1
+    120    119    121     1
+    120    119    134     1
+    121    119    134     1
+    119    121    122     1
+    119    121    123     1
+    119    121    124     1
+    122    121    123     1
+    122    121    124     1
+    123    121    124     1
+    121    124    125     1
+    121    124    126     1
+    121    124    130     1
+    125    124    126     1
+    125    124    130     1
+    126    124    130     1
+    124    126    127     1
+    124    126    128     1
+    124    126    129     1
+    127    126    128     1
+    127    126    129     1
+    128    126    129     1
+    124    130    131     1
+    124    130    132     1
+    124    130    133     1
+    131    130    132     1
+    131    130    133     1
+    132    130    133     1
+    119    134    135     1
+    119    134    136     1
+    135    134    136     1
+    134    136    137     1
+    134    136    138     1
+    137    136    138     1
+    136    138    139     1
+    136    138    140     1
+    136    138    144     1
+    139    138    140     1
+    139    138    144     1
+    140    138    144     1
+    138    140    141     1
+    138    140    142     1
+    138    140    143     1
+    141    140    142     1
+    141    140    143     1
+    142    140    143     1
+    138    144    145     1
+    138    144    146     1
+    145    144    146     1
+    144    146    147     1
+    144    146    148     1
+    147    146    148     1
+    146    148    149     1
+    146    148    150     1
+    146    148    154     1
+    149    148    150     1
+    149    148    154     1
+    150    148    154     1
+    148    150    151     1
+    148    150    152     1
+    148    150    153     1
+    151    150    152     1
+    151    150    153     1
+    152    150    153     1
+    148    154    155     1
+    148    154    156     1
+    155    154    156     1
+    154    156    157     1
+    154    156    158     1
+    157    156    158     1
+    156    158    159     1
+    156    158    160     1
+    156    158    164     1
+    159    158    160     1
+    159    158    164     1
+    160    158    164     1
+    158    160    161     1
+    158    160    162     1
+    158    160    163     1
+    161    160    162     1
+    161    160    163     1
+    162    160    163     1
+    158    164    165     1
+    158    164    166     1
+    165    164    166     1
+    164    166    167     1
+    164    166    168     1
+    167    166    168     1
+    166    168    169     1
+    166    168    170     1
+    166    168    181     1
+    169    168    170     1
+    169    168    181     1
+    170    168    181     1
+    168    170    171     1
+    168    170    172     1
+    168    170    173     1
+    171    170    172     1
+    171    170    173     1
+    172    170    173     1
+    170    173    174     1
+    170    173    175     1
+    170    173    176     1
+    174    173    175     1
+    174    173    176     1
+    175    173    176     1
+    173    176    177     1
+    176    177    178     1
+    176    177    179     1
+    176    177    180     1
+    178    177    179     1
+    178    177    180     1
+    179    177    180     1
+    168    181    182     1
+    168    181    183     1
+    182    181    183     1
+    181    183    184     1
+    181    183    185     1
+    184    183    185     1
+    183    185    186     1
+    183    185    187     1
+    183    185    203     1
+    186    185    187     1
+    186    185    203     1
+    187    185    203     1
+    185    187    188     1
+    185    187    189     1
+    185    187    190     1
+    188    187    189     1
+    188    187    190     1
+    189    187    190     1
+    187    190    191     1
+    187    190    192     1
+    187    190    193     1
+    191    190    192     1
+    191    190    193     1
+    192    190    193     1
+    190    193    194     1
+    190    193    195     1
+    190    193    196     1
+    194    193    195     1
+    194    193    196     1
+    195    193    196     1
+    193    196    197     1
+    193    196    198     1
+    193    196    199     1
+    197    196    198     1
+    197    196    199     1
+    198    196    199     1
+    196    199    200     1
+    196    199    201     1
+    196    199    202     1
+    200    199    201     1
+    200    199    202     1
+    201    199    202     1
+    185    203    204     1
+    185    203    205     1
+    204    203    205     1
+    203    205    206     1
+    203    205    207     1
+    206    205    207     1
+    205    207    208     1
+    205    207    209     1
+    205    207    227     1
+    208    207    209     1
+    208    207    227     1
+    209    207    227     1
+    207    209    210     1
+    207    209    211     1
+    207    209    212     1
+    210    209    211     1
+    210    209    212     1
+    211    209    212     1
+    209    212    213     1
+    209    212    214     1
+    209    212    215     1
+    213    212    214     1
+    213    212    215     1
+    214    212    215     1
+    212    215    216     1
+    212    215    217     1
+    212    215    218     1
+    216    215    217     1
+    216    215    218     1
+    217    215    218     1
+    215    218    219     1
+    215    218    220     1
+    219    218    220     1
+    218    220    221     1
+    218    220    224     1
+    221    220    224     1
+    220    221    222     1
+    220    221    223     1
+    222    221    223     1
+    220    224    225     1
+    220    224    226     1
+    225    224    226     1
+    207    227    228     1
+    207    227    229     1
+    228    227    229     1
+    227    229    230     1
+    227    229    231     1
+    230    229    231     1
+    229    231    232     1
+    229    231    233     1
+    229    231    244     1
+    232    231    233     1
+    232    231    244     1
+    233    231    244     1
+    231    233    234     1
+    231    233    235     1
+    231    233    236     1
+    234    233    235     1
+    234    233    236     1
+    235    233    236     1
+    233    236    237     1
+    233    236    242     1
+    237    236    242     1
+    236    237    238     1
+    237    238    239     1
+    237    238    240     1
+    239    238    240     1
+    238    240    241     1
+    238    240    242     1
+    241    240    242     1
+    236    242    240     1
+    236    242    243     1
+    240    242    243     1
+    231    244    245     1
+    231    244    246     1
+    245    244    246     1
+    244    246    247     1
+    244    246    248     1
+    247    246    248     1
+    246    248    249     1
+    246    248    250     1
+    246    248    251     1
+    249    248    250     1
+    249    248    251     1
+    250    248    251     1
+    248    251    252     1
+    248    251    253     1
+    252    251    253     1
+    251    253    254     1
+    251    253    255     1
+    254    253    255     1
+    253    255    256     1
+    253    255    257     1
+    253    255    270     1
+    256    255    257     1
+    256    255    270     1
+    257    255    270     1
+    255    257    258     1
+    255    257    259     1
+    255    257    260     1
+    258    257    259     1
+    258    257    260     1
+    259    257    260     1
+    257    260    261     1
+    257    260    262     1
+    257    260    266     1
+    261    260    262     1
+    261    260    266     1
+    262    260    266     1
+    260    262    263     1
+    260    262    264     1
+    260    262    265     1
+    263    262    264     1
+    263    262    265     1
+    264    262    265     1
+    260    266    267     1
+    260    266    268     1
+    260    266    269     1
+    267    266    268     1
+    267    266    269     1
+    268    266    269     1
+    255    270    271     1
+    255    270    272     1
+    271    270    272     1
+    270    272    273     1
+    270    272    274     1
+    273    272    274     1
+    272    274    275     1
+    272    274    276     1
+    272    274    282     1
+    275    274    276     1
+    275    274    282     1
+    276    274    282     1
+    274    276    277     1
+    274    276    278     1
+    274    276    279     1
+    277    276    278     1
+    277    276    279     1
+    278    276    279     1
+    276    279    280     1
+    276    279    281     1
+    280    279    281     1
+    274    282    283     1
+    274    282    284     1
+    283    282    284     1
+    282    284    285     1
+    282    284    286     1
+    285    284    286     1
+    284    286    287     1
+    284    286    288     1
+    284    286    296     1
+    287    286    288     1
+    287    286    296     1
+    288    286    296     1
+    286    288    289     1
+    286    288    290     1
+    286    288    291     1
+    289    288    290     1
+    289    288    291     1
+    290    288    291     1
+    288    291    292     1
+    288    291    293     1
+    292    291    293     1
+    291    293    294     1
+    291    293    295     1
+    294    293    295     1
+    286    296    297     1
+    286    296    298     1
+    297    296    298     1
+    296    298    299     1
+    296    298    300     1
+    299    298    300     1
+    298    300    301     1
+    298    300    302     1
+    298    300    317     1
+    301    300    302     1
+    301    300    317     1
+    302    300    317     1
+    300    302    303     1
+    300    302    304     1
+    300    302    305     1
+    303    302    304     1
+    303    302    305     1
+    304    302    305     1
+    302    305    306     1
+    302    305    315     1
+    306    305    315     1
+    305    306    307     1
+    305    306    308     1
+    307    306    308     1
+    306    308    309     1
+    306    308    310     1
+    309    308    310     1
+    308    310    311     1
+    308    310    313     1
+    311    310    313     1
+    310    311    312     1
+    310    313    314     1
+    310    313    315     1
+    314    313    315     1
+    305    315    313     1
+    305    315    316     1
+    313    315    316     1
+    300    317    318     1
+    300    317    319     1
+    318    317    319     1
+    317    319    320     1
+    317    319    321     1
+    320    319    321     1
+    319    321    322     1
+    319    321    323     1
+    319    321    341     1
+    322    321    323     1
+    322    321    341     1
+    323    321    341     1
+    321    323    324     1
+    321    323    325     1
+    321    323    326     1
+    324    323    325     1
+    324    323    326     1
+    325    323    326     1
+    323    326    327     1
+    323    326    328     1
+    323    326    329     1
+    327    326    328     1
+    327    326    329     1
+    328    326    329     1
+    326    329    330     1
+    326    329    331     1
+    326    329    332     1
+    330    329    331     1
+    330    329    332     1
+    331    329    332     1
+    329    332    333     1
+    329    332    334     1
+    333    332    334     1
+    332    334    335     1
+    332    334    338     1
+    335    334    338     1
+    334    335    336     1
+    334    335    337     1
+    336    335    337     1
+    334    338    339     1
+    334    338    340     1
+    339    338    340     1
+    321    341    342     1
+    321    341    343     1
+    342    341    343     1
+    341    343    344     1
+    341    343    345     1
+    344    343    345     1
+    343    345    346     1
+    343    345    347     1
+    343    345    348     1
+    346    345    347     1
+    346    345    348     1
+    347    345    348     1
+    345    348    349     1
+    345    348    350     1
+    349    348    350     1
+    348    350    351     1
+    348    350    352     1
+    351    350    352     1
+    350    352    353     1
+    350    352    354     1
+    350    352    369     1
+    353    352    354     1
+    353    352    369     1
+    354    352    369     1
+    352    354    355     1
+    352    354    356     1
+    352    354    357     1
+    355    354    356     1
+    355    354    357     1
+    356    354    357     1
+    354    357    358     1
+    354    357    367     1
+    358    357    367     1
+    357    358    359     1
+    357    358    360     1
+    359    358    360     1
+    358    360    361     1
+    358    360    362     1
+    361    360    362     1
+    360    362    363     1
+    360    362    365     1
+    363    362    365     1
+    362    363    364     1
+    362    365    366     1
+    362    365    367     1
+    366    365    367     1
+    357    367    365     1
+    357    367    368     1
+    365    367    368     1
+    352    369    370     1
+    352    369    371     1
+    370    369    371     1
+    369    371    372     1
+    369    371    373     1
+    372    371    373     1
+    371    373    374     1
+    371    373    375     1
+    371    373    380     1
+    374    373    375     1
+    374    373    380     1
+    375    373    380     1
+    373    375    376     1
+    373    375    377     1
+    373    375    378     1
+    376    375    377     1
+    376    375    378     1
+    377    375    378     1
+    375    378    379     1
+    373    380    381     1
+    373    380    382     1
+    381    380    382     1
+    380    382    383     1
+    380    382    384     1
+    383    382    384     1
+    382    384    385     1
+    382    384    386     1
+    382    384    399     1
+    385    384    386     1
+    385    384    399     1
+    386    384    399     1
+    384    386    387     1
+    384    386    388     1
+    384    386    389     1
+    387    386    388     1
+    387    386    389     1
+    388    386    389     1
+    386    389    390     1
+    386    389    391     1
+    386    389    395     1
+    390    389    391     1
+    390    389    395     1
+    391    389    395     1
+    389    391    392     1
+    389    391    393     1
+    389    391    394     1
+    392    391    393     1
+    392    391    394     1
+    393    391    394     1
+    389    395    396     1
+    389    395    397     1
+    389    395    398     1
+    396    395    397     1
+    396    395    398     1
+    397    395    398     1
+    384    399    400     1
+    384    399    401     1
+    400    399    401     1
+    399    401    402     1
+    399    401    403     1
+    402    401    403     1
+    401    403    404     1
+    401    403    405     1
+    401    403    406     1
+    404    403    405     1
+    404    403    406     1
+    405    403    406     1
+    403    406    407     1
+    403    406    408     1
+    407    406    408     1
+    406    408    409     1
+    406    408    410     1
+    409    408    410     1
+    408    410    411     1
+    408    410    412     1
+    408    410    420     1
+    411    410    412     1
+    411    410    420     1
+    412    410    420     1
+    410    412    413     1
+    410    412    414     1
+    410    412    415     1
+    413    412    414     1
+    413    412    415     1
+    414    412    415     1
+    412    415    416     1
+    412    415    417     1
+    416    415    417     1
+    415    417    418     1
+    415    417    419     1
+    418    417    419     1
+    410    420    421     1
+    410    420    422     1
+    421    420    422     1
+    420    422    423     1
+    420    422    424     1
+    423    422    424     1
+    422    424    425     1
+    422    424    426     1
+    422    424    444     1
+    425    424    426     1
+    425    424    444     1
+    426    424    444     1
+    424    426    427     1
+    424    426    428     1
+    424    426    429     1
+    427    426    428     1
+    427    426    429     1
+    428    426    429     1
+    426    429    430     1
+    426    429    443     1
+    430    429    443     1
+    429    430    431     1
+    429    430    432     1
+    431    430    432     1
+    430    432    433     1
+    430    432    434     1
+    433    432    434     1
+    432    434    435     1
+    432    434    443     1
+    435    434    443     1
+    434    435    436     1
+    434    435    437     1
+    436    435    437     1
+    435    437    438     1
+    435    437    439     1
+    438    437    439     1
+    437    439    440     1
+    437    439    441     1
+    440    439    441     1
+    439    441    442     1
+    439    441    443     1
+    442    441    443     1
+    429    443    434     1
+    429    443    441     1
+    434    443    441     1
+    424    444    445     1
+    424    444    446     1
+    445    444    446     1
+    444    446    447     1
+    444    446    448     1
+    447    446    448     1
+    446    448    449     1
+    446    448    450     1
+    446    448    460     1
+    449    448    450     1
+    449    448    460     1
+    450    448    460     1
+    448    450    451     1
+    448    450    452     1
+    448    450    456     1
+    451    450    452     1
+    451    450    456     1
+    452    450    456     1
+    450    452    453     1
+    450    452    454     1
+    450    452    455     1
+    453    452    454     1
+    453    452    455     1
+    454    452    455     1
+    450    456    457     1
+    450    456    458     1
+    450    456    459     1
+    457    456    458     1
+    457    456    459     1
+    458    456    459     1
+    448    460    461     1
+    448    460    462     1
+    461    460    462     1
+    460    462    463     1
+    460    462    464     1
+    463    462    464     1
+    462    464    465     1
+    462    464    466     1
+    462    464    470     1
+    465    464    466     1
+    465    464    470     1
+    466    464    470     1
+    464    466    467     1
+    464    466    468     1
+    464    466    469     1
+    467    466    468     1
+    467    466    469     1
+    468    466    469     1
+    466    469   1732     1
+    464    470    471     1
+    464    470    472     1
+    471    470    472     1
+    470    472    473     1
+    470    472    474     1
+    473    472    474     1
+    472    474    475     1
+    472    474    476     1
+    472    474    480     1
+    475    474    476     1
+    475    474    480     1
+    476    474    480     1
+    474    476    477     1
+    474    476    478     1
+    474    476    479     1
+    477    476    478     1
+    477    476    479     1
+    478    476    479     1
+    474    480    481     1
+    474    480    482     1
+    481    480    482     1
+    480    482    483     1
+    480    482    484     1
+    483    482    484     1
+    482    484    485     1
+    482    484    486     1
+    482    484    490     1
+    485    484    486     1
+    485    484    490     1
+    486    484    490     1
+    484    486    487     1
+    484    486    488     1
+    484    486    489     1
+    487    486    488     1
+    487    486    489     1
+    488    486    489     1
+    484    490    491     1
+    484    490    492     1
+    491    490    492     1
+    490    492    493     1
+    490    492    494     1
+    493    492    494     1
+    492    494    495     1
+    492    494    496     1
+    492    494    512     1
+    495    494    496     1
+    495    494    512     1
+    496    494    512     1
+    494    496    497     1
+    494    496    498     1
+    494    496    499     1
+    497    496    498     1
+    497    496    499     1
+    498    496    499     1
+    496    499    500     1
+    496    499    501     1
+    496    499    502     1
+    500    499    501     1
+    500    499    502     1
+    501    499    502     1
+    499    502    503     1
+    499    502    504     1
+    499    502    505     1
+    503    502    504     1
+    503    502    505     1
+    504    502    505     1
+    502    505    506     1
+    502    505    507     1
+    502    505    508     1
+    506    505    507     1
+    506    505    508     1
+    507    505    508     1
+    505    508    509     1
+    505    508    510     1
+    505    508    511     1
+    509    508    510     1
+    509    508    511     1
+    510    508    511     1
+    494    512    513     1
+    494    512    514     1
+    513    512    514     1
+    512    514    515     1
+    512    514    516     1
+    515    514    516     1
+    514    516    517     1
+    514    516    518     1
+    514    516    532     1
+    517    516    518     1
+    517    516    532     1
+    518    516    532     1
+    516    518    519     1
+    516    518    520     1
+    516    518    521     1
+    519    518    520     1
+    519    518    521     1
+    520    518    521     1
+    518    521    522     1
+    518    521    530     1
+    522    521    530     1
+    521    522    523     1
+    521    522    524     1
+    523    522    524     1
+    522    524    525     1
+    522    524    526     1
+    525    524    526     1
+    524    526    527     1
+    524    526    528     1
+    527    526    528     1
+    526    528    529     1
+    526    528    530     1
+    529    528    530     1
+    521    530    528     1
+    521    530    531     1
+    528    530    531     1
+    516    532    533     1
+    516    532    534     1
+    533    532    534     1
+    532    534    535     1
+    532    534    536     1
+    535    534    536     1
+    534    536    537     1
+    534    536    538     1
+    534    536    547     1
+    537    536    538     1
+    537    536    547     1
+    538    536    547     1
+    536    538    539     1
+    536    538    540     1
+    536    538    541     1
+    539    538    540     1
+    539    538    541     1
+    540    538    541     1
+    538    541    542     1
+    538    541    543     1
+    538    541    544     1
+    542    541    543     1
+    542    541    544     1
+    543    541    544     1
+    541    544    545     1
+    541    544    546     1
+    545    544    546     1
+    536    547    548     1
+    536    547    549     1
+    548    547    549     1
+    547    549    550     1
+    547    549    551     1
+    550    549    551     1
+    549    551    552     1
+    549    551    553     1
+    549    551    558     1
+    552    551    553     1
+    552    551    558     1
+    553    551    558     1
+    551    553    554     1
+    551    553    555     1
+    551    553    556     1
+    554    553    555     1
+    554    553    556     1
+    555    553    556     1
+    553    556    557     1
+    551    558    559     1
+    551    558    560     1
+    559    558    560     1
+    558    560    561     1
+    558    560    562     1
+    561    560    562     1
+    560    562    563     1
+    560    562    564     1
+    560    562    572     1
+    563    562    564     1
+    563    562    572     1
+    564    562    572     1
+    562    564    565     1
+    562    564    566     1
+    562    564    567     1
+    565    564    566     1
+    565    564    567     1
+    566    564    567     1
+    564    567    568     1
+    564    567    569     1
+    568    567    569     1
+    567    569    570     1
+    567    569    571     1
+    570    569    571     1
+    562    572    573     1
+    562    572    574     1
+    573    572    574     1
+    572    574    575     1
+    572    574    576     1
+    575    574    576     1
+    574    576    577     1
+    574    576    578     1
+    574    576    592     1
+    577    576    578     1
+    577    576    592     1
+    578    576    592     1
+    576    578    579     1
+    576    578    580     1
+    576    578    581     1
+    579    578    580     1
+    579    578    581     1
+    580    578    581     1
+    578    581    582     1
+    578    581    590     1
+    582    581    590     1
+    581    582    583     1
+    581    582    584     1
+    583    582    584     1
+    582    584    585     1
+    582    584    586     1
+    585    584    586     1
+    584    586    587     1
+    584    586    588     1
+    587    586    588     1
+    586    588    589     1
+    586    588    590     1
+    589    588    590     1
+    581    590    588     1
+    581    590    591     1
+    588    590    591     1
+    576    592    593     1
+    576    592    594     1
+    593    592    594     1
+    592    594    595     1
+    592    594    596     1
+    595    594    596     1
+    594    596    597     1
+    594    596    598     1
+    594    596    606     1
+    597    596    598     1
+    597    596    606     1
+    598    596    606     1
+    596    598    599     1
+    596    598    600     1
+    596    598    601     1
+    599    598    600     1
+    599    598    601     1
+    600    598    601     1
+    598    601    602     1
+    598    601    603     1
+    602    601    603     1
+    601    603    604     1
+    601    603    605     1
+    604    603    605     1
+    596    606    607     1
+    596    606    608     1
+    607    606    608     1
+    606    608    609     1
+    606    608    610     1
+    609    608    610     1
+    608    610    611     1
+    608    610    612     1
+    608    610    620     1
+    611    610    612     1
+    611    610    620     1
+    612    610    620     1
+    610    612    613     1
+    610    612    614     1
+    610    612    618     1
+    613    612    614     1
+    613    612    618     1
+    614    612    618     1
+    612    614    615     1
+    612    614    616     1
+    612    614    617     1
+    615    614    616     1
+    615    614    617     1
+    616    614    617     1
+    612    618    619     1
+    610    620    621     1
+    610    620    622     1
+    621    620    622     1
+    620    622    623     1
+    620    622    624     1
+    623    622    624     1
+    622    624    625     1
+    622    624    626     1
+    622    624    637     1
+    625    624    626     1
+    625    624    637     1
+    626    624    637     1
+    624    626    627     1
+    624    626    628     1
+    624    626    629     1
+    627    626    628     1
+    627    626    629     1
+    628    626    629     1
+    626    629    630     1
+    626    629    631     1
+    626    629    632     1
+    630    629    631     1
+    630    629    632     1
+    631    629    632     1
+    629    632    633     1
+    629    632    634     1
+    633    632    634     1
+    632    634    635     1
+    632    634    636     1
+    635    634    636     1
+    624    637    638     1
+    624    637    639     1
+    638    637    639     1
+    637    639    640     1
+    637    639    641     1
+    640    639    641     1
+    639    641    642     1
+    639    641    643     1
+    639    641    647     1
+    642    641    643     1
+    642    641    647     1
+    643    641    647     1
+    641    643    644     1
+    641    643    645     1
+    641    643    646     1
+    644    643    645     1
+    644    643    646     1
+    645    643    646     1
+    641    647    648     1
+    641    647    649     1
+    648    647    649     1
+    647    649    650     1
+    647    649    651     1
+    650    649    651     1
+    649    651    652     1
+    649    651    653     1
+    649    651    661     1
+    652    651    653     1
+    652    651    661     1
+    653    651    661     1
+    651    653    654     1
+    651    653    655     1
+    651    653    659     1
+    654    653    655     1
+    654    653    659     1
+    655    653    659     1
+    653    655    656     1
+    653    655    657     1
+    653    655    658     1
+    656    655    657     1
+    656    655    658     1
+    657    655    658     1
+    653    659    660     1
+    651    661    662     1
+    651    661    663     1
+    662    661    663     1
+    661    663    664     1
+    661    663    665     1
+    664    663    665     1
+    663    665    666     1
+    663    665    667     1
+    663    665    675     1
+    666    665    667     1
+    666    665    675     1
+    667    665    675     1
+    665    667    668     1
+    665    667    669     1
+    665    667    670     1
+    668    667    669     1
+    668    667    670     1
+    669    667    670     1
+    667    670    671     1
+    667    670    672     1
+    671    670    672     1
+    670    672    673     1
+    670    672    674     1
+    673    672    674     1
+    665    675    676     1
+    665    675    677     1
+    676    675    677     1
+    675    677    678     1
+    675    677    679     1
+    678    677    679     1
+    677    679    680     1
+    677    679    681     1
+    677    679    699     1
+    680    679    681     1
+    680    679    699     1
+    681    679    699     1
+    679    681    682     1
+    679    681    683     1
+    679    681    684     1
+    682    681    683     1
+    682    681    684     1
+    683    681    684     1
+    681    684    685     1
+    681    684    686     1
+    681    684    687     1
+    685    684    686     1
+    685    684    687     1
+    686    684    687     1
+    684    687    688     1
+    684    687    689     1
+    684    687    690     1
+    688    687    689     1
+    688    687    690     1
+    689    687    690     1
+    687    690    691     1
+    687    690    692     1
+    691    690    692     1
+    690    692    693     1
+    690    692    696     1
+    693    692    696     1
+    692    693    694     1
+    692    693    695     1
+    694    693    695     1
+    692    696    697     1
+    692    696    698     1
+    697    696    698     1
+    679    699    700     1
+    679    699    701     1
+    700    699    701     1
+    699    701    702     1
+    699    701    703     1
+    702    701    703     1
+    701    703    704     1
+    701    703    705     1
+    701    703    713     1
+    704    703    705     1
+    704    703    713     1
+    705    703    713     1
+    703    705    706     1
+    703    705    707     1
+    703    705    708     1
+    706    705    707     1
+    706    705    708     1
+    707    705    708     1
+    705    708    709     1
+    705    708    710     1
+    709    708    710     1
+    708    710    711     1
+    708    710    712     1
+    711    710    712     1
+    703    713    714     1
+    703    713    715     1
+    714    713    715     1
+    713    715    716     1
+    713    715    717     1
+    716    715    717     1
+    715    717    718     1
+    715    717    719     1
+    715    717    727     1
+    718    717    719     1
+    718    717    727     1
+    719    717    727     1
+    717    719    720     1
+    717    719    721     1
+    717    719    725     1
+    720    719    721     1
+    720    719    725     1
+    721    719    725     1
+    719    721    722     1
+    719    721    723     1
+    719    721    724     1
+    722    721    723     1
+    722    721    724     1
+    723    721    724     1
+    719    725    726     1
+    717    727    728     1
+    717    727    729     1
+    728    727    729     1
+    727    729    730     1
+    727    729    731     1
+    730    729    731     1
+    729    731    732     1
+    729    731    733     1
+    729    731    739     1
+    732    731    733     1
+    732    731    739     1
+    733    731    739     1
+    731    733    734     1
+    731    733    735     1
+    731    733    736     1
+    734    733    735     1
+    734    733    736     1
+    735    733    736     1
+    733    736    737     1
+    733    736    738     1
+    737    736    738     1
+    731    739    740     1
+    731    739    741     1
+    740    739    741     1
+    739    741    742     1
+    739    741    743     1
+    742    741    743     1
+    741    743    744     1
+    741    743    745     1
+    741    743    746     1
+    744    743    745     1
+    744    743    746     1
+    745    743    746     1
+    743    746    747     1
+    743    746    748     1
+    747    746    748     1
+    746    748    749     1
+    746    748    750     1
+    749    748    750     1
+    748    750    751     1
+    748    750    752     1
+    748    750    757     1
+    751    750    752     1
+    751    750    757     1
+    752    750    757     1
+    750    752    753     1
+    750    752    754     1
+    750    752    755     1
+    753    752    754     1
+    753    752    755     1
+    754    752    755     1
+    752    755    756     1
+    750    757    758     1
+    750    757    759     1
+    758    757    759     1
+    757    759    760     1
+    757    759    761     1
+    760    759    761     1
+    759    761    762     1
+    759    761    763     1
+    759    761    771     1
+    762    761    763     1
+    762    761    771     1
+    763    761    771     1
+    761    763    764     1
+    761    763    765     1
+    761    763    769     1
+    764    763    765     1
+    764    763    769     1
+    765    763    769     1
+    763    765    766     1
+    763    765    767     1
+    763    765    768     1
+    766    765    767     1
+    766    765    768     1
+    767    765    768     1
+    763    769    770     1
+    761    771    772     1
+    761    771    773     1
+    772    771    773     1
+    771    773    774     1
+    771    773    775     1
+    774    773    775     1
+    773    775    776     1
+    773    775    777     1
+    773    775    783     1
+    776    775    777     1
+    776    775    783     1
+    777    775    783     1
+    775    777    778     1
+    775    777    779     1
+    775    777    780     1
+    778    777    779     1
+    778    777    780     1
+    779    777    780     1
+    777    780    781     1
+    777    780    782     1
+    781    780    782     1
+    775    783    784     1
+    775    783    785     1
+    784    783    785     1
+    783    785    786     1
+    783    785    787     1
+    786    785    787     1
+    785    787    788     1
+    785    787    789     1
+    785    787    804     1
+    788    787    789     1
+    788    787    804     1
+    789    787    804     1
+    787    789    790     1
+    787    789    791     1
+    787    789    792     1
+    790    789    791     1
+    790    789    792     1
+    791    789    792     1
+    789    792    793     1
+    789    792    802     1
+    793    792    802     1
+    792    793    794     1
+    792    793    795     1
+    794    793    795     1
+    793    795    796     1
+    793    795    797     1
+    796    795    797     1
+    795    797    798     1
+    795    797    800     1
+    798    797    800     1
+    797    798    799     1
+    797    800    801     1
+    797    800    802     1
+    801    800    802     1
+    792    802    800     1
+    792    802    803     1
+    800    802    803     1
+    787    804    805     1
+    787    804    806     1
+    805    804    806     1
+    804    806    807     1
+    804    806    808     1
+    807    806    808     1
+    806    808    809     1
+    806    808    810     1
+    806    808    811     1
+    809    808    810     1
+    809    808    811     1
+    810    808    811     1
+    808    811    812     1
+    808    811    813     1
+    812    811    813     1
+    811    813    814     1
+    811    813    815     1
+    814    813    815     1
+    813    815    816     1
+    813    815    817     1
+    813    815    830     1
+    816    815    817     1
+    816    815    830     1
+    817    815    830     1
+    815    817    818     1
+    815    817    819     1
+    815    817    823     1
+    818    817    819     1
+    818    817    823     1
+    819    817    823     1
+    817    819    820     1
+    817    819    821     1
+    817    819    822     1
+    820    819    821     1
+    820    819    822     1
+    821    819    822     1
+    817    823    824     1
+    817    823    825     1
+    817    823    826     1
+    824    823    825     1
+    824    823    826     1
+    825    823    826     1
+    823    826    827     1
+    823    826    828     1
+    823    826    829     1
+    827    826    828     1
+    827    826    829     1
+    828    826    829     1
+    815    830    831     1
+    815    830    832     1
+    831    830    832     1
+    830    832    833     1
+    830    832    834     1
+    833    832    834     1
+    832    834    835     1
+    832    834    836     1
+    832    834    849     1
+    835    834    836     1
+    835    834    849     1
+    836    834    849     1
+    834    836    837     1
+    834    836    838     1
+    834    836    839     1
+    837    836    838     1
+    837    836    839     1
+    838    836    839     1
+    836    839    840     1
+    836    839    841     1
+    836    839    845     1
+    840    839    841     1
+    840    839    845     1
+    841    839    845     1
+    839    841    842     1
+    839    841    843     1
+    839    841    844     1
+    842    841    843     1
+    842    841    844     1
+    843    841    844     1
+    839    845    846     1
+    839    845    847     1
+    839    845    848     1
+    846    845    847     1
+    846    845    848     1
+    847    845    848     1
+    834    849    850     1
+    834    849    851     1
+    850    849    851     1
+    849    851    852     1
+    849    851    853     1
+    852    851    853     1
+    851    853    854     1
+    851    853    855     1
+    851    853    866     1
+    854    853    855     1
+    854    853    866     1
+    855    853    866     1
+    853    855    856     1
+    853    855    857     1
+    853    855    858     1
+    856    855    857     1
+    856    855    858     1
+    857    855    858     1
+    855    858    859     1
+    855    858    860     1
+    855    858    861     1
+    859    858    860     1
+    859    858    861     1
+    860    858    861     1
+    858    861    862     1
+    858    861    863     1
+    862    861    863     1
+    861    863    864     1
+    861    863    865     1
+    864    863    865     1
+    853    866    867     1
+    853    866    868     1
+    867    866    868     1
+    866    868    869     1
+    866    868    870     1
+    869    868    870     1
+    868    870    871     1
+    868    870    872     1
+    868    870    885     1
+    871    870    872     1
+    871    870    885     1
+    872    870    885     1
+    870    872    873     1
+    870    872    874     1
+    870    872    878     1
+    873    872    874     1
+    873    872    878     1
+    874    872    878     1
+    872    874    875     1
+    872    874    876     1
+    872    874    877     1
+    875    874    876     1
+    875    874    877     1
+    876    874    877     1
+    872    878    879     1
+    872    878    880     1
+    872    878    881     1
+    879    878    880     1
+    879    878    881     1
+    880    878    881     1
+    878    881    882     1
+    878    881    883     1
+    878    881    884     1
+    882    881    883     1
+    882    881    884     1
+    883    881    884     1
+    870    885    886     1
+    870    885    887     1
+    886    885    887     1
+    885    887    888     1
+    885    887    889     1
+    888    887    889     1
+    887    889    890     1
+    887    889    891     1
+    887    889    899     1
+    890    889    891     1
+    890    889    899     1
+    891    889    899     1
+    889    891    892     1
+    889    891    893     1
+    889    891    894     1
+    892    891    893     1
+    892    891    894     1
+    893    891    894     1
+    891    894    895     1
+    891    894    896     1
+    895    894    896     1
+    894    896    897     1
+    894    896    898     1
+    897    896    898     1
+    889    899    900     1
+    889    899    901     1
+    900    899    901     1
+    899    901    902     1
+    899    901    903     1
+    902    901    903     1
+    901    903    904     1
+    901    903    905     1
+    901    903    910     1
+    904    903    905     1
+    904    903    910     1
+    905    903    910     1
+    903    905    906     1
+    903    905    907     1
+    903    905    908     1
+    906    905    907     1
+    906    905    908     1
+    907    905    908     1
+    905    908    909     1
+    903    910    911     1
+    903    910    912     1
+    911    910    912     1
+    910    912    913     1
+    910    912    914     1
+    913    912    914     1
+    912    914    915     1
+    912    914    916     1
+    912    914    934     1
+    915    914    916     1
+    915    914    934     1
+    916    914    934     1
+    914    916    917     1
+    914    916    918     1
+    914    916    919     1
+    917    916    918     1
+    917    916    919     1
+    918    916    919     1
+    916    919    920     1
+    916    919    921     1
+    916    919    922     1
+    920    919    921     1
+    920    919    922     1
+    921    919    922     1
+    919    922    923     1
+    919    922    924     1
+    919    922    925     1
+    923    922    924     1
+    923    922    925     1
+    924    922    925     1
+    922    925    926     1
+    922    925    927     1
+    926    925    927     1
+    925    927    928     1
+    925    927    931     1
+    928    927    931     1
+    927    928    929     1
+    927    928    930     1
+    929    928    930     1
+    927    931    932     1
+    927    931    933     1
+    932    931    933     1
+    914    934    935     1
+    914    934    936     1
+    935    934    936     1
+    934    936    937     1
+    934    936    938     1
+    937    936    938     1
+    936    938    939     1
+    936    938    940     1
+    936    938    958     1
+    939    938    940     1
+    939    938    958     1
+    940    938    958     1
+    938    940    941     1
+    938    940    942     1
+    938    940    943     1
+    941    940    942     1
+    941    940    943     1
+    942    940    943     1
+    940    943    944     1
+    940    943    957     1
+    944    943    957     1
+    943    944    945     1
+    943    944    946     1
+    945    944    946     1
+    944    946    947     1
+    944    946    948     1
+    947    946    948     1
+    946    948    949     1
+    946    948    957     1
+    949    948    957     1
+    948    949    950     1
+    948    949    951     1
+    950    949    951     1
+    949    951    952     1
+    949    951    953     1
+    952    951    953     1
+    951    953    954     1
+    951    953    955     1
+    954    953    955     1
+    953    955    956     1
+    953    955    957     1
+    956    955    957     1
+    943    957    948     1
+    943    957    955     1
+    948    957    955     1
+    938    958    959     1
+    938    958    960     1
+    959    958    960     1
+    958    960    961     1
+    958    960    962     1
+    961    960    962     1
+    960    962    963     1
+    960    962    964     1
+    960    962    982     1
+    963    962    964     1
+    963    962    982     1
+    964    962    982     1
+    962    964    965     1
+    962    964    966     1
+    962    964    967     1
+    965    964    966     1
+    965    964    967     1
+    966    964    967     1
+    964    967    968     1
+    964    967    981     1
+    968    967    981     1
+    967    968    969     1
+    967    968    970     1
+    969    968    970     1
+    968    970    971     1
+    968    970    972     1
+    971    970    972     1
+    970    972    973     1
+    970    972    981     1
+    973    972    981     1
+    972    973    974     1
+    972    973    975     1
+    974    973    975     1
+    973    975    976     1
+    973    975    977     1
+    976    975    977     1
+    975    977    978     1
+    975    977    979     1
+    978    977    979     1
+    977    979    980     1
+    977    979    981     1
+    980    979    981     1
+    967    981    972     1
+    967    981    979     1
+    972    981    979     1
+    962    982    983     1
+    962    982    984     1
+    983    982    984     1
+    982    984    985     1
+    982    984    986     1
+    985    984    986     1
+    984    986    987     1
+    984    986    988     1
+    984    986    992     1
+    987    986    988     1
+    987    986    992     1
+    988    986    992     1
+    986    988    989     1
+    986    988    990     1
+    986    988    991     1
+    989    988    990     1
+    989    988    991     1
+    990    988    991     1
+    988    991   1218     1
+    986    992    993     1
+    986    992    994     1
+    993    992    994     1
+    992    994    995     1
+    992    994    996     1
+    995    994    996     1
+    994    996    997     1
+    994    996    998     1
+    994    996   1006     1
+    997    996    998     1
+    997    996   1006     1
+    998    996   1006     1
+    996    998    999     1
+    996    998   1000     1
+    996    998   1001     1
+    999    998   1000     1
+    999    998   1001     1
+   1000    998   1001     1
+    998   1001   1002     1
+    998   1001   1003     1
+   1002   1001   1003     1
+   1001   1003   1004     1
+   1001   1003   1005     1
+   1004   1003   1005     1
+    996   1006   1007     1
+    996   1006   1008     1
+   1007   1006   1008     1
+   1006   1008   1009     1
+   1006   1008   1010     1
+   1009   1008   1010     1
+   1008   1010   1011     1
+   1008   1010   1012     1
+   1008   1010   1018     1
+   1011   1010   1012     1
+   1011   1010   1018     1
+   1012   1010   1018     1
+   1010   1012   1013     1
+   1010   1012   1014     1
+   1010   1012   1015     1
+   1013   1012   1014     1
+   1013   1012   1015     1
+   1014   1012   1015     1
+   1012   1015   1016     1
+   1012   1015   1017     1
+   1016   1015   1017     1
+   1010   1018   1019     1
+   1010   1018   1020     1
+   1019   1018   1020     1
+   1018   1020   1021     1
+   1018   1020   1022     1
+   1021   1020   1022     1
+   1020   1022   1023     1
+   1020   1022   1024     1
+   1020   1022   1025     1
+   1023   1022   1024     1
+   1023   1022   1025     1
+   1024   1022   1025     1
+   1022   1025   1026     1
+   1022   1025   1027     1
+   1026   1025   1027     1
+   1025   1027   1028     1
+   1025   1027   1029     1
+   1028   1027   1029     1
+   1027   1029   1030     1
+   1027   1029   1031     1
+   1027   1029   1049     1
+   1030   1029   1031     1
+   1030   1029   1049     1
+   1031   1029   1049     1
+   1029   1031   1032     1
+   1029   1031   1033     1
+   1029   1031   1034     1
+   1032   1031   1033     1
+   1032   1031   1034     1
+   1033   1031   1034     1
+   1031   1034   1035     1
+   1031   1034   1036     1
+   1031   1034   1037     1
+   1035   1034   1036     1
+   1035   1034   1037     1
+   1036   1034   1037     1
+   1034   1037   1038     1
+   1034   1037   1039     1
+   1034   1037   1040     1
+   1038   1037   1039     1
+   1038   1037   1040     1
+   1039   1037   1040     1
+   1037   1040   1041     1
+   1037   1040   1042     1
+   1041   1040   1042     1
+   1040   1042   1043     1
+   1040   1042   1046     1
+   1043   1042   1046     1
+   1042   1043   1044     1
+   1042   1043   1045     1
+   1044   1043   1045     1
+   1042   1046   1047     1
+   1042   1046   1048     1
+   1047   1046   1048     1
+   1029   1049   1050     1
+   1029   1049   1051     1
+   1050   1049   1051     1
+   1049   1051   1052     1
+   1049   1051   1053     1
+   1052   1051   1053     1
+   1051   1053   1054     1
+   1051   1053   1055     1
+   1051   1053   1063     1
+   1054   1053   1055     1
+   1054   1053   1063     1
+   1055   1053   1063     1
+   1053   1055   1056     1
+   1053   1055   1057     1
+   1053   1055   1061     1
+   1056   1055   1057     1
+   1056   1055   1061     1
+   1057   1055   1061     1
+   1055   1057   1058     1
+   1055   1057   1059     1
+   1055   1057   1060     1
+   1058   1057   1059     1
+   1058   1057   1060     1
+   1059   1057   1060     1
+   1055   1061   1062     1
+   1053   1063   1064     1
+   1053   1063   1065     1
+   1064   1063   1065     1
+   1063   1065   1066     1
+   1063   1065   1075     1
+   1066   1065   1075     1
+   1065   1066   1067     1
+   1065   1066   1068     1
+   1065   1066   1069     1
+   1067   1066   1068     1
+   1067   1066   1069     1
+   1068   1066   1069     1
+   1066   1069   1070     1
+   1066   1069   1071     1
+   1066   1069   1072     1
+   1070   1069   1071     1
+   1070   1069   1072     1
+   1071   1069   1072     1
+   1069   1072   1073     1
+   1069   1072   1074     1
+   1069   1072   1075     1
+   1073   1072   1074     1
+   1073   1072   1075     1
+   1074   1072   1075     1
+   1065   1075   1072     1
+   1065   1075   1076     1
+   1065   1075   1077     1
+   1072   1075   1076     1
+   1072   1075   1077     1
+   1076   1075   1077     1
+   1075   1077   1078     1
+   1075   1077   1079     1
+   1078   1077   1079     1
+   1077   1079   1080     1
+   1077   1079   1081     1
+   1080   1079   1081     1
+   1079   1081   1082     1
+   1079   1081   1083     1
+   1079   1081   1084     1
+   1082   1081   1083     1
+   1082   1081   1084     1
+   1083   1081   1084     1
+   1081   1084   1085     1
+   1081   1084   1086     1
+   1085   1084   1086     1
+   1084   1086   1087     1
+   1084   1086   1088     1
+   1087   1086   1088     1
+   1086   1088   1089     1
+   1086   1088   1090     1
+   1086   1088   1095     1
+   1089   1088   1090     1
+   1089   1088   1095     1
+   1090   1088   1095     1
+   1088   1090   1091     1
+   1088   1090   1092     1
+   1088   1090   1093     1
+   1091   1090   1092     1
+   1091   1090   1093     1
+   1092   1090   1093     1
+   1090   1093   1094     1
+   1088   1095   1096     1
+   1088   1095   1097     1
+   1096   1095   1097     1
+   1095   1097   1098     1
+   1095   1097   1099     1
+   1098   1097   1099     1
+   1097   1099   1100     1
+   1097   1099   1101     1
+   1097   1099   1119     1
+   1100   1099   1101     1
+   1100   1099   1119     1
+   1101   1099   1119     1
+   1099   1101   1102     1
+   1099   1101   1103     1
+   1099   1101   1104     1
+   1102   1101   1103     1
+   1102   1101   1104     1
+   1103   1101   1104     1
+   1101   1104   1105     1
+   1101   1104   1106     1
+   1101   1104   1107     1
+   1105   1104   1106     1
+   1105   1104   1107     1
+   1106   1104   1107     1
+   1104   1107   1108     1
+   1104   1107   1109     1
+   1104   1107   1110     1
+   1108   1107   1109     1
+   1108   1107   1110     1
+   1109   1107   1110     1
+   1107   1110   1111     1
+   1107   1110   1112     1
+   1111   1110   1112     1
+   1110   1112   1113     1
+   1110   1112   1116     1
+   1113   1112   1116     1
+   1112   1113   1114     1
+   1112   1113   1115     1
+   1114   1113   1115     1
+   1112   1116   1117     1
+   1112   1116   1118     1
+   1117   1116   1118     1
+   1099   1119   1120     1
+   1099   1119   1121     1
+   1120   1119   1121     1
+   1119   1121   1122     1
+   1119   1121   1123     1
+   1122   1121   1123     1
+   1121   1123   1124     1
+   1121   1123   1125     1
+   1121   1123   1133     1
+   1124   1123   1125     1
+   1124   1123   1133     1
+   1125   1123   1133     1
+   1123   1125   1126     1
+   1123   1125   1127     1
+   1123   1125   1128     1
+   1126   1125   1127     1
+   1126   1125   1128     1
+   1127   1125   1128     1
+   1125   1128   1129     1
+   1125   1128   1130     1
+   1129   1128   1130     1
+   1128   1130   1131     1
+   1128   1130   1132     1
+   1131   1130   1132     1
+   1123   1133   1134     1
+   1123   1133   1135     1
+   1134   1133   1135     1
+   1133   1135   1136     1
+   1133   1135   1137     1
+   1136   1135   1137     1
+   1135   1137   1138     1
+   1135   1137   1139     1
+   1135   1137   1152     1
+   1138   1137   1139     1
+   1138   1137   1152     1
+   1139   1137   1152     1
+   1137   1139   1140     1
+   1137   1139   1141     1
+   1137   1139   1142     1
+   1140   1139   1141     1
+   1140   1139   1142     1
+   1141   1139   1142     1
+   1139   1142   1143     1
+   1139   1142   1144     1
+   1139   1142   1148     1
+   1143   1142   1144     1
+   1143   1142   1148     1
+   1144   1142   1148     1
+   1142   1144   1145     1
+   1142   1144   1146     1
+   1142   1144   1147     1
+   1145   1144   1146     1
+   1145   1144   1147     1
+   1146   1144   1147     1
+   1142   1148   1149     1
+   1142   1148   1150     1
+   1142   1148   1151     1
+   1149   1148   1150     1
+   1149   1148   1151     1
+   1150   1148   1151     1
+   1137   1152   1153     1
+   1137   1152   1154     1
+   1153   1152   1154     1
+   1152   1154   1155     1
+   1152   1154   1156     1
+   1155   1154   1156     1
+   1154   1156   1157     1
+   1154   1156   1158     1
+   1154   1156   1162     1
+   1157   1156   1158     1
+   1157   1156   1162     1
+   1158   1156   1162     1
+   1156   1158   1159     1
+   1156   1158   1160     1
+   1156   1158   1161     1
+   1159   1158   1160     1
+   1159   1158   1161     1
+   1160   1158   1161     1
+   1158   1161   1405     1
+   1156   1162   1163     1
+   1156   1162   1164     1
+   1163   1162   1164     1
+   1162   1164   1165     1
+   1162   1164   1166     1
+   1165   1164   1166     1
+   1164   1166   1167     1
+   1164   1166   1168     1
+   1164   1166   1176     1
+   1167   1166   1168     1
+   1167   1166   1176     1
+   1168   1166   1176     1
+   1166   1168   1169     1
+   1166   1168   1170     1
+   1166   1168   1171     1
+   1169   1168   1170     1
+   1169   1168   1171     1
+   1170   1168   1171     1
+   1168   1171   1172     1
+   1168   1171   1173     1
+   1172   1171   1173     1
+   1171   1173   1174     1
+   1171   1173   1175     1
+   1174   1173   1175     1
+   1166   1176   1177     1
+   1166   1176   1178     1
+   1177   1176   1178     1
+   1176   1178   1179     1
+   1176   1178   1180     1
+   1179   1178   1180     1
+   1178   1180   1181     1
+   1178   1180   1182     1
+   1178   1180   1195     1
+   1181   1180   1182     1
+   1181   1180   1195     1
+   1182   1180   1195     1
+   1180   1182   1183     1
+   1180   1182   1184     1
+   1180   1182   1188     1
+   1183   1182   1184     1
+   1183   1182   1188     1
+   1184   1182   1188     1
+   1182   1184   1185     1
+   1182   1184   1186     1
+   1182   1184   1187     1
+   1185   1184   1186     1
+   1185   1184   1187     1
+   1186   1184   1187     1
+   1182   1188   1189     1
+   1182   1188   1190     1
+   1182   1188   1191     1
+   1189   1188   1190     1
+   1189   1188   1191     1
+   1190   1188   1191     1
+   1188   1191   1192     1
+   1188   1191   1193     1
+   1188   1191   1194     1
+   1192   1191   1193     1
+   1192   1191   1194     1
+   1193   1191   1194     1
+   1180   1195   1196     1
+   1180   1195   1197     1
+   1196   1195   1197     1
+   1195   1197   1198     1
+   1195   1197   1207     1
+   1198   1197   1207     1
+   1197   1198   1199     1
+   1197   1198   1200     1
+   1197   1198   1201     1
+   1199   1198   1200     1
+   1199   1198   1201     1
+   1200   1198   1201     1
+   1198   1201   1202     1
+   1198   1201   1203     1
+   1198   1201   1204     1
+   1202   1201   1203     1
+   1202   1201   1204     1
+   1203   1201   1204     1
+   1201   1204   1205     1
+   1201   1204   1206     1
+   1201   1204   1207     1
+   1205   1204   1206     1
+   1205   1204   1207     1
+   1206   1204   1207     1
+   1197   1207   1204     1
+   1197   1207   1208     1
+   1197   1207   1209     1
+   1204   1207   1208     1
+   1204   1207   1209     1
+   1208   1207   1209     1
+   1207   1209   1210     1
+   1207   1209   1211     1
+   1210   1209   1211     1
+   1209   1211   1212     1
+   1209   1211   1213     1
+   1212   1211   1213     1
+   1211   1213   1214     1
+   1211   1213   1215     1
+   1211   1213   1219     1
+   1214   1213   1215     1
+   1214   1213   1219     1
+   1215   1213   1219     1
+   1213   1215   1216     1
+   1213   1215   1217     1
+   1213   1215   1218     1
+   1216   1215   1217     1
+   1216   1215   1218     1
+   1217   1215   1218     1
+    991   1218   1215     1
+   1213   1219   1220     1
+   1213   1219   1221     1
+   1220   1219   1221     1
+   1219   1221   1222     1
+   1219   1221   1223     1
+   1222   1221   1223     1
+   1221   1223   1224     1
+   1221   1223   1225     1
+   1221   1223   1230     1
+   1224   1223   1225     1
+   1224   1223   1230     1
+   1225   1223   1230     1
+   1223   1225   1226     1
+   1223   1225   1227     1
+   1223   1225   1228     1
+   1226   1225   1227     1
+   1226   1225   1228     1
+   1227   1225   1228     1
+   1225   1228   1229     1
+   1223   1230   1231     1
+   1223   1230   1232     1
+   1231   1230   1232     1
+   1230   1232   1233     1
+   1230   1232   1234     1
+   1233   1232   1234     1
+   1232   1234   1235     1
+   1232   1234   1236     1
+   1232   1234   1240     1
+   1235   1234   1236     1
+   1235   1234   1240     1
+   1236   1234   1240     1
+   1234   1236   1237     1
+   1234   1236   1238     1
+   1234   1236   1239     1
+   1237   1236   1238     1
+   1237   1236   1239     1
+   1238   1236   1239     1
+   1234   1240   1241     1
+   1234   1240   1242     1
+   1241   1240   1242     1
+   1240   1242   1243     1
+   1240   1242   1244     1
+   1243   1242   1244     1
+   1242   1244   1245     1
+   1242   1244   1246     1
+   1242   1244   1259     1
+   1245   1244   1246     1
+   1245   1244   1259     1
+   1246   1244   1259     1
+   1244   1246   1247     1
+   1244   1246   1248     1
+   1244   1246   1249     1
+   1247   1246   1248     1
+   1247   1246   1249     1
+   1248   1246   1249     1
+   1246   1249   1250     1
+   1246   1249   1251     1
+   1246   1249   1255     1
+   1250   1249   1251     1
+   1250   1249   1255     1
+   1251   1249   1255     1
+   1249   1251   1252     1
+   1249   1251   1253     1
+   1249   1251   1254     1
+   1252   1251   1253     1
+   1252   1251   1254     1
+   1253   1251   1254     1
+   1249   1255   1256     1
+   1249   1255   1257     1
+   1249   1255   1258     1
+   1256   1255   1257     1
+   1256   1255   1258     1
+   1257   1255   1258     1
+   1244   1259   1260     1
+   1244   1259   1261     1
+   1260   1259   1261     1
+   1259   1261   1262     1
+   1259   1261   1263     1
+   1262   1261   1263     1
+   1261   1263   1264     1
+   1261   1263   1265     1
+   1261   1263   1278     1
+   1264   1263   1265     1
+   1264   1263   1278     1
+   1265   1263   1278     1
+   1263   1265   1266     1
+   1263   1265   1267     1
+   1263   1265   1268     1
+   1266   1265   1267     1
+   1266   1265   1268     1
+   1267   1265   1268     1
+   1265   1268   1269     1
+   1265   1268   1270     1
+   1265   1268   1274     1
+   1269   1268   1270     1
+   1269   1268   1274     1
+   1270   1268   1274     1
+   1268   1270   1271     1
+   1268   1270   1272     1
+   1268   1270   1273     1
+   1271   1270   1272     1
+   1271   1270   1273     1
+   1272   1270   1273     1
+   1268   1274   1275     1
+   1268   1274   1276     1
+   1268   1274   1277     1
+   1275   1274   1276     1
+   1275   1274   1277     1
+   1276   1274   1277     1
+   1263   1278   1279     1
+   1263   1278   1280     1
+   1279   1278   1280     1
+   1278   1280   1281     1
+   1278   1280   1282     1
+   1281   1280   1282     1
+   1280   1282   1283     1
+   1280   1282   1284     1
+   1280   1282   1289     1
+   1283   1282   1284     1
+   1283   1282   1289     1
+   1284   1282   1289     1
+   1282   1284   1285     1
+   1282   1284   1286     1
+   1282   1284   1287     1
+   1285   1284   1286     1
+   1285   1284   1287     1
+   1286   1284   1287     1
+   1284   1287   1288     1
+   1282   1289   1290     1
+   1282   1289   1291     1
+   1290   1289   1291     1
+   1289   1291   1292     1
+   1289   1291   1293     1
+   1292   1291   1293     1
+   1291   1293   1294     1
+   1291   1293   1295     1
+   1291   1293   1300     1
+   1294   1293   1295     1
+   1294   1293   1300     1
+   1295   1293   1300     1
+   1293   1295   1296     1
+   1293   1295   1297     1
+   1293   1295   1298     1
+   1296   1295   1297     1
+   1296   1295   1298     1
+   1297   1295   1298     1
+   1295   1298   1299     1
+   1293   1300   1301     1
+   1293   1300   1302     1
+   1301   1300   1302     1
+   1300   1302   1303     1
+   1300   1302   1304     1
+   1303   1302   1304     1
+   1302   1304   1305     1
+   1302   1304   1306     1
+   1302   1304   1312     1
+   1305   1304   1306     1
+   1305   1304   1312     1
+   1306   1304   1312     1
+   1304   1306   1307     1
+   1304   1306   1308     1
+   1304   1306   1309     1
+   1307   1306   1308     1
+   1307   1306   1309     1
+   1308   1306   1309     1
+   1306   1309   1310     1
+   1306   1309   1311     1
+   1310   1309   1311     1
+   1304   1312   1313     1
+   1304   1312   1314     1
+   1313   1312   1314     1
+   1312   1314   1315     1
+   1312   1314   1316     1
+   1315   1314   1316     1
+   1314   1316   1317     1
+   1314   1316   1318     1
+   1314   1316   1331     1
+   1317   1316   1318     1
+   1317   1316   1331     1
+   1318   1316   1331     1
+   1316   1318   1319     1
+   1316   1318   1320     1
+   1316   1318   1324     1
+   1319   1318   1320     1
+   1319   1318   1324     1
+   1320   1318   1324     1
+   1318   1320   1321     1
+   1318   1320   1322     1
+   1318   1320   1323     1
+   1321   1320   1322     1
+   1321   1320   1323     1
+   1322   1320   1323     1
+   1318   1324   1325     1
+   1318   1324   1326     1
+   1318   1324   1327     1
+   1325   1324   1326     1
+   1325   1324   1327     1
+   1326   1324   1327     1
+   1324   1327   1328     1
+   1324   1327   1329     1
+   1324   1327   1330     1
+   1328   1327   1329     1
+   1328   1327   1330     1
+   1329   1327   1330     1
+   1316   1331   1332     1
+   1316   1331   1333     1
+   1332   1331   1333     1
+   1331   1333   1334     1
+   1331   1333   1335     1
+   1334   1333   1335     1
+   1333   1335   1336     1
+   1333   1335   1337     1
+   1333   1335   1345     1
+   1336   1335   1337     1
+   1336   1335   1345     1
+   1337   1335   1345     1
+   1335   1337   1338     1
+   1335   1337   1339     1
+   1335   1337   1343     1
+   1338   1337   1339     1
+   1338   1337   1343     1
+   1339   1337   1343     1
+   1337   1339   1340     1
+   1337   1339   1341     1
+   1337   1339   1342     1
+   1340   1339   1341     1
+   1340   1339   1342     1
+   1341   1339   1342     1
+   1337   1343   1344     1
+   1335   1345   1346     1
+   1335   1345   1347     1
+   1346   1345   1347     1
+   1345   1347   1348     1
+   1345   1347   1349     1
+   1348   1347   1349     1
+   1347   1349   1350     1
+   1347   1349   1351     1
+   1347   1349   1355     1
+   1350   1349   1351     1
+   1350   1349   1355     1
+   1351   1349   1355     1
+   1349   1351   1352     1
+   1349   1351   1353     1
+   1349   1351   1354     1
+   1352   1351   1353     1
+   1352   1351   1354     1
+   1353   1351   1354     1
+   1349   1355   1356     1
+   1349   1355   1357     1
+   1356   1355   1357     1
+   1355   1357   1358     1
+   1355   1357   1359     1
+   1358   1357   1359     1
+   1357   1359   1360     1
+   1357   1359   1361     1
+   1357   1359   1366     1
+   1360   1359   1361     1
+   1360   1359   1366     1
+   1361   1359   1366     1
+   1359   1361   1362     1
+   1359   1361   1363     1
+   1359   1361   1364     1
+   1362   1361   1363     1
+   1362   1361   1364     1
+   1363   1361   1364     1
+   1361   1364   1365     1
+   1359   1366   1367     1
+   1359   1366   1368     1
+   1367   1366   1368     1
+   1366   1368   1369     1
+   1366   1368   1370     1
+   1369   1368   1370     1
+   1368   1370   1371     1
+   1368   1370   1372     1
+   1368   1370   1382     1
+   1371   1370   1372     1
+   1371   1370   1382     1
+   1372   1370   1382     1
+   1370   1372   1373     1
+   1370   1372   1374     1
+   1370   1372   1378     1
+   1373   1372   1374     1
+   1373   1372   1378     1
+   1374   1372   1378     1
+   1372   1374   1375     1
+   1372   1374   1376     1
+   1372   1374   1377     1
+   1375   1374   1376     1
+   1375   1374   1377     1
+   1376   1374   1377     1
+   1372   1378   1379     1
+   1372   1378   1380     1
+   1372   1378   1381     1
+   1379   1378   1380     1
+   1379   1378   1381     1
+   1380   1378   1381     1
+   1370   1382   1383     1
+   1370   1382   1384     1
+   1383   1382   1384     1
+   1382   1384   1385     1
+   1382   1384   1386     1
+   1385   1384   1386     1
+   1384   1386   1387     1
+   1384   1386   1388     1
+   1384   1386   1396     1
+   1387   1386   1388     1
+   1387   1386   1396     1
+   1388   1386   1396     1
+   1386   1388   1389     1
+   1386   1388   1390     1
+   1386   1388   1391     1
+   1389   1388   1390     1
+   1389   1388   1391     1
+   1390   1388   1391     1
+   1388   1391   1392     1
+   1388   1391   1393     1
+   1392   1391   1393     1
+   1391   1393   1394     1
+   1391   1393   1395     1
+   1394   1393   1395     1
+   1386   1396   1397     1
+   1386   1396   1398     1
+   1397   1396   1398     1
+   1396   1398   1399     1
+   1396   1398   1400     1
+   1399   1398   1400     1
+   1398   1400   1401     1
+   1398   1400   1402     1
+   1398   1400   1406     1
+   1401   1400   1402     1
+   1401   1400   1406     1
+   1402   1400   1406     1
+   1400   1402   1403     1
+   1400   1402   1404     1
+   1400   1402   1405     1
+   1403   1402   1404     1
+   1403   1402   1405     1
+   1404   1402   1405     1
+   1161   1405   1402     1
+   1400   1406   1407     1
+   1400   1406   1408     1
+   1407   1406   1408     1
+   1406   1408   1409     1
+   1406   1408   1410     1
+   1409   1408   1410     1
+   1408   1410   1411     1
+   1408   1410   1412     1
+   1408   1410   1416     1
+   1411   1410   1412     1
+   1411   1410   1416     1
+   1412   1410   1416     1
+   1410   1412   1413     1
+   1410   1412   1414     1
+   1410   1412   1415     1
+   1413   1412   1414     1
+   1413   1412   1415     1
+   1414   1412   1415     1
+   1410   1416   1417     1
+   1410   1416   1418     1
+   1417   1416   1418     1
+   1416   1418   1419     1
+   1416   1418   1420     1
+   1419   1418   1420     1
+   1418   1420   1421     1
+   1418   1420   1422     1
+   1418   1420   1438     1
+   1421   1420   1422     1
+   1421   1420   1438     1
+   1422   1420   1438     1
+   1420   1422   1423     1
+   1420   1422   1424     1
+   1420   1422   1425     1
+   1423   1422   1424     1
+   1423   1422   1425     1
+   1424   1422   1425     1
+   1422   1425   1426     1
+   1422   1425   1427     1
+   1422   1425   1428     1
+   1426   1425   1427     1
+   1426   1425   1428     1
+   1427   1425   1428     1
+   1425   1428   1429     1
+   1425   1428   1430     1
+   1425   1428   1431     1
+   1429   1428   1430     1
+   1429   1428   1431     1
+   1430   1428   1431     1
+   1428   1431   1432     1
+   1428   1431   1433     1
+   1428   1431   1434     1
+   1432   1431   1433     1
+   1432   1431   1434     1
+   1433   1431   1434     1
+   1431   1434   1435     1
+   1431   1434   1436     1
+   1431   1434   1437     1
+   1435   1434   1436     1
+   1435   1434   1437     1
+   1436   1434   1437     1
+   1420   1438   1439     1
+   1420   1438   1440     1
+   1439   1438   1440     1
+   1438   1440   1441     1
+   1438   1440   1442     1
+   1441   1440   1442     1
+   1440   1442   1443     1
+   1440   1442   1444     1
+   1440   1442   1460     1
+   1443   1442   1444     1
+   1443   1442   1460     1
+   1444   1442   1460     1
+   1442   1444   1445     1
+   1442   1444   1446     1
+   1442   1444   1447     1
+   1445   1444   1446     1
+   1445   1444   1447     1
+   1446   1444   1447     1
+   1444   1447   1448     1
+   1444   1447   1449     1
+   1444   1447   1450     1
+   1448   1447   1449     1
+   1448   1447   1450     1
+   1449   1447   1450     1
+   1447   1450   1451     1
+   1447   1450   1452     1
+   1447   1450   1453     1
+   1451   1450   1452     1
+   1451   1450   1453     1
+   1452   1450   1453     1
+   1450   1453   1454     1
+   1450   1453   1455     1
+   1450   1453   1456     1
+   1454   1453   1455     1
+   1454   1453   1456     1
+   1455   1453   1456     1
+   1453   1456   1457     1
+   1453   1456   1458     1
+   1453   1456   1459     1
+   1457   1456   1458     1
+   1457   1456   1459     1
+   1458   1456   1459     1
+   1442   1460   1461     1
+   1442   1460   1462     1
+   1461   1460   1462     1
+   1460   1462   1463     1
+   1460   1462   1464     1
+   1463   1462   1464     1
+   1462   1464   1465     1
+   1462   1464   1466     1
+   1462   1464   1479     1
+   1465   1464   1466     1
+   1465   1464   1479     1
+   1466   1464   1479     1
+   1464   1466   1467     1
+   1464   1466   1468     1
+   1464   1466   1472     1
+   1467   1466   1468     1
+   1467   1466   1472     1
+   1468   1466   1472     1
+   1466   1468   1469     1
+   1466   1468   1470     1
+   1466   1468   1471     1
+   1469   1468   1470     1
+   1469   1468   1471     1
+   1470   1468   1471     1
+   1466   1472   1473     1
+   1466   1472   1474     1
+   1466   1472   1475     1
+   1473   1472   1474     1
+   1473   1472   1475     1
+   1474   1472   1475     1
+   1472   1475   1476     1
+   1472   1475   1477     1
+   1472   1475   1478     1
+   1476   1475   1477     1
+   1476   1475   1478     1
+   1477   1475   1478     1
+   1464   1479   1480     1
+   1464   1479   1481     1
+   1480   1479   1481     1
+   1479   1481   1482     1
+   1479   1481   1483     1
+   1482   1481   1483     1
+   1481   1483   1484     1
+   1481   1483   1485     1
+   1481   1483   1495     1
+   1484   1483   1485     1
+   1484   1483   1495     1
+   1485   1483   1495     1
+   1483   1485   1486     1
+   1483   1485   1487     1
+   1483   1485   1491     1
+   1486   1485   1487     1
+   1486   1485   1491     1
+   1487   1485   1491     1
+   1485   1487   1488     1
+   1485   1487   1489     1
+   1485   1487   1490     1
+   1488   1487   1489     1
+   1488   1487   1490     1
+   1489   1487   1490     1
+   1485   1491   1492     1
+   1485   1491   1493     1
+   1485   1491   1494     1
+   1492   1491   1493     1
+   1492   1491   1494     1
+   1493   1491   1494     1
+   1483   1495   1496     1
+   1483   1495   1497     1
+   1496   1495   1497     1
+   1495   1497   1498     1
+   1495   1497   1499     1
+   1498   1497   1499     1
+   1497   1499   1500     1
+   1497   1499   1501     1
+   1497   1499   1506     1
+   1500   1499   1501     1
+   1500   1499   1506     1
+   1501   1499   1506     1
+   1499   1501   1502     1
+   1499   1501   1503     1
+   1499   1501   1504     1
+   1502   1501   1503     1
+   1502   1501   1504     1
+   1503   1501   1504     1
+   1501   1504   1505     1
+   1499   1506   1507     1
+   1499   1506   1508     1
+   1507   1506   1508     1
+   1506   1508   1509     1
+   1506   1508   1510     1
+   1509   1508   1510     1
+   1508   1510   1511     1
+   1508   1510   1512     1
+   1508   1510   1518     1
+   1511   1510   1512     1
+   1511   1510   1518     1
+   1512   1510   1518     1
+   1510   1512   1513     1
+   1510   1512   1514     1
+   1510   1512   1515     1
+   1513   1512   1514     1
+   1513   1512   1515     1
+   1514   1512   1515     1
+   1512   1515   1516     1
+   1512   1515   1517     1
+   1516   1515   1517     1
+   1510   1518   1519     1
+   1510   1518   1520     1
+   1519   1518   1520     1
+   1518   1520   1521     1
+   1518   1520   1522     1
+   1521   1520   1522     1
+   1520   1522   1523     1
+   1520   1522   1524     1
+   1520   1522   1525     1
+   1523   1522   1524     1
+   1523   1522   1525     1
+   1524   1522   1525     1
+   1522   1525   1526     1
+   1522   1525   1527     1
+   1526   1525   1527     1
+   1525   1527   1528     1
+   1525   1527   1529     1
+   1528   1527   1529     1
+   1527   1529   1530     1
+   1527   1529   1531     1
+   1527   1529   1539     1
+   1530   1529   1531     1
+   1530   1529   1539     1
+   1531   1529   1539     1
+   1529   1531   1532     1
+   1529   1531   1533     1
+   1529   1531   1534     1
+   1532   1531   1533     1
+   1532   1531   1534     1
+   1533   1531   1534     1
+   1531   1534   1535     1
+   1531   1534   1536     1
+   1535   1534   1536     1
+   1534   1536   1537     1
+   1534   1536   1538     1
+   1537   1536   1538     1
+   1529   1539   1540     1
+   1529   1539   1541     1
+   1540   1539   1541     1
+   1539   1541   1542     1
+   1539   1541   1543     1
+   1542   1541   1543     1
+   1541   1543   1544     1
+   1541   1543   1545     1
+   1541   1543   1546     1
+   1544   1543   1545     1
+   1544   1543   1546     1
+   1545   1543   1546     1
+   1543   1546   1547     1
+   1543   1546   1548     1
+   1547   1546   1548     1
+   1546   1548   1549     1
+   1546   1548   1550     1
+   1549   1548   1550     1
+   1548   1550   1551     1
+   1548   1550   1552     1
+   1548   1550   1563     1
+   1551   1550   1552     1
+   1551   1550   1563     1
+   1552   1550   1563     1
+   1550   1552   1553     1
+   1550   1552   1554     1
+   1550   1552   1555     1
+   1553   1552   1554     1
+   1553   1552   1555     1
+   1554   1552   1555     1
+   1552   1555   1556     1
+   1552   1555   1557     1
+   1552   1555   1558     1
+   1556   1555   1557     1
+   1556   1555   1558     1
+   1557   1555   1558     1
+   1555   1558   1559     1
+   1558   1559   1560     1
+   1558   1559   1561     1
+   1558   1559   1562     1
+   1560   1559   1561     1
+   1560   1559   1562     1
+   1561   1559   1562     1
+   1550   1563   1564     1
+   1550   1563   1565     1
+   1564   1563   1565     1
+   1563   1565   1566     1
+   1563   1565   1567     1
+   1566   1565   1567     1
+   1565   1567   1568     1
+   1565   1567   1569     1
+   1565   1567   1577     1
+   1568   1567   1569     1
+   1568   1567   1577     1
+   1569   1567   1577     1
+   1567   1569   1570     1
+   1567   1569   1571     1
+   1567   1569   1572     1
+   1570   1569   1571     1
+   1570   1569   1572     1
+   1571   1569   1572     1
+   1569   1572   1573     1
+   1569   1572   1574     1
+   1573   1572   1574     1
+   1572   1574   1575     1
+   1572   1574   1576     1
+   1575   1574   1576     1
+   1567   1577   1578     1
+   1567   1577   1579     1
+   1578   1577   1579     1
+   1577   1579   1580     1
+   1577   1579   1581     1
+   1580   1579   1581     1
+   1579   1581   1582     1
+   1579   1581   1583     1
+   1579   1581   1587     1
+   1582   1581   1583     1
+   1582   1581   1587     1
+   1583   1581   1587     1
+   1581   1583   1584     1
+   1581   1583   1585     1
+   1581   1583   1586     1
+   1584   1583   1585     1
+   1584   1583   1586     1
+   1585   1583   1586     1
+   1581   1587   1588     1
+   1581   1587   1589     1
+   1588   1587   1589     1
+   1587   1589   1590     1
+   1587   1589   1591     1
+   1590   1589   1591     1
+   1589   1591   1592     1
+   1589   1591   1593     1
+   1589   1591   1611     1
+   1592   1591   1593     1
+   1592   1591   1611     1
+   1593   1591   1611     1
+   1591   1593   1594     1
+   1591   1593   1595     1
+   1591   1593   1596     1
+   1594   1593   1595     1
+   1594   1593   1596     1
+   1595   1593   1596     1
+   1593   1596   1597     1
+   1593   1596   1610     1
+   1597   1596   1610     1
+   1596   1597   1598     1
+   1596   1597   1599     1
+   1598   1597   1599     1
+   1597   1599   1600     1
+   1597   1599   1601     1
+   1600   1599   1601     1
+   1599   1601   1602     1
+   1599   1601   1610     1
+   1602   1601   1610     1
+   1601   1602   1603     1
+   1601   1602   1604     1
+   1603   1602   1604     1
+   1602   1604   1605     1
+   1602   1604   1606     1
+   1605   1604   1606     1
+   1604   1606   1607     1
+   1604   1606   1608     1
+   1607   1606   1608     1
+   1606   1608   1609     1
+   1606   1608   1610     1
+   1609   1608   1610     1
+   1596   1610   1601     1
+   1596   1610   1608     1
+   1601   1610   1608     1
+   1591   1611   1612     1
+   1591   1611   1613     1
+   1612   1611   1613     1
+   1611   1613   1614     1
+   1611   1613   1615     1
+   1614   1613   1615     1
+   1613   1615   1616     1
+   1613   1615   1617     1
+   1613   1615   1627     1
+   1616   1615   1617     1
+   1616   1615   1627     1
+   1617   1615   1627     1
+   1615   1617   1618     1
+   1615   1617   1619     1
+   1615   1617   1623     1
+   1618   1617   1619     1
+   1618   1617   1623     1
+   1619   1617   1623     1
+   1617   1619   1620     1
+   1617   1619   1621     1
+   1617   1619   1622     1
+   1620   1619   1621     1
+   1620   1619   1622     1
+   1621   1619   1622     1
+   1617   1623   1624     1
+   1617   1623   1625     1
+   1617   1623   1626     1
+   1624   1623   1625     1
+   1624   1623   1626     1
+   1625   1623   1626     1
+   1615   1627   1628     1
+   1615   1627   1629     1
+   1628   1627   1629     1
+   1627   1629   1630     1
+   1627   1629   1631     1
+   1630   1629   1631     1
+   1629   1631   1632     1
+   1629   1631   1633     1
+   1629   1631   1637     1
+   1632   1631   1633     1
+   1632   1631   1637     1
+   1633   1631   1637     1
+   1631   1633   1634     1
+   1631   1633   1635     1
+   1631   1633   1636     1
+   1634   1633   1635     1
+   1634   1633   1636     1
+   1635   1633   1636     1
+   1631   1637   1638     1
+   1631   1637   1639     1
+   1638   1637   1639     1
+   1637   1639   1640     1
+   1637   1639   1641     1
+   1640   1639   1641     1
+   1639   1641   1642     1
+   1639   1641   1643     1
+   1639   1641   1661     1
+   1642   1641   1643     1
+   1642   1641   1661     1
+   1643   1641   1661     1
+   1641   1643   1644     1
+   1641   1643   1645     1
+   1641   1643   1646     1
+   1644   1643   1645     1
+   1644   1643   1646     1
+   1645   1643   1646     1
+   1643   1646   1647     1
+   1643   1646   1660     1
+   1647   1646   1660     1
+   1646   1647   1648     1
+   1646   1647   1649     1
+   1648   1647   1649     1
+   1647   1649   1650     1
+   1647   1649   1651     1
+   1650   1649   1651     1
+   1649   1651   1652     1
+   1649   1651   1660     1
+   1652   1651   1660     1
+   1651   1652   1653     1
+   1651   1652   1654     1
+   1653   1652   1654     1
+   1652   1654   1655     1
+   1652   1654   1656     1
+   1655   1654   1656     1
+   1654   1656   1657     1
+   1654   1656   1658     1
+   1657   1656   1658     1
+   1656   1658   1659     1
+   1656   1658   1660     1
+   1659   1658   1660     1
+   1646   1660   1651     1
+   1646   1660   1658     1
+   1651   1660   1658     1
+   1641   1661   1662     1
+   1641   1661   1663     1
+   1662   1661   1663     1
+   1661   1663   1664     1
+   1661   1663   1665     1
+   1664   1663   1665     1
+   1663   1665   1666     1
+   1663   1665   1667     1
+   1663   1665   1685     1
+   1666   1665   1667     1
+   1666   1665   1685     1
+   1667   1665   1685     1
+   1665   1667   1668     1
+   1665   1667   1669     1
+   1665   1667   1670     1
+   1668   1667   1669     1
+   1668   1667   1670     1
+   1669   1667   1670     1
+   1667   1670   1671     1
+   1667   1670   1672     1
+   1667   1670   1673     1
+   1671   1670   1672     1
+   1671   1670   1673     1
+   1672   1670   1673     1
+   1670   1673   1674     1
+   1670   1673   1675     1
+   1670   1673   1676     1
+   1674   1673   1675     1
+   1674   1673   1676     1
+   1675   1673   1676     1
+   1673   1676   1677     1
+   1673   1676   1678     1
+   1677   1676   1678     1
+   1676   1678   1679     1
+   1676   1678   1682     1
+   1679   1678   1682     1
+   1678   1679   1680     1
+   1678   1679   1681     1
+   1680   1679   1681     1
+   1678   1682   1683     1
+   1678   1682   1684     1
+   1683   1682   1684     1
+   1665   1685   1686     1
+   1665   1685   1687     1
+   1686   1685   1687     1
+   1685   1687   1688     1
+   1685   1687   1689     1
+   1688   1687   1689     1
+   1687   1689   1690     1
+   1687   1689   1691     1
+   1687   1689   1699     1
+   1690   1689   1691     1
+   1690   1689   1699     1
+   1691   1689   1699     1
+   1689   1691   1692     1
+   1689   1691   1693     1
+   1689   1691   1694     1
+   1692   1691   1693     1
+   1692   1691   1694     1
+   1693   1691   1694     1
+   1691   1694   1695     1
+   1691   1694   1696     1
+   1695   1694   1696     1
+   1694   1696   1697     1
+   1694   1696   1698     1
+   1697   1696   1698     1
+   1689   1699   1700     1
+   1689   1699   1701     1
+   1700   1699   1701     1
+   1699   1701   1702     1
+   1699   1701   1703     1
+   1702   1701   1703     1
+   1701   1703   1704     1
+   1701   1703   1705     1
+   1701   1703   1723     1
+   1704   1703   1705     1
+   1704   1703   1723     1
+   1705   1703   1723     1
+   1703   1705   1706     1
+   1703   1705   1707     1
+   1703   1705   1708     1
+   1706   1705   1707     1
+   1706   1705   1708     1
+   1707   1705   1708     1
+   1705   1708   1709     1
+   1705   1708   1710     1
+   1705   1708   1711     1
+   1709   1708   1710     1
+   1709   1708   1711     1
+   1710   1708   1711     1
+   1708   1711   1712     1
+   1708   1711   1713     1
+   1708   1711   1714     1
+   1712   1711   1713     1
+   1712   1711   1714     1
+   1713   1711   1714     1
+   1711   1714   1715     1
+   1711   1714   1716     1
+   1715   1714   1716     1
+   1714   1716   1717     1
+   1714   1716   1720     1
+   1717   1716   1720     1
+   1716   1717   1718     1
+   1716   1717   1719     1
+   1718   1717   1719     1
+   1716   1720   1721     1
+   1716   1720   1722     1
+   1721   1720   1722     1
+   1703   1723   1724     1
+   1703   1723   1725     1
+   1724   1723   1725     1
+   1723   1725   1726     1
+   1723   1725   1727     1
+   1726   1725   1727     1
+   1725   1727   1728     1
+   1725   1727   1729     1
+   1725   1727   1733     1
+   1728   1727   1729     1
+   1728   1727   1733     1
+   1729   1727   1733     1
+   1727   1729   1730     1
+   1727   1729   1731     1
+   1727   1729   1732     1
+   1730   1729   1731     1
+   1730   1729   1732     1
+   1731   1729   1732     1
+    469   1732   1729     1
+   1727   1733   1734     1
+   1727   1733   1735     1
+   1734   1733   1735     1
+   1733   1735   1736     1
+   1733   1735   1737     1
+   1736   1735   1737     1
+   1735   1737   1738     1
+   1735   1737   1739     1
+   1735   1737   1755     1
+   1738   1737   1739     1
+   1738   1737   1755     1
+   1739   1737   1755     1
+   1737   1739   1740     1
+   1737   1739   1741     1
+   1737   1739   1742     1
+   1740   1739   1741     1
+   1740   1739   1742     1
+   1741   1739   1742     1
+   1739   1742   1743     1
+   1739   1742   1744     1
+   1739   1742   1745     1
+   1743   1742   1744     1
+   1743   1742   1745     1
+   1744   1742   1745     1
+   1742   1745   1746     1
+   1742   1745   1747     1
+   1742   1745   1748     1
+   1746   1745   1747     1
+   1746   1745   1748     1
+   1747   1745   1748     1
+   1745   1748   1749     1
+   1745   1748   1750     1
+   1745   1748   1751     1
+   1749   1748   1750     1
+   1749   1748   1751     1
+   1750   1748   1751     1
+   1748   1751   1752     1
+   1748   1751   1753     1
+   1748   1751   1754     1
+   1752   1751   1753     1
+   1752   1751   1754     1
+   1753   1751   1754     1
+   1737   1755   1756     1
+   1737   1755   1757     1
+   1756   1755   1757     1
+   1755   1757   1758     1
+   1755   1757   1759     1
+   1758   1757   1759     1
+   1757   1759   1760     1
+   1757   1759   1761     1
+   1757   1759   1762     1
+   1760   1759   1761     1
+   1760   1759   1762     1
+   1761   1759   1762     1
+   1759   1762   1763     1
+   1759   1762   1764     1
+   1763   1762   1764     1
+   1762   1764   1765     1
+   1762   1764   1766     1
+   1765   1764   1766     1
+   1764   1766   1767     1
+   1764   1766   1768     1
+   1764   1766   1776     1
+   1767   1766   1768     1
+   1767   1766   1776     1
+   1768   1766   1776     1
+   1766   1768   1769     1
+   1766   1768   1770     1
+   1766   1768   1774     1
+   1769   1768   1770     1
+   1769   1768   1774     1
+   1770   1768   1774     1
+   1768   1770   1771     1
+   1768   1770   1772     1
+   1768   1770   1773     1
+   1771   1770   1772     1
+   1771   1770   1773     1
+   1772   1770   1773     1
+   1768   1774   1775     1
+   1766   1776   1777     1
+   1766   1776   1778     1
+   1777   1776   1778     1
+   1776   1778   1779     1
+   1776   1778   1780     1
+   1779   1778   1780     1
+   1778   1780   1781     1
+   1778   1780   1782     1
+   1778   1780   1788     1
+   1781   1780   1782     1
+   1781   1780   1788     1
+   1782   1780   1788     1
+   1780   1782   1783     1
+   1780   1782   1784     1
+   1780   1782   1785     1
+   1783   1782   1784     1
+   1783   1782   1785     1
+   1784   1782   1785     1
+   1782   1785   1786     1
+   1782   1785   1787     1
+   1786   1785   1787     1
+   1780   1788   1789     1
+   1780   1788   1790     1
+   1789   1788   1790     1
+   1788   1790   1791     1
+   1788   1790   1792     1
+   1791   1790   1792     1
+   1790   1792   1793     1
+   1790   1792   1794     1
+   1790   1792   1804     1
+   1793   1792   1794     1
+   1793   1792   1804     1
+   1794   1792   1804     1
+   1792   1794   1795     1
+   1792   1794   1796     1
+   1792   1794   1800     1
+   1795   1794   1796     1
+   1795   1794   1800     1
+   1796   1794   1800     1
+   1794   1796   1797     1
+   1794   1796   1798     1
+   1794   1796   1799     1
+   1797   1796   1798     1
+   1797   1796   1799     1
+   1798   1796   1799     1
+   1794   1800   1801     1
+   1794   1800   1802     1
+   1794   1800   1803     1
+   1801   1800   1802     1
+   1801   1800   1803     1
+   1802   1800   1803     1
+   1792   1804   1805     1
+   1792   1804   1806     1
+   1805   1804   1806     1
+   1804   1806   1807     1
+   1804   1806   1808     1
+   1807   1806   1808     1
+   1806   1808   1809     1
+   1806   1808   1810     1
+   1806   1808   1821     1
+   1809   1808   1810     1
+   1809   1808   1821     1
+   1810   1808   1821     1
+   1808   1810   1811     1
+   1808   1810   1812     1
+   1808   1810   1813     1
+   1811   1810   1812     1
+   1811   1810   1813     1
+   1812   1810   1813     1
+   1810   1813   1814     1
+   1810   1813   1815     1
+   1810   1813   1816     1
+   1814   1813   1815     1
+   1814   1813   1816     1
+   1815   1813   1816     1
+   1813   1816   1817     1
+   1813   1816   1818     1
+   1817   1816   1818     1
+   1816   1818   1819     1
+   1816   1818   1820     1
+   1819   1818   1820     1
+   1808   1821   1822     1
+   1808   1821   1823     1
+   1822   1821   1823     1
+   1821   1823   1824     1
+   1821   1823   1825     1
+   1824   1823   1825     1
+   1823   1825   1826     1
+   1823   1825   1827     1
+   1823   1825   1831     1
+   1826   1825   1827     1
+   1826   1825   1831     1
+   1827   1825   1831     1
+   1825   1827   1828     1
+   1825   1827   1829     1
+   1825   1827   1830     1
+   1828   1827   1829     1
+   1828   1827   1830     1
+   1829   1827   1830     1
+   1825   1831   1832     1
+   1825   1831   1833     1
+   1832   1831   1833     1
+   1831   1833   1834     1
+   1831   1833   1835     1
+   1834   1833   1835     1
+   1833   1835   1836     1
+   1833   1835   1837     1
+   1833   1835   1855     1
+   1836   1835   1837     1
+   1836   1835   1855     1
+   1837   1835   1855     1
+   1835   1837   1838     1
+   1835   1837   1839     1
+   1835   1837   1840     1
+   1838   1837   1839     1
+   1838   1837   1840     1
+   1839   1837   1840     1
+   1837   1840   1841     1
+   1837   1840   1854     1
+   1841   1840   1854     1
+   1840   1841   1842     1
+   1840   1841   1843     1
+   1842   1841   1843     1
+   1841   1843   1844     1
+   1841   1843   1845     1
+   1844   1843   1845     1
+   1843   1845   1846     1
+   1843   1845   1854     1
+   1846   1845   1854     1
+   1845   1846   1847     1
+   1845   1846   1848     1
+   1847   1846   1848     1
+   1846   1848   1849     1
+   1846   1848   1850     1
+   1849   1848   1850     1
+   1848   1850   1851     1
+   1848   1850   1852     1
+   1851   1850   1852     1
+   1850   1852   1853     1
+   1850   1852   1854     1
+   1853   1852   1854     1
+   1840   1854   1845     1
+   1840   1854   1852     1
+   1845   1854   1852     1
+   1835   1855   1856     1
+   1835   1855   1857     1
+   1856   1855   1857     1
+   1855   1857   1858     1
+   1855   1857   1859     1
+   1858   1857   1859     1
+   1857   1859   1860     1
+   1857   1859   1861     1
+   1857   1859   1874     1
+   1860   1859   1861     1
+   1860   1859   1874     1
+   1861   1859   1874     1
+   1859   1861   1862     1
+   1859   1861   1863     1
+   1859   1861   1867     1
+   1862   1861   1863     1
+   1862   1861   1867     1
+   1863   1861   1867     1
+   1861   1863   1864     1
+   1861   1863   1865     1
+   1861   1863   1866     1
+   1864   1863   1865     1
+   1864   1863   1866     1
+   1865   1863   1866     1
+   1861   1867   1868     1
+   1861   1867   1869     1
+   1861   1867   1870     1
+   1868   1867   1869     1
+   1868   1867   1870     1
+   1869   1867   1870     1
+   1867   1870   1871     1
+   1867   1870   1872     1
+   1867   1870   1873     1
+   1871   1870   1872     1
+   1871   1870   1873     1
+   1872   1870   1873     1
+   1859   1874   1875     1
+   1859   1874   1876     1
+   1875   1874   1876     1
+   1874   1876   1877     1
+   1874   1876   1878     1
+   1877   1876   1878     1
+   1876   1878   1879     1
+   1876   1878   1880     1
+   1876   1878   1898     1
+   1879   1878   1880     1
+   1879   1878   1898     1
+   1880   1878   1898     1
+   1878   1880   1881     1
+   1878   1880   1882     1
+   1878   1880   1883     1
+   1881   1880   1882     1
+   1881   1880   1883     1
+   1882   1880   1883     1
+   1880   1883   1884     1
+   1880   1883   1885     1
+   1880   1883   1886     1
+   1884   1883   1885     1
+   1884   1883   1886     1
+   1885   1883   1886     1
+   1883   1886   1887     1
+   1883   1886   1888     1
+   1883   1886   1889     1
+   1887   1886   1888     1
+   1887   1886   1889     1
+   1888   1886   1889     1
+   1886   1889   1890     1
+   1886   1889   1891     1
+   1890   1889   1891     1
+   1889   1891   1892     1
+   1889   1891   1895     1
+   1892   1891   1895     1
+   1891   1892   1893     1
+   1891   1892   1894     1
+   1893   1892   1894     1
+   1891   1895   1896     1
+   1891   1895   1897     1
+   1896   1895   1897     1
+   1878   1898   1899     1
+   1878   1898   1900     1
+   1899   1898   1900     1
+   1898   1900   1901     1
+   1898   1900   1902     1
+   1901   1900   1902     1
+   1900   1902   1903     1
+   1900   1902   1904     1
+   1900   1902   1905     1
+   1903   1902   1904     1
+   1903   1902   1905     1
+   1904   1902   1905     1
+   1902   1905   1906     1
+   1902   1905   1907     1
+   1906   1905   1907     1
+   1905   1907   1908     1
+   1905   1907   1909     1
+   1908   1907   1909     1
+   1907   1909   1910     1
+   1907   1909   1911     1
+   1907   1909   1915     1
+   1910   1909   1911     1
+   1910   1909   1915     1
+   1911   1909   1915     1
+   1909   1911   1912     1
+   1909   1911   1913     1
+   1909   1911   1914     1
+   1912   1911   1913     1
+   1912   1911   1914     1
+   1913   1911   1914     1
+     99   1914   1911     1
+   1909   1915   1916     1
+   1909   1915   1917     1
+   1916   1915   1917     1
+   1915   1917   1918     1
+   1915   1917   1919     1
+   1918   1917   1919     1
+   1917   1919   1920     1
+   1917   1919   1921     1
+   1917   1919   1939     1
+   1920   1919   1921     1
+   1920   1919   1939     1
+   1921   1919   1939     1
+   1919   1921   1922     1
+   1919   1921   1923     1
+   1919   1921   1924     1
+   1922   1921   1923     1
+   1922   1921   1924     1
+   1923   1921   1924     1
+   1921   1924   1925     1
+   1921   1924   1926     1
+   1921   1924   1927     1
+   1925   1924   1926     1
+   1925   1924   1927     1
+   1926   1924   1927     1
+   1924   1927   1928     1
+   1924   1927   1929     1
+   1924   1927   1930     1
+   1928   1927   1929     1
+   1928   1927   1930     1
+   1929   1927   1930     1
+   1927   1930   1931     1
+   1927   1930   1932     1
+   1931   1930   1932     1
+   1930   1932   1933     1
+   1930   1932   1936     1
+   1933   1932   1936     1
+   1932   1933   1934     1
+   1932   1933   1935     1
+   1934   1933   1935     1
+   1932   1936   1937     1
+   1932   1936   1938     1
+   1937   1936   1938     1
+   1919   1939   1940     1
+   1919   1939   1941     1
+   1940   1939   1941     1
+   1939   1941   1942     1
+   1939   1941   1943     1
+   1942   1941   1943     1
+   1941   1943   1944     1
+   1941   1943   1945     1
+   1941   1943   1958     1
+   1944   1943   1945     1
+   1944   1943   1958     1
+   1945   1943   1958     1
+   1943   1945   1946     1
+   1943   1945   1947     1
+   1943   1945   1948     1
+   1946   1945   1947     1
+   1946   1945   1948     1
+   1947   1945   1948     1
+   1945   1948   1949     1
+   1945   1948   1950     1
+   1945   1948   1954     1
+   1949   1948   1950     1
+   1949   1948   1954     1
+   1950   1948   1954     1
+   1948   1950   1951     1
+   1948   1950   1952     1
+   1948   1950   1953     1
+   1951   1950   1952     1
+   1951   1950   1953     1
+   1952   1950   1953     1
+   1948   1954   1955     1
+   1948   1954   1956     1
+   1948   1954   1957     1
+   1955   1954   1956     1
+   1955   1954   1957     1
+   1956   1954   1957     1
+   1943   1958   1959     1
+   1943   1958   1960     1
+   1959   1958   1960     1
+
+[ dihedrals ]
+;    ai     aj     ak     al funct         c0         c1         c2         c3         c4         c5
+      2      1      5      6     9
+      2      1      5      7     9
+      2      1      5     23     9
+      3      1      5      6     9
+      3      1      5      7     9
+      3      1      5     23     9
+      4      1      5      6     9
+      4      1      5      7     9
+      4      1      5     23     9
+      1      5      7      8     9
+      1      5      7      9     9
+      1      5      7     10     9
+      6      5      7      8     9
+      6      5      7      9     9
+      6      5      7     10     9
+     23      5      7      8     9
+     23      5      7      9     9
+     23      5      7     10     9
+      1      5     23     24     9
+      1      5     23     25     9
+      6      5     23     24     9
+      6      5     23     25     9
+      7      5     23     24     9
+      7      5     23     25     9
+      5      7     10     11     9
+      5      7     10     12     9
+      5      7     10     13     9
+      8      7     10     11     9
+      8      7     10     12     9
+      8      7     10     13     9
+      9      7     10     11     9
+      9      7     10     12     9
+      9      7     10     13     9
+      7     10     13     14     9
+      7     10     13     15     9
+      7     10     13     16     9
+     11     10     13     14     9
+     11     10     13     15     9
+     11     10     13     16     9
+     12     10     13     14     9
+     12     10     13     15     9
+     12     10     13     16     9
+     10     13     16     17     9
+     10     13     16     18     9
+     10     13     16     19     9
+     14     13     16     17     9
+     14     13     16     18     9
+     14     13     16     19     9
+     15     13     16     17     9
+     15     13     16     18     9
+     15     13     16     19     9
+     13     16     19     20     9
+     13     16     19     21     9
+     13     16     19     22     9
+     17     16     19     20     9
+     17     16     19     21     9
+     17     16     19     22     9
+     18     16     19     20     9
+     18     16     19     21     9
+     18     16     19     22     9
+      5     23     25     26     9
+      5     23     25     27     9
+     24     23     25     26     9
+     24     23     25     27     9
+     23     25     27     28     9
+     23     25     27     29     9
+     23     25     27     39     9
+     26     25     27     28     9
+     26     25     27     29     9
+     26     25     27     39     9
+     25     27     29     30     9
+     25     27     29     31     9
+     25     27     29     35     9
+     28     27     29     30     9
+     28     27     29     31     9
+     28     27     29     35     9
+     39     27     29     30     9
+     39     27     29     31     9
+     39     27     29     35     9
+     25     27     39     40     9
+     25     27     39     41     9
+     28     27     39     40     9
+     28     27     39     41     9
+     29     27     39     40     9
+     29     27     39     41     9
+     27     29     31     32     9
+     27     29     31     33     9
+     27     29     31     34     9
+     30     29     31     32     9
+     30     29     31     33     9
+     30     29     31     34     9
+     35     29     31     32     9
+     35     29     31     33     9
+     35     29     31     34     9
+     27     29     35     36     9
+     27     29     35     37     9
+     27     29     35     38     9
+     30     29     35     36     9
+     30     29     35     37     9
+     30     29     35     38     9
+     31     29     35     36     9
+     31     29     35     37     9
+     31     29     35     38     9
+     27     39     41     42     9
+     27     39     41     43     9
+     40     39     41     42     9
+     40     39     41     43     9
+     39     41     43     44     9
+     39     41     43     45     9
+     39     41     43     59     9
+     42     41     43     44     9
+     42     41     43     45     9
+     42     41     43     59     9
+     41     43     45     46     9
+     41     43     45     47     9
+     41     43     45     48     9
+     44     43     45     46     9
+     44     43     45     47     9
+     44     43     45     48     9
+     59     43     45     46     9
+     59     43     45     47     9
+     59     43     45     48     9
+     41     43     59     60     9
+     41     43     59     61     9
+     44     43     59     60     9
+     44     43     59     61     9
+     45     43     59     60     9
+     45     43     59     61     9
+     43     45     48     49     9
+     43     45     48     57     9
+     46     45     48     49     9
+     46     45     48     57     9
+     47     45     48     49     9
+     47     45     48     57     9
+     45     48     49     50     9
+     45     48     49     51     9
+     57     48     49     50     9
+     57     48     49     51     9
+     45     48     57     55     9
+     45     48     57     58     9
+     49     48     57     55     9
+     49     48     57     58     9
+     48     49     51     52     9
+     48     49     51     53     9
+     50     49     51     52     9
+     50     49     51     53     9
+     49     51     53     54     9
+     49     51     53     55     9
+     52     51     53     54     9
+     52     51     53     55     9
+     51     53     55     56     9
+     51     53     55     57     9
+     54     53     55     56     9
+     54     53     55     57     9
+     53     55     57     48     9
+     53     55     57     58     9
+     56     55     57     48     9
+     56     55     57     58     9
+     43     59     61     62     9
+     43     59     61     63     9
+     60     59     61     62     9
+     60     59     61     63     9
+     59     61     63     64     9
+     59     61     63     65     9
+     59     61     63     66     9
+     62     61     63     64     9
+     62     61     63     65     9
+     62     61     63     66     9
+     61     63     66     67     9
+     61     63     66     68     9
+     64     63     66     67     9
+     64     63     66     68     9
+     65     63     66     67     9
+     65     63     66     68     9
+     63     66     68     69     9
+     63     66     68     70     9
+     67     66     68     69     9
+     67     66     68     70     9
+     66     68     70     71     9
+     66     68     70     72     9
+     66     68     70     90     9
+     69     68     70     71     9
+     69     68     70     72     9
+     69     68     70     90     9
+     68     70     72     73     9
+     68     70     72     74     9
+     68     70     72     75     9
+     71     70     72     73     9
+     71     70     72     74     9
+     71     70     72     75     9
+     90     70     72     73     9
+     90     70     72     74     9
+     90     70     72     75     9
+     68     70     90     91     9
+     68     70     90     92     9
+     71     70     90     91     9
+     71     70     90     92     9
+     72     70     90     91     9
+     72     70     90     92     9
+     70     72     75     76     9
+     70     72     75     77     9
+     70     72     75     78     9
+     73     72     75     76     9
+     73     72     75     77     9
+     73     72     75     78     9
+     74     72     75     76     9
+     74     72     75     77     9
+     74     72     75     78     9
+     72     75     78     79     9
+     72     75     78     80     9
+     72     75     78     81     9
+     76     75     78     79     9
+     76     75     78     80     9
+     76     75     78     81     9
+     77     75     78     79     9
+     77     75     78     80     9
+     77     75     78     81     9
+     75     78     81     82     9
+     75     78     81     83     9
+     79     78     81     82     9
+     79     78     81     83     9
+     80     78     81     82     9
+     80     78     81     83     9
+     78     81     83     84     9
+     78     81     83     87     9
+     82     81     83     84     9
+     82     81     83     87     9
+     81     83     84     85     9
+     81     83     84     86     9
+     87     83     84     85     9
+     87     83     84     86     9
+     81     83     87     88     9
+     81     83     87     89     9
+     84     83     87     88     9
+     84     83     87     89     9
+     70     90     92     93     9
+     70     90     92     94     9
+     91     90     92     93     9
+     91     90     92     94     9
+     90     92     94     95     9
+     90     92     94     96     9
+     90     92     94    100     9
+     93     92     94     95     9
+     93     92     94     96     9
+     93     92     94    100     9
+     92     94     96     97     9
+     92     94     96     98     9
+     92     94     96     99     9
+     95     94     96     97     9
+     95     94     96     98     9
+     95     94     96     99     9
+    100     94     96     97     9
+    100     94     96     98     9
+    100     94     96     99     9
+     92     94    100    101     9
+     92     94    100    102     9
+     95     94    100    101     9
+     95     94    100    102     9
+     96     94    100    101     9
+     96     94    100    102     9
+     94     96     99   1914     9
+     97     96     99   1914     9
+     98     96     99   1914     9
+     96     99   1914   1911     9
+     94    100    102    103     9
+     94    100    102    104     9
+    101    100    102    103     9
+    101    100    102    104     9
+    100    102    104    105     9
+    100    102    104    106     9
+    100    102    104    115     9
+    103    102    104    105     9
+    103    102    104    106     9
+    103    102    104    115     9
+    102    104    106    107     9
+    102    104    106    108     9
+    102    104    106    109     9
+    105    104    106    107     9
+    105    104    106    108     9
+    105    104    106    109     9
+    115    104    106    107     9
+    115    104    106    108     9
+    115    104    106    109     9
+    102    104    115    116     9
+    102    104    115    117     9
+    105    104    115    116     9
+    105    104    115    117     9
+    106    104    115    116     9
+    106    104    115    117     9
+    104    106    109    110     9
+    104    106    109    111     9
+    104    106    109    112     9
+    107    106    109    110     9
+    107    106    109    111     9
+    107    106    109    112     9
+    108    106    109    110     9
+    108    106    109    111     9
+    108    106    109    112     9
+    106    109    112    113     9
+    106    109    112    114     9
+    110    109    112    113     9
+    110    109    112    114     9
+    111    109    112    113     9
+    111    109    112    114     9
+    104    115    117    118     9
+    104    115    117    119     9
+    116    115    117    118     9
+    116    115    117    119     9
+    115    117    119    120     9
+    115    117    119    121     9
+    115    117    119    134     9
+    118    117    119    120     9
+    118    117    119    121     9
+    118    117    119    134     9
+    134    119    121    124     9
+    117    119    121    122     9
+    117    119    121    123     9
+    117    119    121    124     9
+    120    119    121    122     9
+    120    119    121    123     9
+    120    119    121    124     9
+    134    119    121    122     9
+    134    119    121    123     9
+    117    119    134    135     9
+    117    119    134    136     9
+    120    119    134    135     9
+    120    119    134    136     9
+    121    119    134    135     9
+    121    119    134    136     9
+    119    121    124    125     9
+    119    121    124    126     9
+    119    121    124    130     9
+    122    121    124    125     9
+    122    121    124    126     9
+    122    121    124    130     9
+    123    121    124    125     9
+    123    121    124    126     9
+    123    121    124    130     9
+    121    124    126    127     9
+    121    124    126    128     9
+    121    124    126    129     9
+    125    124    126    127     9
+    125    124    126    128     9
+    125    124    126    129     9
+    130    124    126    127     9
+    130    124    126    128     9
+    130    124    126    129     9
+    121    124    130    131     9
+    121    124    130    132     9
+    121    124    130    133     9
+    125    124    130    131     9
+    125    124    130    132     9
+    125    124    130    133     9
+    126    124    130    131     9
+    126    124    130    132     9
+    126    124    130    133     9
+    119    134    136    137     9
+    119    134    136    138     9
+    135    134    136    137     9
+    135    134    136    138     9
+    134    136    138    139     9
+    134    136    138    140     9
+    134    136    138    144     9
+    137    136    138    139     9
+    137    136    138    140     9
+    137    136    138    144     9
+    136    138    140    141     9
+    136    138    140    142     9
+    136    138    140    143     9
+    139    138    140    141     9
+    139    138    140    142     9
+    139    138    140    143     9
+    144    138    140    141     9
+    144    138    140    142     9
+    144    138    140    143     9
+    136    138    144    145     9
+    136    138    144    146     9
+    139    138    144    145     9
+    139    138    144    146     9
+    140    138    144    145     9
+    140    138    144    146     9
+    138    144    146    147     9
+    138    144    146    148     9
+    145    144    146    147     9
+    145    144    146    148     9
+    144    146    148    149     9
+    144    146    148    150     9
+    144    146    148    154     9
+    147    146    148    149     9
+    147    146    148    150     9
+    147    146    148    154     9
+    146    148    150    151     9
+    146    148    150    152     9
+    146    148    150    153     9
+    149    148    150    151     9
+    149    148    150    152     9
+    149    148    150    153     9
+    154    148    150    151     9
+    154    148    150    152     9
+    154    148    150    153     9
+    146    148    154    155     9
+    146    148    154    156     9
+    149    148    154    155     9
+    149    148    154    156     9
+    150    148    154    155     9
+    150    148    154    156     9
+    148    154    156    157     9
+    148    154    156    158     9
+    155    154    156    157     9
+    155    154    156    158     9
+    154    156    158    159     9
+    154    156    158    160     9
+    154    156    158    164     9
+    157    156    158    159     9
+    157    156    158    160     9
+    157    156    158    164     9
+    156    158    160    161     9
+    156    158    160    162     9
+    156    158    160    163     9
+    159    158    160    161     9
+    159    158    160    162     9
+    159    158    160    163     9
+    164    158    160    161     9
+    164    158    160    162     9
+    164    158    160    163     9
+    156    158    164    165     9
+    156    158    164    166     9
+    159    158    164    165     9
+    159    158    164    166     9
+    160    158    164    165     9
+    160    158    164    166     9
+    158    164    166    167     9
+    158    164    166    168     9
+    165    164    166    167     9
+    165    164    166    168     9
+    164    166    168    169     9
+    164    166    168    170     9
+    164    166    168    181     9
+    167    166    168    169     9
+    167    166    168    170     9
+    167    166    168    181     9
+    166    168    170    171     9
+    166    168    170    172     9
+    166    168    170    173     9
+    169    168    170    171     9
+    169    168    170    172     9
+    169    168    170    173     9
+    181    168    170    171     9
+    181    168    170    172     9
+    181    168    170    173     9
+    166    168    181    182     9
+    166    168    181    183     9
+    169    168    181    182     9
+    169    168    181    183     9
+    170    168    181    182     9
+    170    168    181    183     9
+    168    170    173    174     9
+    168    170    173    175     9
+    168    170    173    176     9
+    171    170    173    174     9
+    171    170    173    175     9
+    171    170    173    176     9
+    172    170    173    174     9
+    172    170    173    175     9
+    172    170    173    176     9
+    170    173    176    177     9
+    174    173    176    177     9
+    175    173    176    177     9
+    173    176    177    178     9
+    173    176    177    179     9
+    173    176    177    180     9
+    168    181    183    184     9
+    168    181    183    185     9
+    182    181    183    184     9
+    182    181    183    185     9
+    181    183    185    186     9
+    181    183    185    187     9
+    181    183    185    203     9
+    184    183    185    186     9
+    184    183    185    187     9
+    184    183    185    203     9
+    183    185    187    188     9
+    183    185    187    189     9
+    183    185    187    190     9
+    186    185    187    188     9
+    186    185    187    189     9
+    186    185    187    190     9
+    203    185    187    188     9
+    203    185    187    189     9
+    203    185    187    190     9
+    183    185    203    204     9
+    183    185    203    205     9
+    186    185    203    204     9
+    186    185    203    205     9
+    187    185    203    204     9
+    187    185    203    205     9
+    185    187    190    191     9
+    185    187    190    192     9
+    185    187    190    193     9
+    188    187    190    191     9
+    188    187    190    192     9
+    188    187    190    193     9
+    189    187    190    191     9
+    189    187    190    192     9
+    189    187    190    193     9
+    187    190    193    194     9
+    187    190    193    195     9
+    187    190    193    196     9
+    191    190    193    194     9
+    191    190    193    195     9
+    191    190    193    196     9
+    192    190    193    194     9
+    192    190    193    195     9
+    192    190    193    196     9
+    190    193    196    197     9
+    190    193    196    198     9
+    190    193    196    199     9
+    194    193    196    197     9
+    194    193    196    198     9
+    194    193    196    199     9
+    195    193    196    197     9
+    195    193    196    198     9
+    195    193    196    199     9
+    193    196    199    200     9
+    193    196    199    201     9
+    193    196    199    202     9
+    197    196    199    200     9
+    197    196    199    201     9
+    197    196    199    202     9
+    198    196    199    200     9
+    198    196    199    201     9
+    198    196    199    202     9
+    185    203    205    206     9
+    185    203    205    207     9
+    204    203    205    206     9
+    204    203    205    207     9
+    203    205    207    208     9
+    203    205    207    209     9
+    203    205    207    227     9
+    206    205    207    208     9
+    206    205    207    209     9
+    206    205    207    227     9
+    205    207    209    210     9
+    205    207    209    211     9
+    205    207    209    212     9
+    208    207    209    210     9
+    208    207    209    211     9
+    208    207    209    212     9
+    227    207    209    210     9
+    227    207    209    211     9
+    227    207    209    212     9
+    205    207    227    228     9
+    205    207    227    229     9
+    208    207    227    228     9
+    208    207    227    229     9
+    209    207    227    228     9
+    209    207    227    229     9
+    207    209    212    213     9
+    207    209    212    214     9
+    207    209    212    215     9
+    210    209    212    213     9
+    210    209    212    214     9
+    210    209    212    215     9
+    211    209    212    213     9
+    211    209    212    214     9
+    211    209    212    215     9
+    209    212    215    216     9
+    209    212    215    217     9
+    209    212    215    218     9
+    213    212    215    216     9
+    213    212    215    217     9
+    213    212    215    218     9
+    214    212    215    216     9
+    214    212    215    217     9
+    214    212    215    218     9
+    212    215    218    219     9
+    212    215    218    220     9
+    216    215    218    219     9
+    216    215    218    220     9
+    217    215    218    219     9
+    217    215    218    220     9
+    215    218    220    221     9
+    215    218    220    224     9
+    219    218    220    221     9
+    219    218    220    224     9
+    218    220    221    222     9
+    218    220    221    223     9
+    224    220    221    222     9
+    224    220    221    223     9
+    218    220    224    225     9
+    218    220    224    226     9
+    221    220    224    225     9
+    221    220    224    226     9
+    207    227    229    230     9
+    207    227    229    231     9
+    228    227    229    230     9
+    228    227    229    231     9
+    227    229    231    232     9
+    227    229    231    233     9
+    227    229    231    244     9
+    230    229    231    232     9
+    230    229    231    233     9
+    230    229    231    244     9
+    229    231    233    234     9
+    229    231    233    235     9
+    229    231    233    236     9
+    232    231    233    234     9
+    232    231    233    235     9
+    232    231    233    236     9
+    244    231    233    234     9
+    244    231    233    235     9
+    244    231    233    236     9
+    229    231    244    245     9
+    229    231    244    246     9
+    232    231    244    245     9
+    232    231    244    246     9
+    233    231    244    245     9
+    233    231    244    246     9
+    231    233    236    237     9
+    231    233    236    242     9
+    234    233    236    237     9
+    234    233    236    242     9
+    235    233    236    237     9
+    235    233    236    242     9
+    233    236    237    238     9
+    242    236    237    238     9
+    233    236    242    240     9
+    233    236    242    243     9
+    237    236    242    240     9
+    237    236    242    243     9
+    236    237    238    239     9
+    236    237    238    240     9
+    237    238    240    241     9
+    237    238    240    242     9
+    239    238    240    241     9
+    239    238    240    242     9
+    238    240    242    236     9
+    238    240    242    243     9
+    241    240    242    236     9
+    241    240    242    243     9
+    231    244    246    247     9
+    231    244    246    248     9
+    245    244    246    247     9
+    245    244    246    248     9
+    244    246    248    249     9
+    244    246    248    250     9
+    244    246    248    251     9
+    247    246    248    249     9
+    247    246    248    250     9
+    247    246    248    251     9
+    246    248    251    252     9
+    246    248    251    253     9
+    249    248    251    252     9
+    249    248    251    253     9
+    250    248    251    252     9
+    250    248    251    253     9
+    248    251    253    254     9
+    248    251    253    255     9
+    252    251    253    254     9
+    252    251    253    255     9
+    251    253    255    256     9
+    251    253    255    257     9
+    251    253    255    270     9
+    254    253    255    256     9
+    254    253    255    257     9
+    254    253    255    270     9
+    270    255    257    260     9
+    253    255    257    258     9
+    253    255    257    259     9
+    253    255    257    260     9
+    256    255    257    258     9
+    256    255    257    259     9
+    256    255    257    260     9
+    270    255    257    258     9
+    270    255    257    259     9
+    253    255    270    271     9
+    253    255    270    272     9
+    256    255    270    271     9
+    256    255    270    272     9
+    257    255    270    271     9
+    257    255    270    272     9
+    255    257    260    261     9
+    255    257    260    262     9
+    255    257    260    266     9
+    258    257    260    261     9
+    258    257    260    262     9
+    258    257    260    266     9
+    259    257    260    261     9
+    259    257    260    262     9
+    259    257    260    266     9
+    257    260    262    263     9
+    257    260    262    264     9
+    257    260    262    265     9
+    261    260    262    263     9
+    261    260    262    264     9
+    261    260    262    265     9
+    266    260    262    263     9
+    266    260    262    264     9
+    266    260    262    265     9
+    257    260    266    267     9
+    257    260    266    268     9
+    257    260    266    269     9
+    261    260    266    267     9
+    261    260    266    268     9
+    261    260    266    269     9
+    262    260    266    267     9
+    262    260    266    268     9
+    262    260    266    269     9
+    255    270    272    273     9
+    255    270    272    274     9
+    271    270    272    273     9
+    271    270    272    274     9
+    270    272    274    275     9
+    270    272    274    276     9
+    270    272    274    282     9
+    273    272    274    275     9
+    273    272    274    276     9
+    273    272    274    282     9
+    272    274    276    279     9
+    272    274    276    277     9
+    272    274    276    278     9
+    275    274    276    277     9
+    275    274    276    278     9
+    275    274    276    279     9
+    282    274    276    277     9
+    282    274    276    278     9
+    282    274    276    279     9
+    272    274    282    283     9
+    272    274    282    284     9
+    275    274    282    283     9
+    275    274    282    284     9
+    276    274    282    283     9
+    276    274    282    284     9
+    274    276    279    280     9
+    274    276    279    281     9
+    277    276    279    280     9
+    277    276    279    281     9
+    278    276    279    280     9
+    278    276    279    281     9
+    274    282    284    285     9
+    274    282    284    286     9
+    283    282    284    285     9
+    283    282    284    286     9
+    282    284    286    287     9
+    282    284    286    288     9
+    282    284    286    296     9
+    285    284    286    287     9
+    285    284    286    288     9
+    285    284    286    296     9
+    296    286    288    291     9
+    284    286    288    289     9
+    284    286    288    290     9
+    284    286    288    291     9
+    287    286    288    289     9
+    287    286    288    290     9
+    287    286    288    291     9
+    296    286    288    289     9
+    296    286    288    290     9
+    284    286    296    297     9
+    284    286    296    298     9
+    287    286    296    297     9
+    287    286    296    298     9
+    288    286    296    297     9
+    288    286    296    298     9
+    286    288    291    293     9
+    286    288    291    292     9
+    289    288    291    292     9
+    289    288    291    293     9
+    290    288    291    292     9
+    290    288    291    293     9
+    288    291    293    294     9
+    288    291    293    295     9
+    292    291    293    294     9
+    292    291    293    295     9
+    286    296    298    299     9
+    286    296    298    300     9
+    297    296    298    299     9
+    297    296    298    300     9
+    296    298    300    301     9
+    296    298    300    302     9
+    296    298    300    317     9
+    299    298    300    301     9
+    299    298    300    302     9
+    299    298    300    317     9
+    298    300    302    303     9
+    298    300    302    304     9
+    298    300    302    305     9
+    301    300    302    303     9
+    301    300    302    304     9
+    301    300    302    305     9
+    317    300    302    303     9
+    317    300    302    304     9
+    317    300    302    305     9
+    298    300    317    318     9
+    298    300    317    319     9
+    301    300    317    318     9
+    301    300    317    319     9
+    302    300    317    318     9
+    302    300    317    319     9
+    300    302    305    306     9
+    300    302    305    315     9
+    303    302    305    306     9
+    303    302    305    315     9
+    304    302    305    306     9
+    304    302    305    315     9
+    302    305    306    307     9
+    302    305    306    308     9
+    315    305    306    307     9
+    315    305    306    308     9
+    302    305    315    313     9
+    302    305    315    316     9
+    306    305    315    313     9
+    306    305    315    316     9
+    305    306    308    309     9
+    305    306    308    310     9
+    307    306    308    309     9
+    307    306    308    310     9
+    306    308    310    311     9
+    306    308    310    313     9
+    309    308    310    311     9
+    309    308    310    313     9
+    308    310    311    312     9
+    313    310    311    312     9
+    308    310    313    314     9
+    308    310    313    315     9
+    311    310    313    314     9
+    311    310    313    315     9
+    310    313    315    305     9
+    310    313    315    316     9
+    314    313    315    305     9
+    314    313    315    316     9
+    300    317    319    320     9
+    300    317    319    321     9
+    318    317    319    320     9
+    318    317    319    321     9
+    317    319    321    322     9
+    317    319    321    323     9
+    317    319    321    341     9
+    320    319    321    322     9
+    320    319    321    323     9
+    320    319    321    341     9
+    319    321    323    324     9
+    319    321    323    325     9
+    319    321    323    326     9
+    322    321    323    324     9
+    322    321    323    325     9
+    322    321    323    326     9
+    341    321    323    324     9
+    341    321    323    325     9
+    341    321    323    326     9
+    319    321    341    342     9
+    319    321    341    343     9
+    322    321    341    342     9
+    322    321    341    343     9
+    323    321    341    342     9
+    323    321    341    343     9
+    321    323    326    327     9
+    321    323    326    328     9
+    321    323    326    329     9
+    324    323    326    327     9
+    324    323    326    328     9
+    324    323    326    329     9
+    325    323    326    327     9
+    325    323    326    328     9
+    325    323    326    329     9
+    323    326    329    330     9
+    323    326    329    331     9
+    323    326    329    332     9
+    327    326    329    330     9
+    327    326    329    331     9
+    327    326    329    332     9
+    328    326    329    330     9
+    328    326    329    331     9
+    328    326    329    332     9
+    326    329    332    333     9
+    326    329    332    334     9
+    330    329    332    333     9
+    330    329    332    334     9
+    331    329    332    333     9
+    331    329    332    334     9
+    329    332    334    335     9
+    329    332    334    338     9
+    333    332    334    335     9
+    333    332    334    338     9
+    332    334    335    336     9
+    332    334    335    337     9
+    338    334    335    336     9
+    338    334    335    337     9
+    332    334    338    339     9
+    332    334    338    340     9
+    335    334    338    339     9
+    335    334    338    340     9
+    321    341    343    344     9
+    321    341    343    345     9
+    342    341    343    344     9
+    342    341    343    345     9
+    341    343    345    346     9
+    341    343    345    347     9
+    341    343    345    348     9
+    344    343    345    346     9
+    344    343    345    347     9
+    344    343    345    348     9
+    343    345    348    349     9
+    343    345    348    350     9
+    346    345    348    349     9
+    346    345    348    350     9
+    347    345    348    349     9
+    347    345    348    350     9
+    345    348    350    351     9
+    345    348    350    352     9
+    349    348    350    351     9
+    349    348    350    352     9
+    348    350    352    353     9
+    348    350    352    354     9
+    348    350    352    369     9
+    351    350    352    353     9
+    351    350    352    354     9
+    351    350    352    369     9
+    350    352    354    355     9
+    350    352    354    356     9
+    350    352    354    357     9
+    353    352    354    355     9
+    353    352    354    356     9
+    353    352    354    357     9
+    369    352    354    355     9
+    369    352    354    356     9
+    369    352    354    357     9
+    350    352    369    370     9
+    350    352    369    371     9
+    353    352    369    370     9
+    353    352    369    371     9
+    354    352    369    370     9
+    354    352    369    371     9
+    352    354    357    358     9
+    352    354    357    367     9
+    355    354    357    358     9
+    355    354    357    367     9
+    356    354    357    358     9
+    356    354    357    367     9
+    354    357    358    359     9
+    354    357    358    360     9
+    367    357    358    359     9
+    367    357    358    360     9
+    354    357    367    365     9
+    354    357    367    368     9
+    358    357    367    365     9
+    358    357    367    368     9
+    357    358    360    361     9
+    357    358    360    362     9
+    359    358    360    361     9
+    359    358    360    362     9
+    358    360    362    363     9
+    358    360    362    365     9
+    361    360    362    363     9
+    361    360    362    365     9
+    360    362    363    364     9
+    365    362    363    364     9
+    360    362    365    366     9
+    360    362    365    367     9
+    363    362    365    366     9
+    363    362    365    367     9
+    362    365    367    357     9
+    362    365    367    368     9
+    366    365    367    357     9
+    366    365    367    368     9
+    352    369    371    372     9
+    352    369    371    373     9
+    370    369    371    372     9
+    370    369    371    373     9
+    369    371    373    374     9
+    369    371    373    375     9
+    369    371    373    380     9
+    372    371    373    374     9
+    372    371    373    375     9
+    372    371    373    380     9
+    371    373    375    376     9
+    371    373    375    377     9
+    371    373    375    378     9
+    374    373    375    376     9
+    374    373    375    377     9
+    374    373    375    378     9
+    380    373    375    376     9
+    380    373    375    377     9
+    380    373    375    378     9
+    371    373    380    381     9
+    371    373    380    382     9
+    374    373    380    381     9
+    374    373    380    382     9
+    375    373    380    381     9
+    375    373    380    382     9
+    373    375    378    379     9
+    376    375    378    379     9
+    377    375    378    379     9
+    373    380    382    383     9
+    373    380    382    384     9
+    381    380    382    383     9
+    381    380    382    384     9
+    380    382    384    385     9
+    380    382    384    386     9
+    380    382    384    399     9
+    383    382    384    385     9
+    383    382    384    386     9
+    383    382    384    399     9
+    399    384    386    389     9
+    382    384    386    387     9
+    382    384    386    388     9
+    382    384    386    389     9
+    385    384    386    387     9
+    385    384    386    388     9
+    385    384    386    389     9
+    399    384    386    387     9
+    399    384    386    388     9
+    382    384    399    400     9
+    382    384    399    401     9
+    385    384    399    400     9
+    385    384    399    401     9
+    386    384    399    400     9
+    386    384    399    401     9
+    384    386    389    390     9
+    384    386    389    391     9
+    384    386    389    395     9
+    387    386    389    390     9
+    387    386    389    391     9
+    387    386    389    395     9
+    388    386    389    390     9
+    388    386    389    391     9
+    388    386    389    395     9
+    386    389    391    392     9
+    386    389    391    393     9
+    386    389    391    394     9
+    390    389    391    392     9
+    390    389    391    393     9
+    390    389    391    394     9
+    395    389    391    392     9
+    395    389    391    393     9
+    395    389    391    394     9
+    386    389    395    396     9
+    386    389    395    397     9
+    386    389    395    398     9
+    390    389    395    396     9
+    390    389    395    397     9
+    390    389    395    398     9
+    391    389    395    396     9
+    391    389    395    397     9
+    391    389    395    398     9
+    384    399    401    402     9
+    384    399    401    403     9
+    400    399    401    402     9
+    400    399    401    403     9
+    399    401    403    404     9
+    399    401    403    405     9
+    399    401    403    406     9
+    402    401    403    404     9
+    402    401    403    405     9
+    402    401    403    406     9
+    401    403    406    407     9
+    401    403    406    408     9
+    404    403    406    407     9
+    404    403    406    408     9
+    405    403    406    407     9
+    405    403    406    408     9
+    403    406    408    409     9
+    403    406    408    410     9
+    407    406    408    409     9
+    407    406    408    410     9
+    406    408    410    411     9
+    406    408    410    412     9
+    406    408    410    420     9
+    409    408    410    411     9
+    409    408    410    412     9
+    409    408    410    420     9
+    420    410    412    415     9
+    408    410    412    413     9
+    408    410    412    414     9
+    408    410    412    415     9
+    411    410    412    413     9
+    411    410    412    414     9
+    411    410    412    415     9
+    420    410    412    413     9
+    420    410    412    414     9
+    408    410    420    421     9
+    408    410    420    422     9
+    411    410    420    421     9
+    411    410    420    422     9
+    412    410    420    421     9
+    412    410    420    422     9
+    410    412    415    417     9
+    410    412    415    416     9
+    413    412    415    416     9
+    413    412    415    417     9
+    414    412    415    416     9
+    414    412    415    417     9
+    412    415    417    418     9
+    412    415    417    419     9
+    416    415    417    418     9
+    416    415    417    419     9
+    410    420    422    423     9
+    410    420    422    424     9
+    421    420    422    423     9
+    421    420    422    424     9
+    420    422    424    425     9
+    420    422    424    426     9
+    420    422    424    444     9
+    423    422    424    425     9
+    423    422    424    426     9
+    423    422    424    444     9
+    422    424    426    427     9
+    422    424    426    428     9
+    422    424    426    429     9
+    425    424    426    427     9
+    425    424    426    428     9
+    425    424    426    429     9
+    444    424    426    427     9
+    444    424    426    428     9
+    444    424    426    429     9
+    422    424    444    445     9
+    422    424    444    446     9
+    425    424    444    445     9
+    425    424    444    446     9
+    426    424    444    445     9
+    426    424    444    446     9
+    424    426    429    430     9
+    424    426    429    443     9
+    427    426    429    430     9
+    427    426    429    443     9
+    428    426    429    430     9
+    428    426    429    443     9
+    426    429    430    431     9
+    426    429    430    432     9
+    443    429    430    431     9
+    443    429    430    432     9
+    426    429    443    434     9
+    426    429    443    441     9
+    430    429    443    434     9
+    430    429    443    441     9
+    429    430    432    433     9
+    429    430    432    434     9
+    431    430    432    433     9
+    431    430    432    434     9
+    430    432    434    435     9
+    430    432    434    443     9
+    433    432    434    435     9
+    433    432    434    443     9
+    432    434    435    436     9
+    432    434    435    437     9
+    443    434    435    436     9
+    443    434    435    437     9
+    432    434    443    429     9
+    432    434    443    441     9
+    435    434    443    429     9
+    435    434    443    441     9
+    434    435    437    438     9
+    434    435    437    439     9
+    436    435    437    438     9
+    436    435    437    439     9
+    435    437    439    440     9
+    435    437    439    441     9
+    438    437    439    440     9
+    438    437    439    441     9
+    437    439    441    442     9
+    437    439    441    443     9
+    440    439    441    442     9
+    440    439    441    443     9
+    439    441    443    429     9
+    439    441    443    434     9
+    442    441    443    429     9
+    442    441    443    434     9
+    424    444    446    447     9
+    424    444    446    448     9
+    445    444    446    447     9
+    445    444    446    448     9
+    444    446    448    449     9
+    444    446    448    450     9
+    444    446    448    460     9
+    447    446    448    449     9
+    447    446    448    450     9
+    447    446    448    460     9
+    446    448    450    451     9
+    446    448    450    452     9
+    446    448    450    456     9
+    449    448    450    451     9
+    449    448    450    452     9
+    449    448    450    456     9
+    460    448    450    451     9
+    460    448    450    452     9
+    460    448    450    456     9
+    446    448    460    461     9
+    446    448    460    462     9
+    449    448    460    461     9
+    449    448    460    462     9
+    450    448    460    461     9
+    450    448    460    462     9
+    448    450    452    453     9
+    448    450    452    454     9
+    448    450    452    455     9
+    451    450    452    453     9
+    451    450    452    454     9
+    451    450    452    455     9
+    456    450    452    453     9
+    456    450    452    454     9
+    456    450    452    455     9
+    448    450    456    457     9
+    448    450    456    458     9
+    448    450    456    459     9
+    451    450    456    457     9
+    451    450    456    458     9
+    451    450    456    459     9
+    452    450    456    457     9
+    452    450    456    458     9
+    452    450    456    459     9
+    448    460    462    463     9
+    448    460    462    464     9
+    461    460    462    463     9
+    461    460    462    464     9
+    460    462    464    465     9
+    460    462    464    466     9
+    460    462    464    470     9
+    463    462    464    465     9
+    463    462    464    466     9
+    463    462    464    470     9
+    462    464    466    467     9
+    462    464    466    468     9
+    462    464    466    469     9
+    465    464    466    467     9
+    465    464    466    468     9
+    465    464    466    469     9
+    470    464    466    467     9
+    470    464    466    468     9
+    470    464    466    469     9
+    462    464    470    471     9
+    462    464    470    472     9
+    465    464    470    471     9
+    465    464    470    472     9
+    466    464    470    471     9
+    466    464    470    472     9
+    464    466    469   1732     9
+    467    466    469   1732     9
+    468    466    469   1732     9
+    466    469   1732   1729     9
+    464    470    472    473     9
+    464    470    472    474     9
+    471    470    472    473     9
+    471    470    472    474     9
+    470    472    474    475     9
+    470    472    474    476     9
+    470    472    474    480     9
+    473    472    474    475     9
+    473    472    474    476     9
+    473    472    474    480     9
+    472    474    476    477     9
+    472    474    476    478     9
+    472    474    476    479     9
+    475    474    476    477     9
+    475    474    476    478     9
+    475    474    476    479     9
+    480    474    476    477     9
+    480    474    476    478     9
+    480    474    476    479     9
+    472    474    480    481     9
+    472    474    480    482     9
+    475    474    480    481     9
+    475    474    480    482     9
+    476    474    480    481     9
+    476    474    480    482     9
+    474    480    482    483     9
+    474    480    482    484     9
+    481    480    482    483     9
+    481    480    482    484     9
+    480    482    484    485     9
+    480    482    484    486     9
+    480    482    484    490     9
+    483    482    484    485     9
+    483    482    484    486     9
+    483    482    484    490     9
+    482    484    486    487     9
+    482    484    486    488     9
+    482    484    486    489     9
+    485    484    486    487     9
+    485    484    486    488     9
+    485    484    486    489     9
+    490    484    486    487     9
+    490    484    486    488     9
+    490    484    486    489     9
+    482    484    490    491     9
+    482    484    490    492     9
+    485    484    490    491     9
+    485    484    490    492     9
+    486    484    490    491     9
+    486    484    490    492     9
+    484    490    492    493     9
+    484    490    492    494     9
+    491    490    492    493     9
+    491    490    492    494     9
+    490    492    494    495     9
+    490    492    494    496     9
+    490    492    494    512     9
+    493    492    494    495     9
+    493    492    494    496     9
+    493    492    494    512     9
+    492    494    496    497     9
+    492    494    496    498     9
+    492    494    496    499     9
+    495    494    496    497     9
+    495    494    496    498     9
+    495    494    496    499     9
+    512    494    496    497     9
+    512    494    496    498     9
+    512    494    496    499     9
+    492    494    512    513     9
+    492    494    512    514     9
+    495    494    512    513     9
+    495    494    512    514     9
+    496    494    512    513     9
+    496    494    512    514     9
+    494    496    499    500     9
+    494    496    499    501     9
+    494    496    499    502     9
+    497    496    499    500     9
+    497    496    499    501     9
+    497    496    499    502     9
+    498    496    499    500     9
+    498    496    499    501     9
+    498    496    499    502     9
+    496    499    502    503     9
+    496    499    502    504     9
+    496    499    502    505     9
+    500    499    502    503     9
+    500    499    502    504     9
+    500    499    502    505     9
+    501    499    502    503     9
+    501    499    502    504     9
+    501    499    502    505     9
+    499    502    505    506     9
+    499    502    505    507     9
+    499    502    505    508     9
+    503    502    505    506     9
+    503    502    505    507     9
+    503    502    505    508     9
+    504    502    505    506     9
+    504    502    505    507     9
+    504    502    505    508     9
+    502    505    508    509     9
+    502    505    508    510     9
+    502    505    508    511     9
+    506    505    508    509     9
+    506    505    508    510     9
+    506    505    508    511     9
+    507    505    508    509     9
+    507    505    508    510     9
+    507    505    508    511     9
+    494    512    514    515     9
+    494    512    514    516     9
+    513    512    514    515     9
+    513    512    514    516     9
+    512    514    516    517     9
+    512    514    516    518     9
+    512    514    516    532     9
+    515    514    516    517     9
+    515    514    516    518     9
+    515    514    516    532     9
+    514    516    518    519     9
+    514    516    518    520     9
+    514    516    518    521     9
+    517    516    518    519     9
+    517    516    518    520     9
+    517    516    518    521     9
+    532    516    518    519     9
+    532    516    518    520     9
+    532    516    518    521     9
+    514    516    532    533     9
+    514    516    532    534     9
+    517    516    532    533     9
+    517    516    532    534     9
+    518    516    532    533     9
+    518    516    532    534     9
+    516    518    521    522     9
+    516    518    521    530     9
+    519    518    521    522     9
+    519    518    521    530     9
+    520    518    521    522     9
+    520    518    521    530     9
+    518    521    522    523     9
+    518    521    522    524     9
+    530    521    522    523     9
+    530    521    522    524     9
+    518    521    530    528     9
+    518    521    530    531     9
+    522    521    530    528     9
+    522    521    530    531     9
+    521    522    524    525     9
+    521    522    524    526     9
+    523    522    524    525     9
+    523    522    524    526     9
+    522    524    526    527     9
+    522    524    526    528     9
+    525    524    526    527     9
+    525    524    526    528     9
+    524    526    528    529     9
+    524    526    528    530     9
+    527    526    528    529     9
+    527    526    528    530     9
+    526    528    530    521     9
+    526    528    530    531     9
+    529    528    530    521     9
+    529    528    530    531     9
+    516    532    534    535     9
+    516    532    534    536     9
+    533    532    534    535     9
+    533    532    534    536     9
+    532    534    536    537     9
+    532    534    536    538     9
+    532    534    536    547     9
+    535    534    536    537     9
+    535    534    536    538     9
+    535    534    536    547     9
+    534    536    538    539     9
+    534    536    538    540     9
+    534    536    538    541     9
+    537    536    538    539     9
+    537    536    538    540     9
+    537    536    538    541     9
+    547    536    538    539     9
+    547    536    538    540     9
+    547    536    538    541     9
+    534    536    547    548     9
+    534    536    547    549     9
+    537    536    547    548     9
+    537    536    547    549     9
+    538    536    547    548     9
+    538    536    547    549     9
+    536    538    541    542     9
+    536    538    541    543     9
+    536    538    541    544     9
+    539    538    541    542     9
+    539    538    541    543     9
+    539    538    541    544     9
+    540    538    541    542     9
+    540    538    541    543     9
+    540    538    541    544     9
+    538    541    544    545     9
+    538    541    544    546     9
+    542    541    544    545     9
+    542    541    544    546     9
+    543    541    544    545     9
+    543    541    544    546     9
+    536    547    549    550     9
+    536    547    549    551     9
+    548    547    549    550     9
+    548    547    549    551     9
+    547    549    551    552     9
+    547    549    551    553     9
+    547    549    551    558     9
+    550    549    551    552     9
+    550    549    551    553     9
+    550    549    551    558     9
+    549    551    553    554     9
+    549    551    553    555     9
+    549    551    553    556     9
+    552    551    553    554     9
+    552    551    553    555     9
+    552    551    553    556     9
+    558    551    553    554     9
+    558    551    553    555     9
+    558    551    553    556     9
+    549    551    558    559     9
+    549    551    558    560     9
+    552    551    558    559     9
+    552    551    558    560     9
+    553    551    558    559     9
+    553    551    558    560     9
+    551    553    556    557     9
+    554    553    556    557     9
+    555    553    556    557     9
+    551    558    560    561     9
+    551    558    560    562     9
+    559    558    560    561     9
+    559    558    560    562     9
+    558    560    562    563     9
+    558    560    562    564     9
+    558    560    562    572     9
+    561    560    562    563     9
+    561    560    562    564     9
+    561    560    562    572     9
+    572    562    564    567     9
+    560    562    564    565     9
+    560    562    564    566     9
+    560    562    564    567     9
+    563    562    564    565     9
+    563    562    564    566     9
+    563    562    564    567     9
+    572    562    564    565     9
+    572    562    564    566     9
+    560    562    572    573     9
+    560    562    572    574     9
+    563    562    572    573     9
+    563    562    572    574     9
+    564    562    572    573     9
+    564    562    572    574     9
+    562    564    567    569     9
+    562    564    567    568     9
+    565    564    567    568     9
+    565    564    567    569     9
+    566    564    567    568     9
+    566    564    567    569     9
+    564    567    569    570     9
+    564    567    569    571     9
+    568    567    569    570     9
+    568    567    569    571     9
+    562    572    574    575     9
+    562    572    574    576     9
+    573    572    574    575     9
+    573    572    574    576     9
+    572    574    576    577     9
+    572    574    576    578     9
+    572    574    576    592     9
+    575    574    576    577     9
+    575    574    576    578     9
+    575    574    576    592     9
+    574    576    578    579     9
+    574    576    578    580     9
+    574    576    578    581     9
+    577    576    578    579     9
+    577    576    578    580     9
+    577    576    578    581     9
+    592    576    578    579     9
+    592    576    578    580     9
+    592    576    578    581     9
+    574    576    592    593     9
+    574    576    592    594     9
+    577    576    592    593     9
+    577    576    592    594     9
+    578    576    592    593     9
+    578    576    592    594     9
+    576    578    581    582     9
+    576    578    581    590     9
+    579    578    581    582     9
+    579    578    581    590     9
+    580    578    581    582     9
+    580    578    581    590     9
+    578    581    582    583     9
+    578    581    582    584     9
+    590    581    582    583     9
+    590    581    582    584     9
+    578    581    590    588     9
+    578    581    590    591     9
+    582    581    590    588     9
+    582    581    590    591     9
+    581    582    584    585     9
+    581    582    584    586     9
+    583    582    584    585     9
+    583    582    584    586     9
+    582    584    586    587     9
+    582    584    586    588     9
+    585    584    586    587     9
+    585    584    586    588     9
+    584    586    588    589     9
+    584    586    588    590     9
+    587    586    588    589     9
+    587    586    588    590     9
+    586    588    590    581     9
+    586    588    590    591     9
+    589    588    590    581     9
+    589    588    590    591     9
+    576    592    594    595     9
+    576    592    594    596     9
+    593    592    594    595     9
+    593    592    594    596     9
+    592    594    596    597     9
+    592    594    596    598     9
+    592    594    596    606     9
+    595    594    596    597     9
+    595    594    596    598     9
+    595    594    596    606     9
+    606    596    598    601     9
+    594    596    598    599     9
+    594    596    598    600     9
+    594    596    598    601     9
+    597    596    598    599     9
+    597    596    598    600     9
+    597    596    598    601     9
+    606    596    598    599     9
+    606    596    598    600     9
+    594    596    606    607     9
+    594    596    606    608     9
+    597    596    606    607     9
+    597    596    606    608     9
+    598    596    606    607     9
+    598    596    606    608     9
+    596    598    601    603     9
+    596    598    601    602     9
+    599    598    601    602     9
+    599    598    601    603     9
+    600    598    601    602     9
+    600    598    601    603     9
+    598    601    603    604     9
+    598    601    603    605     9
+    602    601    603    604     9
+    602    601    603    605     9
+    596    606    608    609     9
+    596    606    608    610     9
+    607    606    608    609     9
+    607    606    608    610     9
+    606    608    610    611     9
+    606    608    610    612     9
+    606    608    610    620     9
+    609    608    610    611     9
+    609    608    610    612     9
+    609    608    610    620     9
+    608    610    612    613     9
+    608    610    612    614     9
+    608    610    612    618     9
+    611    610    612    613     9
+    611    610    612    614     9
+    611    610    612    618     9
+    620    610    612    613     9
+    620    610    612    614     9
+    620    610    612    618     9
+    608    610    620    621     9
+    608    610    620    622     9
+    611    610    620    621     9
+    611    610    620    622     9
+    612    610    620    621     9
+    612    610    620    622     9
+    610    612    614    615     9
+    610    612    614    616     9
+    610    612    614    617     9
+    613    612    614    615     9
+    613    612    614    616     9
+    613    612    614    617     9
+    618    612    614    615     9
+    618    612    614    616     9
+    618    612    614    617     9
+    610    612    618    619     9
+    613    612    618    619     9
+    614    612    618    619     9
+    610    620    622    623     9
+    610    620    622    624     9
+    621    620    622    623     9
+    621    620    622    624     9
+    620    622    624    625     9
+    620    622    624    626     9
+    620    622    624    637     9
+    623    622    624    625     9
+    623    622    624    626     9
+    623    622    624    637     9
+    622    624    626    627     9
+    622    624    626    628     9
+    622    624    626    629     9
+    625    624    626    627     9
+    625    624    626    628     9
+    625    624    626    629     9
+    637    624    626    627     9
+    637    624    626    628     9
+    637    624    626    629     9
+    622    624    637    638     9
+    622    624    637    639     9
+    625    624    637    638     9
+    625    624    637    639     9
+    626    624    637    638     9
+    626    624    637    639     9
+    624    626    629    630     9
+    624    626    629    631     9
+    624    626    629    632     9
+    627    626    629    630     9
+    627    626    629    631     9
+    627    626    629    632     9
+    628    626    629    630     9
+    628    626    629    631     9
+    628    626    629    632     9
+    626    629    632    633     9
+    626    629    632    634     9
+    630    629    632    633     9
+    630    629    632    634     9
+    631    629    632    633     9
+    631    629    632    634     9
+    629    632    634    635     9
+    629    632    634    636     9
+    633    632    634    635     9
+    633    632    634    636     9
+    624    637    639    640     9
+    624    637    639    641     9
+    638    637    639    640     9
+    638    637    639    641     9
+    637    639    641    642     9
+    637    639    641    643     9
+    637    639    641    647     9
+    640    639    641    642     9
+    640    639    641    643     9
+    640    639    641    647     9
+    639    641    643    644     9
+    639    641    643    645     9
+    639    641    643    646     9
+    642    641    643    644     9
+    642    641    643    645     9
+    642    641    643    646     9
+    647    641    643    644     9
+    647    641    643    645     9
+    647    641    643    646     9
+    639    641    647    648     9
+    639    641    647    649     9
+    642    641    647    648     9
+    642    641    647    649     9
+    643    641    647    648     9
+    643    641    647    649     9
+    641    647    649    650     9
+    641    647    649    651     9
+    648    647    649    650     9
+    648    647    649    651     9
+    647    649    651    652     9
+    647    649    651    653     9
+    647    649    651    661     9
+    650    649    651    652     9
+    650    649    651    653     9
+    650    649    651    661     9
+    649    651    653    654     9
+    649    651    653    655     9
+    649    651    653    659     9
+    652    651    653    654     9
+    652    651    653    655     9
+    652    651    653    659     9
+    661    651    653    654     9
+    661    651    653    655     9
+    661    651    653    659     9
+    649    651    661    662     9
+    649    651    661    663     9
+    652    651    661    662     9
+    652    651    661    663     9
+    653    651    661    662     9
+    653    651    661    663     9
+    651    653    655    656     9
+    651    653    655    657     9
+    651    653    655    658     9
+    654    653    655    656     9
+    654    653    655    657     9
+    654    653    655    658     9
+    659    653    655    656     9
+    659    653    655    657     9
+    659    653    655    658     9
+    651    653    659    660     9
+    654    653    659    660     9
+    655    653    659    660     9
+    651    661    663    664     9
+    651    661    663    665     9
+    662    661    663    664     9
+    662    661    663    665     9
+    661    663    665    666     9
+    661    663    665    667     9
+    661    663    665    675     9
+    664    663    665    666     9
+    664    663    665    667     9
+    664    663    665    675     9
+    675    665    667    670     9
+    663    665    667    668     9
+    663    665    667    669     9
+    663    665    667    670     9
+    666    665    667    668     9
+    666    665    667    669     9
+    666    665    667    670     9
+    675    665    667    668     9
+    675    665    667    669     9
+    663    665    675    676     9
+    663    665    675    677     9
+    666    665    675    676     9
+    666    665    675    677     9
+    667    665    675    676     9
+    667    665    675    677     9
+    665    667    670    672     9
+    665    667    670    671     9
+    668    667    670    671     9
+    668    667    670    672     9
+    669    667    670    671     9
+    669    667    670    672     9
+    667    670    672    673     9
+    667    670    672    674     9
+    671    670    672    673     9
+    671    670    672    674     9
+    665    675    677    678     9
+    665    675    677    679     9
+    676    675    677    678     9
+    676    675    677    679     9
+    675    677    679    680     9
+    675    677    679    681     9
+    675    677    679    699     9
+    678    677    679    680     9
+    678    677    679    681     9
+    678    677    679    699     9
+    677    679    681    682     9
+    677    679    681    683     9
+    677    679    681    684     9
+    680    679    681    682     9
+    680    679    681    683     9
+    680    679    681    684     9
+    699    679    681    682     9
+    699    679    681    683     9
+    699    679    681    684     9
+    677    679    699    700     9
+    677    679    699    701     9
+    680    679    699    700     9
+    680    679    699    701     9
+    681    679    699    700     9
+    681    679    699    701     9
+    679    681    684    685     9
+    679    681    684    686     9
+    679    681    684    687     9
+    682    681    684    685     9
+    682    681    684    686     9
+    682    681    684    687     9
+    683    681    684    685     9
+    683    681    684    686     9
+    683    681    684    687     9
+    681    684    687    688     9
+    681    684    687    689     9
+    681    684    687    690     9
+    685    684    687    688     9
+    685    684    687    689     9
+    685    684    687    690     9
+    686    684    687    688     9
+    686    684    687    689     9
+    686    684    687    690     9
+    684    687    690    691     9
+    684    687    690    692     9
+    688    687    690    691     9
+    688    687    690    692     9
+    689    687    690    691     9
+    689    687    690    692     9
+    687    690    692    693     9
+    687    690    692    696     9
+    691    690    692    693     9
+    691    690    692    696     9
+    690    692    693    694     9
+    690    692    693    695     9
+    696    692    693    694     9
+    696    692    693    695     9
+    690    692    696    697     9
+    690    692    696    698     9
+    693    692    696    697     9
+    693    692    696    698     9
+    679    699    701    702     9
+    679    699    701    703     9
+    700    699    701    702     9
+    700    699    701    703     9
+    699    701    703    704     9
+    699    701    703    705     9
+    699    701    703    713     9
+    702    701    703    704     9
+    702    701    703    705     9
+    702    701    703    713     9
+    713    703    705    708     9
+    701    703    705    706     9
+    701    703    705    707     9
+    701    703    705    708     9
+    704    703    705    706     9
+    704    703    705    707     9
+    704    703    705    708     9
+    713    703    705    706     9
+    713    703    705    707     9
+    701    703    713    714     9
+    701    703    713    715     9
+    704    703    713    714     9
+    704    703    713    715     9
+    705    703    713    714     9
+    705    703    713    715     9
+    703    705    708    710     9
+    703    705    708    709     9
+    706    705    708    709     9
+    706    705    708    710     9
+    707    705    708    709     9
+    707    705    708    710     9
+    705    708    710    711     9
+    705    708    710    712     9
+    709    708    710    711     9
+    709    708    710    712     9
+    703    713    715    716     9
+    703    713    715    717     9
+    714    713    715    716     9
+    714    713    715    717     9
+    713    715    717    718     9
+    713    715    717    719     9
+    713    715    717    727     9
+    716    715    717    718     9
+    716    715    717    719     9
+    716    715    717    727     9
+    715    717    719    720     9
+    715    717    719    721     9
+    715    717    719    725     9
+    718    717    719    720     9
+    718    717    719    721     9
+    718    717    719    725     9
+    727    717    719    720     9
+    727    717    719    721     9
+    727    717    719    725     9
+    715    717    727    728     9
+    715    717    727    729     9
+    718    717    727    728     9
+    718    717    727    729     9
+    719    717    727    728     9
+    719    717    727    729     9
+    717    719    721    722     9
+    717    719    721    723     9
+    717    719    721    724     9
+    720    719    721    722     9
+    720    719    721    723     9
+    720    719    721    724     9
+    725    719    721    722     9
+    725    719    721    723     9
+    725    719    721    724     9
+    717    719    725    726     9
+    720    719    725    726     9
+    721    719    725    726     9
+    717    727    729    730     9
+    717    727    729    731     9
+    728    727    729    730     9
+    728    727    729    731     9
+    727    729    731    732     9
+    727    729    731    733     9
+    727    729    731    739     9
+    730    729    731    732     9
+    730    729    731    733     9
+    730    729    731    739     9
+    729    731    733    736     9
+    729    731    733    734     9
+    729    731    733    735     9
+    732    731    733    734     9
+    732    731    733    735     9
+    732    731    733    736     9
+    739    731    733    734     9
+    739    731    733    735     9
+    739    731    733    736     9
+    729    731    739    740     9
+    729    731    739    741     9
+    732    731    739    740     9
+    732    731    739    741     9
+    733    731    739    740     9
+    733    731    739    741     9
+    731    733    736    737     9
+    731    733    736    738     9
+    734    733    736    737     9
+    734    733    736    738     9
+    735    733    736    737     9
+    735    733    736    738     9
+    731    739    741    742     9
+    731    739    741    743     9
+    740    739    741    742     9
+    740    739    741    743     9
+    739    741    743    744     9
+    739    741    743    745     9
+    739    741    743    746     9
+    742    741    743    744     9
+    742    741    743    745     9
+    742    741    743    746     9
+    741    743    746    747     9
+    741    743    746    748     9
+    744    743    746    747     9
+    744    743    746    748     9
+    745    743    746    747     9
+    745    743    746    748     9
+    743    746    748    749     9
+    743    746    748    750     9
+    747    746    748    749     9
+    747    746    748    750     9
+    746    748    750    751     9
+    746    748    750    752     9
+    746    748    750    757     9
+    749    748    750    751     9
+    749    748    750    752     9
+    749    748    750    757     9
+    748    750    752    753     9
+    748    750    752    754     9
+    748    750    752    755     9
+    751    750    752    753     9
+    751    750    752    754     9
+    751    750    752    755     9
+    757    750    752    753     9
+    757    750    752    754     9
+    757    750    752    755     9
+    748    750    757    758     9
+    748    750    757    759     9
+    751    750    757    758     9
+    751    750    757    759     9
+    752    750    757    758     9
+    752    750    757    759     9
+    750    752    755    756     9
+    753    752    755    756     9
+    754    752    755    756     9
+    750    757    759    760     9
+    750    757    759    761     9
+    758    757    759    760     9
+    758    757    759    761     9
+    757    759    761    762     9
+    757    759    761    763     9
+    757    759    761    771     9
+    760    759    761    762     9
+    760    759    761    763     9
+    760    759    761    771     9
+    759    761    763    764     9
+    759    761    763    765     9
+    759    761    763    769     9
+    762    761    763    764     9
+    762    761    763    765     9
+    762    761    763    769     9
+    771    761    763    764     9
+    771    761    763    765     9
+    771    761    763    769     9
+    759    761    771    772     9
+    759    761    771    773     9
+    762    761    771    772     9
+    762    761    771    773     9
+    763    761    771    772     9
+    763    761    771    773     9
+    761    763    765    766     9
+    761    763    765    767     9
+    761    763    765    768     9
+    764    763    765    766     9
+    764    763    765    767     9
+    764    763    765    768     9
+    769    763    765    766     9
+    769    763    765    767     9
+    769    763    765    768     9
+    761    763    769    770     9
+    764    763    769    770     9
+    765    763    769    770     9
+    761    771    773    774     9
+    761    771    773    775     9
+    772    771    773    774     9
+    772    771    773    775     9
+    771    773    775    776     9
+    771    773    775    777     9
+    771    773    775    783     9
+    774    773    775    776     9
+    774    773    775    777     9
+    774    773    775    783     9
+    773    775    777    780     9
+    773    775    777    778     9
+    773    775    777    779     9
+    776    775    777    778     9
+    776    775    777    779     9
+    776    775    777    780     9
+    783    775    777    778     9
+    783    775    777    779     9
+    783    775    777    780     9
+    773    775    783    784     9
+    773    775    783    785     9
+    776    775    783    784     9
+    776    775    783    785     9
+    777    775    783    784     9
+    777    775    783    785     9
+    775    777    780    781     9
+    775    777    780    782     9
+    778    777    780    781     9
+    778    777    780    782     9
+    779    777    780    781     9
+    779    777    780    782     9
+    775    783    785    786     9
+    775    783    785    787     9
+    784    783    785    786     9
+    784    783    785    787     9
+    783    785    787    788     9
+    783    785    787    789     9
+    783    785    787    804     9
+    786    785    787    788     9
+    786    785    787    789     9
+    786    785    787    804     9
+    785    787    789    790     9
+    785    787    789    791     9
+    785    787    789    792     9
+    788    787    789    790     9
+    788    787    789    791     9
+    788    787    789    792     9
+    804    787    789    790     9
+    804    787    789    791     9
+    804    787    789    792     9
+    785    787    804    805     9
+    785    787    804    806     9
+    788    787    804    805     9
+    788    787    804    806     9
+    789    787    804    805     9
+    789    787    804    806     9
+    787    789    792    793     9
+    787    789    792    802     9
+    790    789    792    793     9
+    790    789    792    802     9
+    791    789    792    793     9
+    791    789    792    802     9
+    789    792    793    794     9
+    789    792    793    795     9
+    802    792    793    794     9
+    802    792    793    795     9
+    789    792    802    800     9
+    789    792    802    803     9
+    793    792    802    800     9
+    793    792    802    803     9
+    792    793    795    796     9
+    792    793    795    797     9
+    794    793    795    796     9
+    794    793    795    797     9
+    793    795    797    798     9
+    793    795    797    800     9
+    796    795    797    798     9
+    796    795    797    800     9
+    795    797    798    799     9
+    800    797    798    799     9
+    795    797    800    801     9
+    795    797    800    802     9
+    798    797    800    801     9
+    798    797    800    802     9
+    797    800    802    792     9
+    797    800    802    803     9
+    801    800    802    792     9
+    801    800    802    803     9
+    787    804    806    807     9
+    787    804    806    808     9
+    805    804    806    807     9
+    805    804    806    808     9
+    804    806    808    809     9
+    804    806    808    810     9
+    804    806    808    811     9
+    807    806    808    809     9
+    807    806    808    810     9
+    807    806    808    811     9
+    806    808    811    812     9
+    806    808    811    813     9
+    809    808    811    812     9
+    809    808    811    813     9
+    810    808    811    812     9
+    810    808    811    813     9
+    808    811    813    814     9
+    808    811    813    815     9
+    812    811    813    814     9
+    812    811    813    815     9
+    811    813    815    816     9
+    811    813    815    817     9
+    811    813    815    830     9
+    814    813    815    816     9
+    814    813    815    817     9
+    814    813    815    830     9
+    813    815    817    819     9
+    813    815    817    818     9
+    813    815    817    823     9
+    816    815    817    818     9
+    816    815    817    819     9
+    816    815    817    823     9
+    830    815    817    818     9
+    830    815    817    819     9
+    830    815    817    823     9
+    813    815    830    831     9
+    813    815    830    832     9
+    816    815    830    831     9
+    816    815    830    832     9
+    817    815    830    831     9
+    817    815    830    832     9
+    815    817    819    820     9
+    815    817    819    821     9
+    815    817    819    822     9
+    818    817    819    820     9
+    818    817    819    821     9
+    818    817    819    822     9
+    823    817    819    820     9
+    823    817    819    821     9
+    823    817    819    822     9
+    815    817    823    824     9
+    815    817    823    825     9
+    815    817    823    826     9
+    818    817    823    824     9
+    818    817    823    825     9
+    818    817    823    826     9
+    819    817    823    824     9
+    819    817    823    825     9
+    819    817    823    826     9
+    817    823    826    827     9
+    817    823    826    828     9
+    817    823    826    829     9
+    824    823    826    827     9
+    824    823    826    828     9
+    824    823    826    829     9
+    825    823    826    827     9
+    825    823    826    828     9
+    825    823    826    829     9
+    815    830    832    833     9
+    815    830    832    834     9
+    831    830    832    833     9
+    831    830    832    834     9
+    830    832    834    835     9
+    830    832    834    836     9
+    830    832    834    849     9
+    833    832    834    835     9
+    833    832    834    836     9
+    833    832    834    849     9
+    849    834    836    839     9
+    832    834    836    837     9
+    832    834    836    838     9
+    832    834    836    839     9
+    835    834    836    837     9
+    835    834    836    838     9
+    835    834    836    839     9
+    849    834    836    837     9
+    849    834    836    838     9
+    832    834    849    850     9
+    832    834    849    851     9
+    835    834    849    850     9
+    835    834    849    851     9
+    836    834    849    850     9
+    836    834    849    851     9
+    834    836    839    840     9
+    834    836    839    841     9
+    834    836    839    845     9
+    837    836    839    840     9
+    837    836    839    841     9
+    837    836    839    845     9
+    838    836    839    840     9
+    838    836    839    841     9
+    838    836    839    845     9
+    836    839    841    842     9
+    836    839    841    843     9
+    836    839    841    844     9
+    840    839    841    842     9
+    840    839    841    843     9
+    840    839    841    844     9
+    845    839    841    842     9
+    845    839    841    843     9
+    845    839    841    844     9
+    836    839    845    846     9
+    836    839    845    847     9
+    836    839    845    848     9
+    840    839    845    846     9
+    840    839    845    847     9
+    840    839    845    848     9
+    841    839    845    846     9
+    841    839    845    847     9
+    841    839    845    848     9
+    834    849    851    852     9
+    834    849    851    853     9
+    850    849    851    852     9
+    850    849    851    853     9
+    849    851    853    854     9
+    849    851    853    855     9
+    849    851    853    866     9
+    852    851    853    854     9
+    852    851    853    855     9
+    852    851    853    866     9
+    851    853    855    856     9
+    851    853    855    857     9
+    851    853    855    858     9
+    854    853    855    856     9
+    854    853    855    857     9
+    854    853    855    858     9
+    866    853    855    856     9
+    866    853    855    857     9
+    866    853    855    858     9
+    851    853    866    867     9
+    851    853    866    868     9
+    854    853    866    867     9
+    854    853    866    868     9
+    855    853    866    867     9
+    855    853    866    868     9
+    853    855    858    859     9
+    853    855    858    860     9
+    853    855    858    861     9
+    856    855    858    859     9
+    856    855    858    860     9
+    856    855    858    861     9
+    857    855    858    859     9
+    857    855    858    860     9
+    857    855    858    861     9
+    855    858    861    862     9
+    855    858    861    863     9
+    859    858    861    862     9
+    859    858    861    863     9
+    860    858    861    862     9
+    860    858    861    863     9
+    858    861    863    864     9
+    858    861    863    865     9
+    862    861    863    864     9
+    862    861    863    865     9
+    853    866    868    869     9
+    853    866    868    870     9
+    867    866    868    869     9
+    867    866    868    870     9
+    866    868    870    871     9
+    866    868    870    872     9
+    866    868    870    885     9
+    869    868    870    871     9
+    869    868    870    872     9
+    869    868    870    885     9
+    868    870    872    874     9
+    868    870    872    873     9
+    868    870    872    878     9
+    871    870    872    873     9
+    871    870    872    874     9
+    871    870    872    878     9
+    885    870    872    873     9
+    885    870    872    874     9
+    885    870    872    878     9
+    868    870    885    886     9
+    868    870    885    887     9
+    871    870    885    886     9
+    871    870    885    887     9
+    872    870    885    886     9
+    872    870    885    887     9
+    870    872    874    875     9
+    870    872    874    876     9
+    870    872    874    877     9
+    873    872    874    875     9
+    873    872    874    876     9
+    873    872    874    877     9
+    878    872    874    875     9
+    878    872    874    876     9
+    878    872    874    877     9
+    870    872    878    879     9
+    870    872    878    880     9
+    870    872    878    881     9
+    873    872    878    879     9
+    873    872    878    880     9
+    873    872    878    881     9
+    874    872    878    879     9
+    874    872    878    880     9
+    874    872    878    881     9
+    872    878    881    882     9
+    872    878    881    883     9
+    872    878    881    884     9
+    879    878    881    882     9
+    879    878    881    883     9
+    879    878    881    884     9
+    880    878    881    882     9
+    880    878    881    883     9
+    880    878    881    884     9
+    870    885    887    888     9
+    870    885    887    889     9
+    886    885    887    888     9
+    886    885    887    889     9
+    885    887    889    890     9
+    885    887    889    891     9
+    885    887    889    899     9
+    888    887    889    890     9
+    888    887    889    891     9
+    888    887    889    899     9
+    899    889    891    894     9
+    887    889    891    892     9
+    887    889    891    893     9
+    887    889    891    894     9
+    890    889    891    892     9
+    890    889    891    893     9
+    890    889    891    894     9
+    899    889    891    892     9
+    899    889    891    893     9
+    887    889    899    900     9
+    887    889    899    901     9
+    890    889    899    900     9
+    890    889    899    901     9
+    891    889    899    900     9
+    891    889    899    901     9
+    889    891    894    896     9
+    889    891    894    895     9
+    892    891    894    895     9
+    892    891    894    896     9
+    893    891    894    895     9
+    893    891    894    896     9
+    891    894    896    897     9
+    891    894    896    898     9
+    895    894    896    897     9
+    895    894    896    898     9
+    889    899    901    902     9
+    889    899    901    903     9
+    900    899    901    902     9
+    900    899    901    903     9
+    899    901    903    904     9
+    899    901    903    905     9
+    899    901    903    910     9
+    902    901    903    904     9
+    902    901    903    905     9
+    902    901    903    910     9
+    901    903    905    906     9
+    901    903    905    907     9
+    901    903    905    908     9
+    904    903    905    906     9
+    904    903    905    907     9
+    904    903    905    908     9
+    910    903    905    906     9
+    910    903    905    907     9
+    910    903    905    908     9
+    901    903    910    911     9
+    901    903    910    912     9
+    904    903    910    911     9
+    904    903    910    912     9
+    905    903    910    911     9
+    905    903    910    912     9
+    903    905    908    909     9
+    906    905    908    909     9
+    907    905    908    909     9
+    903    910    912    913     9
+    903    910    912    914     9
+    911    910    912    913     9
+    911    910    912    914     9
+    910    912    914    915     9
+    910    912    914    916     9
+    910    912    914    934     9
+    913    912    914    915     9
+    913    912    914    916     9
+    913    912    914    934     9
+    912    914    916    917     9
+    912    914    916    918     9
+    912    914    916    919     9
+    915    914    916    917     9
+    915    914    916    918     9
+    915    914    916    919     9
+    934    914    916    917     9
+    934    914    916    918     9
+    934    914    916    919     9
+    912    914    934    935     9
+    912    914    934    936     9
+    915    914    934    935     9
+    915    914    934    936     9
+    916    914    934    935     9
+    916    914    934    936     9
+    914    916    919    920     9
+    914    916    919    921     9
+    914    916    919    922     9
+    917    916    919    920     9
+    917    916    919    921     9
+    917    916    919    922     9
+    918    916    919    920     9
+    918    916    919    921     9
+    918    916    919    922     9
+    916    919    922    923     9
+    916    919    922    924     9
+    916    919    922    925     9
+    920    919    922    923     9
+    920    919    922    924     9
+    920    919    922    925     9
+    921    919    922    923     9
+    921    919    922    924     9
+    921    919    922    925     9
+    919    922    925    926     9
+    919    922    925    927     9
+    923    922    925    926     9
+    923    922    925    927     9
+    924    922    925    926     9
+    924    922    925    927     9
+    922    925    927    928     9
+    922    925    927    931     9
+    926    925    927    928     9
+    926    925    927    931     9
+    925    927    928    929     9
+    925    927    928    930     9
+    931    927    928    929     9
+    931    927    928    930     9
+    925    927    931    932     9
+    925    927    931    933     9
+    928    927    931    932     9
+    928    927    931    933     9
+    914    934    936    937     9
+    914    934    936    938     9
+    935    934    936    937     9
+    935    934    936    938     9
+    934    936    938    939     9
+    934    936    938    940     9
+    934    936    938    958     9
+    937    936    938    939     9
+    937    936    938    940     9
+    937    936    938    958     9
+    936    938    940    941     9
+    936    938    940    942     9
+    936    938    940    943     9
+    939    938    940    941     9
+    939    938    940    942     9
+    939    938    940    943     9
+    958    938    940    941     9
+    958    938    940    942     9
+    958    938    940    943     9
+    936    938    958    959     9
+    936    938    958    960     9
+    939    938    958    959     9
+    939    938    958    960     9
+    940    938    958    959     9
+    940    938    958    960     9
+    938    940    943    944     9
+    938    940    943    957     9
+    941    940    943    944     9
+    941    940    943    957     9
+    942    940    943    944     9
+    942    940    943    957     9
+    940    943    944    945     9
+    940    943    944    946     9
+    957    943    944    945     9
+    957    943    944    946     9
+    940    943    957    948     9
+    940    943    957    955     9
+    944    943    957    948     9
+    944    943    957    955     9
+    943    944    946    947     9
+    943    944    946    948     9
+    945    944    946    947     9
+    945    944    946    948     9
+    944    946    948    949     9
+    944    946    948    957     9
+    947    946    948    949     9
+    947    946    948    957     9
+    946    948    949    950     9
+    946    948    949    951     9
+    957    948    949    950     9
+    957    948    949    951     9
+    946    948    957    943     9
+    946    948    957    955     9
+    949    948    957    943     9
+    949    948    957    955     9
+    948    949    951    952     9
+    948    949    951    953     9
+    950    949    951    952     9
+    950    949    951    953     9
+    949    951    953    954     9
+    949    951    953    955     9
+    952    951    953    954     9
+    952    951    953    955     9
+    951    953    955    956     9
+    951    953    955    957     9
+    954    953    955    956     9
+    954    953    955    957     9
+    953    955    957    943     9
+    953    955    957    948     9
+    956    955    957    943     9
+    956    955    957    948     9
+    938    958    960    961     9
+    938    958    960    962     9
+    959    958    960    961     9
+    959    958    960    962     9
+    958    960    962    963     9
+    958    960    962    964     9
+    958    960    962    982     9
+    961    960    962    963     9
+    961    960    962    964     9
+    961    960    962    982     9
+    960    962    964    965     9
+    960    962    964    966     9
+    960    962    964    967     9
+    963    962    964    965     9
+    963    962    964    966     9
+    963    962    964    967     9
+    982    962    964    965     9
+    982    962    964    966     9
+    982    962    964    967     9
+    960    962    982    983     9
+    960    962    982    984     9
+    963    962    982    983     9
+    963    962    982    984     9
+    964    962    982    983     9
+    964    962    982    984     9
+    962    964    967    968     9
+    962    964    967    981     9
+    965    964    967    968     9
+    965    964    967    981     9
+    966    964    967    968     9
+    966    964    967    981     9
+    964    967    968    969     9
+    964    967    968    970     9
+    981    967    968    969     9
+    981    967    968    970     9
+    964    967    981    972     9
+    964    967    981    979     9
+    968    967    981    972     9
+    968    967    981    979     9
+    967    968    970    971     9
+    967    968    970    972     9
+    969    968    970    971     9
+    969    968    970    972     9
+    968    970    972    973     9
+    968    970    972    981     9
+    971    970    972    973     9
+    971    970    972    981     9
+    970    972    973    974     9
+    970    972    973    975     9
+    981    972    973    974     9
+    981    972    973    975     9
+    970    972    981    967     9
+    970    972    981    979     9
+    973    972    981    967     9
+    973    972    981    979     9
+    972    973    975    976     9
+    972    973    975    977     9
+    974    973    975    976     9
+    974    973    975    977     9
+    973    975    977    978     9
+    973    975    977    979     9
+    976    975    977    978     9
+    976    975    977    979     9
+    975    977    979    980     9
+    975    977    979    981     9
+    978    977    979    980     9
+    978    977    979    981     9
+    977    979    981    967     9
+    977    979    981    972     9
+    980    979    981    967     9
+    980    979    981    972     9
+    962    982    984    985     9
+    962    982    984    986     9
+    983    982    984    985     9
+    983    982    984    986     9
+    982    984    986    987     9
+    982    984    986    988     9
+    982    984    986    992     9
+    985    984    986    987     9
+    985    984    986    988     9
+    985    984    986    992     9
+    984    986    988    989     9
+    984    986    988    990     9
+    984    986    988    991     9
+    987    986    988    989     9
+    987    986    988    990     9
+    987    986    988    991     9
+    992    986    988    989     9
+    992    986    988    990     9
+    992    986    988    991     9
+    984    986    992    993     9
+    984    986    992    994     9
+    987    986    992    993     9
+    987    986    992    994     9
+    988    986    992    993     9
+    988    986    992    994     9
+    986    988    991   1218     9
+    989    988    991   1218     9
+    990    988    991   1218     9
+    988    991   1218   1215     9
+    986    992    994    995     9
+    986    992    994    996     9
+    993    992    994    995     9
+    993    992    994    996     9
+    992    994    996    997     9
+    992    994    996    998     9
+    992    994    996   1006     9
+    995    994    996    997     9
+    995    994    996    998     9
+    995    994    996   1006     9
+   1006    996    998   1001     9
+    994    996    998    999     9
+    994    996    998   1000     9
+    994    996    998   1001     9
+    997    996    998    999     9
+    997    996    998   1000     9
+    997    996    998   1001     9
+   1006    996    998    999     9
+   1006    996    998   1000     9
+    994    996   1006   1007     9
+    994    996   1006   1008     9
+    997    996   1006   1007     9
+    997    996   1006   1008     9
+    998    996   1006   1007     9
+    998    996   1006   1008     9
+    996    998   1001   1003     9
+    996    998   1001   1002     9
+    999    998   1001   1002     9
+    999    998   1001   1003     9
+   1000    998   1001   1002     9
+   1000    998   1001   1003     9
+    998   1001   1003   1004     9
+    998   1001   1003   1005     9
+   1002   1001   1003   1004     9
+   1002   1001   1003   1005     9
+    996   1006   1008   1009     9
+    996   1006   1008   1010     9
+   1007   1006   1008   1009     9
+   1007   1006   1008   1010     9
+   1006   1008   1010   1011     9
+   1006   1008   1010   1012     9
+   1006   1008   1010   1018     9
+   1009   1008   1010   1011     9
+   1009   1008   1010   1012     9
+   1009   1008   1010   1018     9
+   1008   1010   1012   1015     9
+   1008   1010   1012   1013     9
+   1008   1010   1012   1014     9
+   1011   1010   1012   1013     9
+   1011   1010   1012   1014     9
+   1011   1010   1012   1015     9
+   1018   1010   1012   1013     9
+   1018   1010   1012   1014     9
+   1018   1010   1012   1015     9
+   1008   1010   1018   1019     9
+   1008   1010   1018   1020     9
+   1011   1010   1018   1019     9
+   1011   1010   1018   1020     9
+   1012   1010   1018   1019     9
+   1012   1010   1018   1020     9
+   1010   1012   1015   1016     9
+   1010   1012   1015   1017     9
+   1013   1012   1015   1016     9
+   1013   1012   1015   1017     9
+   1014   1012   1015   1016     9
+   1014   1012   1015   1017     9
+   1010   1018   1020   1021     9
+   1010   1018   1020   1022     9
+   1019   1018   1020   1021     9
+   1019   1018   1020   1022     9
+   1018   1020   1022   1023     9
+   1018   1020   1022   1024     9
+   1018   1020   1022   1025     9
+   1021   1020   1022   1023     9
+   1021   1020   1022   1024     9
+   1021   1020   1022   1025     9
+   1020   1022   1025   1026     9
+   1020   1022   1025   1027     9
+   1023   1022   1025   1026     9
+   1023   1022   1025   1027     9
+   1024   1022   1025   1026     9
+   1024   1022   1025   1027     9
+   1022   1025   1027   1028     9
+   1022   1025   1027   1029     9
+   1026   1025   1027   1028     9
+   1026   1025   1027   1029     9
+   1025   1027   1029   1030     9
+   1025   1027   1029   1031     9
+   1025   1027   1029   1049     9
+   1028   1027   1029   1030     9
+   1028   1027   1029   1031     9
+   1028   1027   1029   1049     9
+   1027   1029   1031   1032     9
+   1027   1029   1031   1033     9
+   1027   1029   1031   1034     9
+   1030   1029   1031   1032     9
+   1030   1029   1031   1033     9
+   1030   1029   1031   1034     9
+   1049   1029   1031   1032     9
+   1049   1029   1031   1033     9
+   1049   1029   1031   1034     9
+   1027   1029   1049   1050     9
+   1027   1029   1049   1051     9
+   1030   1029   1049   1050     9
+   1030   1029   1049   1051     9
+   1031   1029   1049   1050     9
+   1031   1029   1049   1051     9
+   1029   1031   1034   1035     9
+   1029   1031   1034   1036     9
+   1029   1031   1034   1037     9
+   1032   1031   1034   1035     9
+   1032   1031   1034   1036     9
+   1032   1031   1034   1037     9
+   1033   1031   1034   1035     9
+   1033   1031   1034   1036     9
+   1033   1031   1034   1037     9
+   1031   1034   1037   1038     9
+   1031   1034   1037   1039     9
+   1031   1034   1037   1040     9
+   1035   1034   1037   1038     9
+   1035   1034   1037   1039     9
+   1035   1034   1037   1040     9
+   1036   1034   1037   1038     9
+   1036   1034   1037   1039     9
+   1036   1034   1037   1040     9
+   1034   1037   1040   1041     9
+   1034   1037   1040   1042     9
+   1038   1037   1040   1041     9
+   1038   1037   1040   1042     9
+   1039   1037   1040   1041     9
+   1039   1037   1040   1042     9
+   1037   1040   1042   1043     9
+   1037   1040   1042   1046     9
+   1041   1040   1042   1043     9
+   1041   1040   1042   1046     9
+   1040   1042   1043   1044     9
+   1040   1042   1043   1045     9
+   1046   1042   1043   1044     9
+   1046   1042   1043   1045     9
+   1040   1042   1046   1047     9
+   1040   1042   1046   1048     9
+   1043   1042   1046   1047     9
+   1043   1042   1046   1048     9
+   1029   1049   1051   1052     9
+   1029   1049   1051   1053     9
+   1050   1049   1051   1052     9
+   1050   1049   1051   1053     9
+   1049   1051   1053   1054     9
+   1049   1051   1053   1055     9
+   1049   1051   1053   1063     9
+   1052   1051   1053   1054     9
+   1052   1051   1053   1055     9
+   1052   1051   1053   1063     9
+   1051   1053   1055   1056     9
+   1051   1053   1055   1057     9
+   1051   1053   1055   1061     9
+   1054   1053   1055   1056     9
+   1054   1053   1055   1057     9
+   1054   1053   1055   1061     9
+   1063   1053   1055   1056     9
+   1063   1053   1055   1057     9
+   1063   1053   1055   1061     9
+   1051   1053   1063   1064     9
+   1051   1053   1063   1065     9
+   1054   1053   1063   1064     9
+   1054   1053   1063   1065     9
+   1055   1053   1063   1064     9
+   1055   1053   1063   1065     9
+   1053   1055   1057   1058     9
+   1053   1055   1057   1059     9
+   1053   1055   1057   1060     9
+   1056   1055   1057   1058     9
+   1056   1055   1057   1059     9
+   1056   1055   1057   1060     9
+   1061   1055   1057   1058     9
+   1061   1055   1057   1059     9
+   1061   1055   1057   1060     9
+   1053   1055   1061   1062     9
+   1056   1055   1061   1062     9
+   1057   1055   1061   1062     9
+   1053   1063   1065   1066     9
+   1053   1063   1065   1075     9
+   1064   1063   1065   1066     9
+   1064   1063   1065   1075     9
+   1063   1065   1066   1067     9
+   1063   1065   1066   1068     9
+   1063   1065   1066   1069     9
+   1075   1065   1066   1067     9
+   1075   1065   1066   1068     9
+   1075   1065   1066   1069     9
+   1063   1065   1075   1072     9
+   1063   1065   1075   1076     9
+   1063   1065   1075   1077     9
+   1066   1065   1075   1072     9
+   1066   1065   1075   1076     9
+   1066   1065   1075   1077     9
+   1065   1066   1069   1070     9
+   1065   1066   1069   1071     9
+   1065   1066   1069   1072     9
+   1067   1066   1069   1070     9
+   1067   1066   1069   1071     9
+   1067   1066   1069   1072     9
+   1068   1066   1069   1070     9
+   1068   1066   1069   1071     9
+   1068   1066   1069   1072     9
+   1066   1069   1072   1073     9
+   1066   1069   1072   1074     9
+   1066   1069   1072   1075     9
+   1070   1069   1072   1073     9
+   1070   1069   1072   1074     9
+   1070   1069   1072   1075     9
+   1071   1069   1072   1073     9
+   1071   1069   1072   1074     9
+   1071   1069   1072   1075     9
+   1069   1072   1075   1065     9
+   1069   1072   1075   1076     9
+   1069   1072   1075   1077     9
+   1073   1072   1075   1065     9
+   1073   1072   1075   1076     9
+   1073   1072   1075   1077     9
+   1074   1072   1075   1065     9
+   1074   1072   1075   1076     9
+   1074   1072   1075   1077     9
+   1065   1075   1077   1078     9
+   1065   1075   1077   1079     9
+   1072   1075   1077   1078     9
+   1072   1075   1077   1079     9
+   1076   1075   1077   1078     9
+   1076   1075   1077   1079     9
+   1075   1077   1079   1080     9
+   1075   1077   1079   1081     9
+   1078   1077   1079   1080     9
+   1078   1077   1079   1081     9
+   1077   1079   1081   1082     9
+   1077   1079   1081   1083     9
+   1077   1079   1081   1084     9
+   1080   1079   1081   1082     9
+   1080   1079   1081   1083     9
+   1080   1079   1081   1084     9
+   1079   1081   1084   1085     9
+   1079   1081   1084   1086     9
+   1082   1081   1084   1085     9
+   1082   1081   1084   1086     9
+   1083   1081   1084   1085     9
+   1083   1081   1084   1086     9
+   1081   1084   1086   1087     9
+   1081   1084   1086   1088     9
+   1085   1084   1086   1087     9
+   1085   1084   1086   1088     9
+   1084   1086   1088   1089     9
+   1084   1086   1088   1090     9
+   1084   1086   1088   1095     9
+   1087   1086   1088   1089     9
+   1087   1086   1088   1090     9
+   1087   1086   1088   1095     9
+   1086   1088   1090   1091     9
+   1086   1088   1090   1092     9
+   1086   1088   1090   1093     9
+   1089   1088   1090   1091     9
+   1089   1088   1090   1092     9
+   1089   1088   1090   1093     9
+   1095   1088   1090   1091     9
+   1095   1088   1090   1092     9
+   1095   1088   1090   1093     9
+   1086   1088   1095   1096     9
+   1086   1088   1095   1097     9
+   1089   1088   1095   1096     9
+   1089   1088   1095   1097     9
+   1090   1088   1095   1096     9
+   1090   1088   1095   1097     9
+   1088   1090   1093   1094     9
+   1091   1090   1093   1094     9
+   1092   1090   1093   1094     9
+   1088   1095   1097   1098     9
+   1088   1095   1097   1099     9
+   1096   1095   1097   1098     9
+   1096   1095   1097   1099     9
+   1095   1097   1099   1100     9
+   1095   1097   1099   1101     9
+   1095   1097   1099   1119     9
+   1098   1097   1099   1100     9
+   1098   1097   1099   1101     9
+   1098   1097   1099   1119     9
+   1097   1099   1101   1102     9
+   1097   1099   1101   1103     9
+   1097   1099   1101   1104     9
+   1100   1099   1101   1102     9
+   1100   1099   1101   1103     9
+   1100   1099   1101   1104     9
+   1119   1099   1101   1102     9
+   1119   1099   1101   1103     9
+   1119   1099   1101   1104     9
+   1097   1099   1119   1120     9
+   1097   1099   1119   1121     9
+   1100   1099   1119   1120     9
+   1100   1099   1119   1121     9
+   1101   1099   1119   1120     9
+   1101   1099   1119   1121     9
+   1099   1101   1104   1105     9
+   1099   1101   1104   1106     9
+   1099   1101   1104   1107     9
+   1102   1101   1104   1105     9
+   1102   1101   1104   1106     9
+   1102   1101   1104   1107     9
+   1103   1101   1104   1105     9
+   1103   1101   1104   1106     9
+   1103   1101   1104   1107     9
+   1101   1104   1107   1108     9
+   1101   1104   1107   1109     9
+   1101   1104   1107   1110     9
+   1105   1104   1107   1108     9
+   1105   1104   1107   1109     9
+   1105   1104   1107   1110     9
+   1106   1104   1107   1108     9
+   1106   1104   1107   1109     9
+   1106   1104   1107   1110     9
+   1104   1107   1110   1111     9
+   1104   1107   1110   1112     9
+   1108   1107   1110   1111     9
+   1108   1107   1110   1112     9
+   1109   1107   1110   1111     9
+   1109   1107   1110   1112     9
+   1107   1110   1112   1113     9
+   1107   1110   1112   1116     9
+   1111   1110   1112   1113     9
+   1111   1110   1112   1116     9
+   1110   1112   1113   1114     9
+   1110   1112   1113   1115     9
+   1116   1112   1113   1114     9
+   1116   1112   1113   1115     9
+   1110   1112   1116   1117     9
+   1110   1112   1116   1118     9
+   1113   1112   1116   1117     9
+   1113   1112   1116   1118     9
+   1099   1119   1121   1122     9
+   1099   1119   1121   1123     9
+   1120   1119   1121   1122     9
+   1120   1119   1121   1123     9
+   1119   1121   1123   1124     9
+   1119   1121   1123   1125     9
+   1119   1121   1123   1133     9
+   1122   1121   1123   1124     9
+   1122   1121   1123   1125     9
+   1122   1121   1123   1133     9
+   1133   1123   1125   1128     9
+   1121   1123   1125   1126     9
+   1121   1123   1125   1127     9
+   1121   1123   1125   1128     9
+   1124   1123   1125   1126     9
+   1124   1123   1125   1127     9
+   1124   1123   1125   1128     9
+   1133   1123   1125   1126     9
+   1133   1123   1125   1127     9
+   1121   1123   1133   1134     9
+   1121   1123   1133   1135     9
+   1124   1123   1133   1134     9
+   1124   1123   1133   1135     9
+   1125   1123   1133   1134     9
+   1125   1123   1133   1135     9
+   1123   1125   1128   1130     9
+   1123   1125   1128   1129     9
+   1126   1125   1128   1129     9
+   1126   1125   1128   1130     9
+   1127   1125   1128   1129     9
+   1127   1125   1128   1130     9
+   1125   1128   1130   1131     9
+   1125   1128   1130   1132     9
+   1129   1128   1130   1131     9
+   1129   1128   1130   1132     9
+   1123   1133   1135   1136     9
+   1123   1133   1135   1137     9
+   1134   1133   1135   1136     9
+   1134   1133   1135   1137     9
+   1133   1135   1137   1138     9
+   1133   1135   1137   1139     9
+   1133   1135   1137   1152     9
+   1136   1135   1137   1138     9
+   1136   1135   1137   1139     9
+   1136   1135   1137   1152     9
+   1152   1137   1139   1142     9
+   1135   1137   1139   1140     9
+   1135   1137   1139   1141     9
+   1135   1137   1139   1142     9
+   1138   1137   1139   1140     9
+   1138   1137   1139   1141     9
+   1138   1137   1139   1142     9
+   1152   1137   1139   1140     9
+   1152   1137   1139   1141     9
+   1135   1137   1152   1153     9
+   1135   1137   1152   1154     9
+   1138   1137   1152   1153     9
+   1138   1137   1152   1154     9
+   1139   1137   1152   1153     9
+   1139   1137   1152   1154     9
+   1137   1139   1142   1143     9
+   1137   1139   1142   1144     9
+   1137   1139   1142   1148     9
+   1140   1139   1142   1143     9
+   1140   1139   1142   1144     9
+   1140   1139   1142   1148     9
+   1141   1139   1142   1143     9
+   1141   1139   1142   1144     9
+   1141   1139   1142   1148     9
+   1139   1142   1144   1145     9
+   1139   1142   1144   1146     9
+   1139   1142   1144   1147     9
+   1143   1142   1144   1145     9
+   1143   1142   1144   1146     9
+   1143   1142   1144   1147     9
+   1148   1142   1144   1145     9
+   1148   1142   1144   1146     9
+   1148   1142   1144   1147     9
+   1139   1142   1148   1149     9
+   1139   1142   1148   1150     9
+   1139   1142   1148   1151     9
+   1143   1142   1148   1149     9
+   1143   1142   1148   1150     9
+   1143   1142   1148   1151     9
+   1144   1142   1148   1149     9
+   1144   1142   1148   1150     9
+   1144   1142   1148   1151     9
+   1137   1152   1154   1155     9
+   1137   1152   1154   1156     9
+   1153   1152   1154   1155     9
+   1153   1152   1154   1156     9
+   1152   1154   1156   1157     9
+   1152   1154   1156   1158     9
+   1152   1154   1156   1162     9
+   1155   1154   1156   1157     9
+   1155   1154   1156   1158     9
+   1155   1154   1156   1162     9
+   1154   1156   1158   1159     9
+   1154   1156   1158   1160     9
+   1154   1156   1158   1161     9
+   1157   1156   1158   1159     9
+   1157   1156   1158   1160     9
+   1157   1156   1158   1161     9
+   1162   1156   1158   1159     9
+   1162   1156   1158   1160     9
+   1162   1156   1158   1161     9
+   1154   1156   1162   1163     9
+   1154   1156   1162   1164     9
+   1157   1156   1162   1163     9
+   1157   1156   1162   1164     9
+   1158   1156   1162   1163     9
+   1158   1156   1162   1164     9
+   1156   1158   1161   1405     9
+   1159   1158   1161   1405     9
+   1160   1158   1161   1405     9
+   1158   1161   1405   1402     9
+   1156   1162   1164   1165     9
+   1156   1162   1164   1166     9
+   1163   1162   1164   1165     9
+   1163   1162   1164   1166     9
+   1162   1164   1166   1167     9
+   1162   1164   1166   1168     9
+   1162   1164   1166   1176     9
+   1165   1164   1166   1167     9
+   1165   1164   1166   1168     9
+   1165   1164   1166   1176     9
+   1176   1166   1168   1171     9
+   1164   1166   1168   1169     9
+   1164   1166   1168   1170     9
+   1164   1166   1168   1171     9
+   1167   1166   1168   1169     9
+   1167   1166   1168   1170     9
+   1167   1166   1168   1171     9
+   1176   1166   1168   1169     9
+   1176   1166   1168   1170     9
+   1164   1166   1176   1177     9
+   1164   1166   1176   1178     9
+   1167   1166   1176   1177     9
+   1167   1166   1176   1178     9
+   1168   1166   1176   1177     9
+   1168   1166   1176   1178     9
+   1166   1168   1171   1173     9
+   1166   1168   1171   1172     9
+   1169   1168   1171   1172     9
+   1169   1168   1171   1173     9
+   1170   1168   1171   1172     9
+   1170   1168   1171   1173     9
+   1168   1171   1173   1174     9
+   1168   1171   1173   1175     9
+   1172   1171   1173   1174     9
+   1172   1171   1173   1175     9
+   1166   1176   1178   1179     9
+   1166   1176   1178   1180     9
+   1177   1176   1178   1179     9
+   1177   1176   1178   1180     9
+   1176   1178   1180   1181     9
+   1176   1178   1180   1182     9
+   1176   1178   1180   1195     9
+   1179   1178   1180   1181     9
+   1179   1178   1180   1182     9
+   1179   1178   1180   1195     9
+   1178   1180   1182   1184     9
+   1178   1180   1182   1183     9
+   1178   1180   1182   1188     9
+   1181   1180   1182   1183     9
+   1181   1180   1182   1184     9
+   1181   1180   1182   1188     9
+   1195   1180   1182   1183     9
+   1195   1180   1182   1184     9
+   1195   1180   1182   1188     9
+   1178   1180   1195   1196     9
+   1178   1180   1195   1197     9
+   1181   1180   1195   1196     9
+   1181   1180   1195   1197     9
+   1182   1180   1195   1196     9
+   1182   1180   1195   1197     9
+   1180   1182   1184   1185     9
+   1180   1182   1184   1186     9
+   1180   1182   1184   1187     9
+   1183   1182   1184   1185     9
+   1183   1182   1184   1186     9
+   1183   1182   1184   1187     9
+   1188   1182   1184   1185     9
+   1188   1182   1184   1186     9
+   1188   1182   1184   1187     9
+   1180   1182   1188   1189     9
+   1180   1182   1188   1190     9
+   1180   1182   1188   1191     9
+   1183   1182   1188   1189     9
+   1183   1182   1188   1190     9
+   1183   1182   1188   1191     9
+   1184   1182   1188   1189     9
+   1184   1182   1188   1190     9
+   1184   1182   1188   1191     9
+   1182   1188   1191   1192     9
+   1182   1188   1191   1193     9
+   1182   1188   1191   1194     9
+   1189   1188   1191   1192     9
+   1189   1188   1191   1193     9
+   1189   1188   1191   1194     9
+   1190   1188   1191   1192     9
+   1190   1188   1191   1193     9
+   1190   1188   1191   1194     9
+   1180   1195   1197   1198     9
+   1180   1195   1197   1207     9
+   1196   1195   1197   1198     9
+   1196   1195   1197   1207     9
+   1195   1197   1198   1199     9
+   1195   1197   1198   1200     9
+   1195   1197   1198   1201     9
+   1207   1197   1198   1199     9
+   1207   1197   1198   1200     9
+   1207   1197   1198   1201     9
+   1195   1197   1207   1204     9
+   1195   1197   1207   1208     9
+   1195   1197   1207   1209     9
+   1198   1197   1207   1204     9
+   1198   1197   1207   1208     9
+   1198   1197   1207   1209     9
+   1197   1198   1201   1202     9
+   1197   1198   1201   1203     9
+   1197   1198   1201   1204     9
+   1199   1198   1201   1202     9
+   1199   1198   1201   1203     9
+   1199   1198   1201   1204     9
+   1200   1198   1201   1202     9
+   1200   1198   1201   1203     9
+   1200   1198   1201   1204     9
+   1198   1201   1204   1205     9
+   1198   1201   1204   1206     9
+   1198   1201   1204   1207     9
+   1202   1201   1204   1205     9
+   1202   1201   1204   1206     9
+   1202   1201   1204   1207     9
+   1203   1201   1204   1205     9
+   1203   1201   1204   1206     9
+   1203   1201   1204   1207     9
+   1201   1204   1207   1197     9
+   1201   1204   1207   1208     9
+   1201   1204   1207   1209     9
+   1205   1204   1207   1197     9
+   1205   1204   1207   1208     9
+   1205   1204   1207   1209     9
+   1206   1204   1207   1197     9
+   1206   1204   1207   1208     9
+   1206   1204   1207   1209     9
+   1197   1207   1209   1210     9
+   1197   1207   1209   1211     9
+   1204   1207   1209   1210     9
+   1204   1207   1209   1211     9
+   1208   1207   1209   1210     9
+   1208   1207   1209   1211     9
+   1207   1209   1211   1212     9
+   1207   1209   1211   1213     9
+   1210   1209   1211   1212     9
+   1210   1209   1211   1213     9
+   1209   1211   1213   1214     9
+   1209   1211   1213   1215     9
+   1209   1211   1213   1219     9
+   1212   1211   1213   1214     9
+   1212   1211   1213   1215     9
+   1212   1211   1213   1219     9
+   1211   1213   1215   1216     9
+   1211   1213   1215   1217     9
+   1211   1213   1215   1218     9
+   1214   1213   1215   1216     9
+   1214   1213   1215   1217     9
+   1214   1213   1215   1218     9
+   1219   1213   1215   1216     9
+   1219   1213   1215   1217     9
+   1219   1213   1215   1218     9
+   1211   1213   1219   1220     9
+   1211   1213   1219   1221     9
+   1214   1213   1219   1220     9
+   1214   1213   1219   1221     9
+   1215   1213   1219   1220     9
+   1215   1213   1219   1221     9
+   1213   1215   1218    991     9
+   1216   1215   1218    991     9
+   1217   1215   1218    991     9
+   1213   1219   1221   1222     9
+   1213   1219   1221   1223     9
+   1220   1219   1221   1222     9
+   1220   1219   1221   1223     9
+   1219   1221   1223   1224     9
+   1219   1221   1223   1225     9
+   1219   1221   1223   1230     9
+   1222   1221   1223   1224     9
+   1222   1221   1223   1225     9
+   1222   1221   1223   1230     9
+   1221   1223   1225   1226     9
+   1221   1223   1225   1227     9
+   1221   1223   1225   1228     9
+   1224   1223   1225   1226     9
+   1224   1223   1225   1227     9
+   1224   1223   1225   1228     9
+   1230   1223   1225   1226     9
+   1230   1223   1225   1227     9
+   1230   1223   1225   1228     9
+   1221   1223   1230   1231     9
+   1221   1223   1230   1232     9
+   1224   1223   1230   1231     9
+   1224   1223   1230   1232     9
+   1225   1223   1230   1231     9
+   1225   1223   1230   1232     9
+   1223   1225   1228   1229     9
+   1226   1225   1228   1229     9
+   1227   1225   1228   1229     9
+   1223   1230   1232   1233     9
+   1223   1230   1232   1234     9
+   1231   1230   1232   1233     9
+   1231   1230   1232   1234     9
+   1230   1232   1234   1235     9
+   1230   1232   1234   1236     9
+   1230   1232   1234   1240     9
+   1233   1232   1234   1235     9
+   1233   1232   1234   1236     9
+   1233   1232   1234   1240     9
+   1232   1234   1236   1237     9
+   1232   1234   1236   1238     9
+   1232   1234   1236   1239     9
+   1235   1234   1236   1237     9
+   1235   1234   1236   1238     9
+   1235   1234   1236   1239     9
+   1240   1234   1236   1237     9
+   1240   1234   1236   1238     9
+   1240   1234   1236   1239     9
+   1232   1234   1240   1241     9
+   1232   1234   1240   1242     9
+   1235   1234   1240   1241     9
+   1235   1234   1240   1242     9
+   1236   1234   1240   1241     9
+   1236   1234   1240   1242     9
+   1234   1240   1242   1243     9
+   1234   1240   1242   1244     9
+   1241   1240   1242   1243     9
+   1241   1240   1242   1244     9
+   1240   1242   1244   1245     9
+   1240   1242   1244   1246     9
+   1240   1242   1244   1259     9
+   1243   1242   1244   1245     9
+   1243   1242   1244   1246     9
+   1243   1242   1244   1259     9
+   1259   1244   1246   1249     9
+   1242   1244   1246   1247     9
+   1242   1244   1246   1248     9
+   1242   1244   1246   1249     9
+   1245   1244   1246   1247     9
+   1245   1244   1246   1248     9
+   1245   1244   1246   1249     9
+   1259   1244   1246   1247     9
+   1259   1244   1246   1248     9
+   1242   1244   1259   1260     9
+   1242   1244   1259   1261     9
+   1245   1244   1259   1260     9
+   1245   1244   1259   1261     9
+   1246   1244   1259   1260     9
+   1246   1244   1259   1261     9
+   1244   1246   1249   1250     9
+   1244   1246   1249   1251     9
+   1244   1246   1249   1255     9
+   1247   1246   1249   1250     9
+   1247   1246   1249   1251     9
+   1247   1246   1249   1255     9
+   1248   1246   1249   1250     9
+   1248   1246   1249   1251     9
+   1248   1246   1249   1255     9
+   1246   1249   1251   1252     9
+   1246   1249   1251   1253     9
+   1246   1249   1251   1254     9
+   1250   1249   1251   1252     9
+   1250   1249   1251   1253     9
+   1250   1249   1251   1254     9
+   1255   1249   1251   1252     9
+   1255   1249   1251   1253     9
+   1255   1249   1251   1254     9
+   1246   1249   1255   1256     9
+   1246   1249   1255   1257     9
+   1246   1249   1255   1258     9
+   1250   1249   1255   1256     9
+   1250   1249   1255   1257     9
+   1250   1249   1255   1258     9
+   1251   1249   1255   1256     9
+   1251   1249   1255   1257     9
+   1251   1249   1255   1258     9
+   1244   1259   1261   1262     9
+   1244   1259   1261   1263     9
+   1260   1259   1261   1262     9
+   1260   1259   1261   1263     9
+   1259   1261   1263   1264     9
+   1259   1261   1263   1265     9
+   1259   1261   1263   1278     9
+   1262   1261   1263   1264     9
+   1262   1261   1263   1265     9
+   1262   1261   1263   1278     9
+   1278   1263   1265   1268     9
+   1261   1263   1265   1266     9
+   1261   1263   1265   1267     9
+   1261   1263   1265   1268     9
+   1264   1263   1265   1266     9
+   1264   1263   1265   1267     9
+   1264   1263   1265   1268     9
+   1278   1263   1265   1266     9
+   1278   1263   1265   1267     9
+   1261   1263   1278   1279     9
+   1261   1263   1278   1280     9
+   1264   1263   1278   1279     9
+   1264   1263   1278   1280     9
+   1265   1263   1278   1279     9
+   1265   1263   1278   1280     9
+   1263   1265   1268   1269     9
+   1263   1265   1268   1270     9
+   1263   1265   1268   1274     9
+   1266   1265   1268   1269     9
+   1266   1265   1268   1270     9
+   1266   1265   1268   1274     9
+   1267   1265   1268   1269     9
+   1267   1265   1268   1270     9
+   1267   1265   1268   1274     9
+   1265   1268   1270   1271     9
+   1265   1268   1270   1272     9
+   1265   1268   1270   1273     9
+   1269   1268   1270   1271     9
+   1269   1268   1270   1272     9
+   1269   1268   1270   1273     9
+   1274   1268   1270   1271     9
+   1274   1268   1270   1272     9
+   1274   1268   1270   1273     9
+   1265   1268   1274   1275     9
+   1265   1268   1274   1276     9
+   1265   1268   1274   1277     9
+   1269   1268   1274   1275     9
+   1269   1268   1274   1276     9
+   1269   1268   1274   1277     9
+   1270   1268   1274   1275     9
+   1270   1268   1274   1276     9
+   1270   1268   1274   1277     9
+   1263   1278   1280   1281     9
+   1263   1278   1280   1282     9
+   1279   1278   1280   1281     9
+   1279   1278   1280   1282     9
+   1278   1280   1282   1283     9
+   1278   1280   1282   1284     9
+   1278   1280   1282   1289     9
+   1281   1280   1282   1283     9
+   1281   1280   1282   1284     9
+   1281   1280   1282   1289     9
+   1280   1282   1284   1285     9
+   1280   1282   1284   1286     9
+   1280   1282   1284   1287     9
+   1283   1282   1284   1285     9
+   1283   1282   1284   1286     9
+   1283   1282   1284   1287     9
+   1289   1282   1284   1285     9
+   1289   1282   1284   1286     9
+   1289   1282   1284   1287     9
+   1280   1282   1289   1290     9
+   1280   1282   1289   1291     9
+   1283   1282   1289   1290     9
+   1283   1282   1289   1291     9
+   1284   1282   1289   1290     9
+   1284   1282   1289   1291     9
+   1282   1284   1287   1288     9
+   1285   1284   1287   1288     9
+   1286   1284   1287   1288     9
+   1282   1289   1291   1292     9
+   1282   1289   1291   1293     9
+   1290   1289   1291   1292     9
+   1290   1289   1291   1293     9
+   1289   1291   1293   1294     9
+   1289   1291   1293   1295     9
+   1289   1291   1293   1300     9
+   1292   1291   1293   1294     9
+   1292   1291   1293   1295     9
+   1292   1291   1293   1300     9
+   1291   1293   1295   1296     9
+   1291   1293   1295   1297     9
+   1291   1293   1295   1298     9
+   1294   1293   1295   1296     9
+   1294   1293   1295   1297     9
+   1294   1293   1295   1298     9
+   1300   1293   1295   1296     9
+   1300   1293   1295   1297     9
+   1300   1293   1295   1298     9
+   1291   1293   1300   1301     9
+   1291   1293   1300   1302     9
+   1294   1293   1300   1301     9
+   1294   1293   1300   1302     9
+   1295   1293   1300   1301     9
+   1295   1293   1300   1302     9
+   1293   1295   1298   1299     9
+   1296   1295   1298   1299     9
+   1297   1295   1298   1299     9
+   1293   1300   1302   1303     9
+   1293   1300   1302   1304     9
+   1301   1300   1302   1303     9
+   1301   1300   1302   1304     9
+   1300   1302   1304   1305     9
+   1300   1302   1304   1306     9
+   1300   1302   1304   1312     9
+   1303   1302   1304   1305     9
+   1303   1302   1304   1306     9
+   1303   1302   1304   1312     9
+   1302   1304   1306   1309     9
+   1302   1304   1306   1307     9
+   1302   1304   1306   1308     9
+   1305   1304   1306   1307     9
+   1305   1304   1306   1308     9
+   1305   1304   1306   1309     9
+   1312   1304   1306   1307     9
+   1312   1304   1306   1308     9
+   1312   1304   1306   1309     9
+   1302   1304   1312   1313     9
+   1302   1304   1312   1314     9
+   1305   1304   1312   1313     9
+   1305   1304   1312   1314     9
+   1306   1304   1312   1313     9
+   1306   1304   1312   1314     9
+   1304   1306   1309   1310     9
+   1304   1306   1309   1311     9
+   1307   1306   1309   1310     9
+   1307   1306   1309   1311     9
+   1308   1306   1309   1310     9
+   1308   1306   1309   1311     9
+   1304   1312   1314   1315     9
+   1304   1312   1314   1316     9
+   1313   1312   1314   1315     9
+   1313   1312   1314   1316     9
+   1312   1314   1316   1317     9
+   1312   1314   1316   1318     9
+   1312   1314   1316   1331     9
+   1315   1314   1316   1317     9
+   1315   1314   1316   1318     9
+   1315   1314   1316   1331     9
+   1314   1316   1318   1320     9
+   1314   1316   1318   1319     9
+   1314   1316   1318   1324     9
+   1317   1316   1318   1319     9
+   1317   1316   1318   1320     9
+   1317   1316   1318   1324     9
+   1331   1316   1318   1319     9
+   1331   1316   1318   1320     9
+   1331   1316   1318   1324     9
+   1314   1316   1331   1332     9
+   1314   1316   1331   1333     9
+   1317   1316   1331   1332     9
+   1317   1316   1331   1333     9
+   1318   1316   1331   1332     9
+   1318   1316   1331   1333     9
+   1316   1318   1320   1321     9
+   1316   1318   1320   1322     9
+   1316   1318   1320   1323     9
+   1319   1318   1320   1321     9
+   1319   1318   1320   1322     9
+   1319   1318   1320   1323     9
+   1324   1318   1320   1321     9
+   1324   1318   1320   1322     9
+   1324   1318   1320   1323     9
+   1316   1318   1324   1325     9
+   1316   1318   1324   1326     9
+   1316   1318   1324   1327     9
+   1319   1318   1324   1325     9
+   1319   1318   1324   1326     9
+   1319   1318   1324   1327     9
+   1320   1318   1324   1325     9
+   1320   1318   1324   1326     9
+   1320   1318   1324   1327     9
+   1318   1324   1327   1328     9
+   1318   1324   1327   1329     9
+   1318   1324   1327   1330     9
+   1325   1324   1327   1328     9
+   1325   1324   1327   1329     9
+   1325   1324   1327   1330     9
+   1326   1324   1327   1328     9
+   1326   1324   1327   1329     9
+   1326   1324   1327   1330     9
+   1316   1331   1333   1334     9
+   1316   1331   1333   1335     9
+   1332   1331   1333   1334     9
+   1332   1331   1333   1335     9
+   1331   1333   1335   1336     9
+   1331   1333   1335   1337     9
+   1331   1333   1335   1345     9
+   1334   1333   1335   1336     9
+   1334   1333   1335   1337     9
+   1334   1333   1335   1345     9
+   1333   1335   1337   1338     9
+   1333   1335   1337   1339     9
+   1333   1335   1337   1343     9
+   1336   1335   1337   1338     9
+   1336   1335   1337   1339     9
+   1336   1335   1337   1343     9
+   1345   1335   1337   1338     9
+   1345   1335   1337   1339     9
+   1345   1335   1337   1343     9
+   1333   1335   1345   1346     9
+   1333   1335   1345   1347     9
+   1336   1335   1345   1346     9
+   1336   1335   1345   1347     9
+   1337   1335   1345   1346     9
+   1337   1335   1345   1347     9
+   1335   1337   1339   1340     9
+   1335   1337   1339   1341     9
+   1335   1337   1339   1342     9
+   1338   1337   1339   1340     9
+   1338   1337   1339   1341     9
+   1338   1337   1339   1342     9
+   1343   1337   1339   1340     9
+   1343   1337   1339   1341     9
+   1343   1337   1339   1342     9
+   1335   1337   1343   1344     9
+   1338   1337   1343   1344     9
+   1339   1337   1343   1344     9
+   1335   1345   1347   1348     9
+   1335   1345   1347   1349     9
+   1346   1345   1347   1348     9
+   1346   1345   1347   1349     9
+   1345   1347   1349   1350     9
+   1345   1347   1349   1351     9
+   1345   1347   1349   1355     9
+   1348   1347   1349   1350     9
+   1348   1347   1349   1351     9
+   1348   1347   1349   1355     9
+   1347   1349   1351   1352     9
+   1347   1349   1351   1353     9
+   1347   1349   1351   1354     9
+   1350   1349   1351   1352     9
+   1350   1349   1351   1353     9
+   1350   1349   1351   1354     9
+   1355   1349   1351   1352     9
+   1355   1349   1351   1353     9
+   1355   1349   1351   1354     9
+   1347   1349   1355   1356     9
+   1347   1349   1355   1357     9
+   1350   1349   1355   1356     9
+   1350   1349   1355   1357     9
+   1351   1349   1355   1356     9
+   1351   1349   1355   1357     9
+   1349   1355   1357   1358     9
+   1349   1355   1357   1359     9
+   1356   1355   1357   1358     9
+   1356   1355   1357   1359     9
+   1355   1357   1359   1360     9
+   1355   1357   1359   1361     9
+   1355   1357   1359   1366     9
+   1358   1357   1359   1360     9
+   1358   1357   1359   1361     9
+   1358   1357   1359   1366     9
+   1357   1359   1361   1362     9
+   1357   1359   1361   1363     9
+   1357   1359   1361   1364     9
+   1360   1359   1361   1362     9
+   1360   1359   1361   1363     9
+   1360   1359   1361   1364     9
+   1366   1359   1361   1362     9
+   1366   1359   1361   1363     9
+   1366   1359   1361   1364     9
+   1357   1359   1366   1367     9
+   1357   1359   1366   1368     9
+   1360   1359   1366   1367     9
+   1360   1359   1366   1368     9
+   1361   1359   1366   1367     9
+   1361   1359   1366   1368     9
+   1359   1361   1364   1365     9
+   1362   1361   1364   1365     9
+   1363   1361   1364   1365     9
+   1359   1366   1368   1369     9
+   1359   1366   1368   1370     9
+   1367   1366   1368   1369     9
+   1367   1366   1368   1370     9
+   1366   1368   1370   1371     9
+   1366   1368   1370   1372     9
+   1366   1368   1370   1382     9
+   1369   1368   1370   1371     9
+   1369   1368   1370   1372     9
+   1369   1368   1370   1382     9
+   1368   1370   1372   1373     9
+   1368   1370   1372   1374     9
+   1368   1370   1372   1378     9
+   1371   1370   1372   1373     9
+   1371   1370   1372   1374     9
+   1371   1370   1372   1378     9
+   1382   1370   1372   1373     9
+   1382   1370   1372   1374     9
+   1382   1370   1372   1378     9
+   1368   1370   1382   1383     9
+   1368   1370   1382   1384     9
+   1371   1370   1382   1383     9
+   1371   1370   1382   1384     9
+   1372   1370   1382   1383     9
+   1372   1370   1382   1384     9
+   1370   1372   1374   1375     9
+   1370   1372   1374   1376     9
+   1370   1372   1374   1377     9
+   1373   1372   1374   1375     9
+   1373   1372   1374   1376     9
+   1373   1372   1374   1377     9
+   1378   1372   1374   1375     9
+   1378   1372   1374   1376     9
+   1378   1372   1374   1377     9
+   1370   1372   1378   1379     9
+   1370   1372   1378   1380     9
+   1370   1372   1378   1381     9
+   1373   1372   1378   1379     9
+   1373   1372   1378   1380     9
+   1373   1372   1378   1381     9
+   1374   1372   1378   1379     9
+   1374   1372   1378   1380     9
+   1374   1372   1378   1381     9
+   1370   1382   1384   1385     9
+   1370   1382   1384   1386     9
+   1383   1382   1384   1385     9
+   1383   1382   1384   1386     9
+   1382   1384   1386   1387     9
+   1382   1384   1386   1388     9
+   1382   1384   1386   1396     9
+   1385   1384   1386   1387     9
+   1385   1384   1386   1388     9
+   1385   1384   1386   1396     9
+   1396   1386   1388   1391     9
+   1384   1386   1388   1389     9
+   1384   1386   1388   1390     9
+   1384   1386   1388   1391     9
+   1387   1386   1388   1389     9
+   1387   1386   1388   1390     9
+   1387   1386   1388   1391     9
+   1396   1386   1388   1389     9
+   1396   1386   1388   1390     9
+   1384   1386   1396   1397     9
+   1384   1386   1396   1398     9
+   1387   1386   1396   1397     9
+   1387   1386   1396   1398     9
+   1388   1386   1396   1397     9
+   1388   1386   1396   1398     9
+   1386   1388   1391   1393     9
+   1386   1388   1391   1392     9
+   1389   1388   1391   1392     9
+   1389   1388   1391   1393     9
+   1390   1388   1391   1392     9
+   1390   1388   1391   1393     9
+   1388   1391   1393   1394     9
+   1388   1391   1393   1395     9
+   1392   1391   1393   1394     9
+   1392   1391   1393   1395     9
+   1386   1396   1398   1399     9
+   1386   1396   1398   1400     9
+   1397   1396   1398   1399     9
+   1397   1396   1398   1400     9
+   1396   1398   1400   1401     9
+   1396   1398   1400   1402     9
+   1396   1398   1400   1406     9
+   1399   1398   1400   1401     9
+   1399   1398   1400   1402     9
+   1399   1398   1400   1406     9
+   1398   1400   1402   1403     9
+   1398   1400   1402   1404     9
+   1398   1400   1402   1405     9
+   1401   1400   1402   1403     9
+   1401   1400   1402   1404     9
+   1401   1400   1402   1405     9
+   1406   1400   1402   1403     9
+   1406   1400   1402   1404     9
+   1406   1400   1402   1405     9
+   1398   1400   1406   1407     9
+   1398   1400   1406   1408     9
+   1401   1400   1406   1407     9
+   1401   1400   1406   1408     9
+   1402   1400   1406   1407     9
+   1402   1400   1406   1408     9
+   1400   1402   1405   1161     9
+   1403   1402   1405   1161     9
+   1404   1402   1405   1161     9
+   1400   1406   1408   1409     9
+   1400   1406   1408   1410     9
+   1407   1406   1408   1409     9
+   1407   1406   1408   1410     9
+   1406   1408   1410   1411     9
+   1406   1408   1410   1412     9
+   1406   1408   1410   1416     9
+   1409   1408   1410   1411     9
+   1409   1408   1410   1412     9
+   1409   1408   1410   1416     9
+   1408   1410   1412   1413     9
+   1408   1410   1412   1414     9
+   1408   1410   1412   1415     9
+   1411   1410   1412   1413     9
+   1411   1410   1412   1414     9
+   1411   1410   1412   1415     9
+   1416   1410   1412   1413     9
+   1416   1410   1412   1414     9
+   1416   1410   1412   1415     9
+   1408   1410   1416   1417     9
+   1408   1410   1416   1418     9
+   1411   1410   1416   1417     9
+   1411   1410   1416   1418     9
+   1412   1410   1416   1417     9
+   1412   1410   1416   1418     9
+   1410   1416   1418   1419     9
+   1410   1416   1418   1420     9
+   1417   1416   1418   1419     9
+   1417   1416   1418   1420     9
+   1416   1418   1420   1421     9
+   1416   1418   1420   1422     9
+   1416   1418   1420   1438     9
+   1419   1418   1420   1421     9
+   1419   1418   1420   1422     9
+   1419   1418   1420   1438     9
+   1418   1420   1422   1423     9
+   1418   1420   1422   1424     9
+   1418   1420   1422   1425     9
+   1421   1420   1422   1423     9
+   1421   1420   1422   1424     9
+   1421   1420   1422   1425     9
+   1438   1420   1422   1423     9
+   1438   1420   1422   1424     9
+   1438   1420   1422   1425     9
+   1418   1420   1438   1439     9
+   1418   1420   1438   1440     9
+   1421   1420   1438   1439     9
+   1421   1420   1438   1440     9
+   1422   1420   1438   1439     9
+   1422   1420   1438   1440     9
+   1420   1422   1425   1426     9
+   1420   1422   1425   1427     9
+   1420   1422   1425   1428     9
+   1423   1422   1425   1426     9
+   1423   1422   1425   1427     9
+   1423   1422   1425   1428     9
+   1424   1422   1425   1426     9
+   1424   1422   1425   1427     9
+   1424   1422   1425   1428     9
+   1422   1425   1428   1429     9
+   1422   1425   1428   1430     9
+   1422   1425   1428   1431     9
+   1426   1425   1428   1429     9
+   1426   1425   1428   1430     9
+   1426   1425   1428   1431     9
+   1427   1425   1428   1429     9
+   1427   1425   1428   1430     9
+   1427   1425   1428   1431     9
+   1425   1428   1431   1432     9
+   1425   1428   1431   1433     9
+   1425   1428   1431   1434     9
+   1429   1428   1431   1432     9
+   1429   1428   1431   1433     9
+   1429   1428   1431   1434     9
+   1430   1428   1431   1432     9
+   1430   1428   1431   1433     9
+   1430   1428   1431   1434     9
+   1428   1431   1434   1435     9
+   1428   1431   1434   1436     9
+   1428   1431   1434   1437     9
+   1432   1431   1434   1435     9
+   1432   1431   1434   1436     9
+   1432   1431   1434   1437     9
+   1433   1431   1434   1435     9
+   1433   1431   1434   1436     9
+   1433   1431   1434   1437     9
+   1420   1438   1440   1441     9
+   1420   1438   1440   1442     9
+   1439   1438   1440   1441     9
+   1439   1438   1440   1442     9
+   1438   1440   1442   1443     9
+   1438   1440   1442   1444     9
+   1438   1440   1442   1460     9
+   1441   1440   1442   1443     9
+   1441   1440   1442   1444     9
+   1441   1440   1442   1460     9
+   1440   1442   1444   1445     9
+   1440   1442   1444   1446     9
+   1440   1442   1444   1447     9
+   1443   1442   1444   1445     9
+   1443   1442   1444   1446     9
+   1443   1442   1444   1447     9
+   1460   1442   1444   1445     9
+   1460   1442   1444   1446     9
+   1460   1442   1444   1447     9
+   1440   1442   1460   1461     9
+   1440   1442   1460   1462     9
+   1443   1442   1460   1461     9
+   1443   1442   1460   1462     9
+   1444   1442   1460   1461     9
+   1444   1442   1460   1462     9
+   1442   1444   1447   1448     9
+   1442   1444   1447   1449     9
+   1442   1444   1447   1450     9
+   1445   1444   1447   1448     9
+   1445   1444   1447   1449     9
+   1445   1444   1447   1450     9
+   1446   1444   1447   1448     9
+   1446   1444   1447   1449     9
+   1446   1444   1447   1450     9
+   1444   1447   1450   1451     9
+   1444   1447   1450   1452     9
+   1444   1447   1450   1453     9
+   1448   1447   1450   1451     9
+   1448   1447   1450   1452     9
+   1448   1447   1450   1453     9
+   1449   1447   1450   1451     9
+   1449   1447   1450   1452     9
+   1449   1447   1450   1453     9
+   1447   1450   1453   1454     9
+   1447   1450   1453   1455     9
+   1447   1450   1453   1456     9
+   1451   1450   1453   1454     9
+   1451   1450   1453   1455     9
+   1451   1450   1453   1456     9
+   1452   1450   1453   1454     9
+   1452   1450   1453   1455     9
+   1452   1450   1453   1456     9
+   1450   1453   1456   1457     9
+   1450   1453   1456   1458     9
+   1450   1453   1456   1459     9
+   1454   1453   1456   1457     9
+   1454   1453   1456   1458     9
+   1454   1453   1456   1459     9
+   1455   1453   1456   1457     9
+   1455   1453   1456   1458     9
+   1455   1453   1456   1459     9
+   1442   1460   1462   1463     9
+   1442   1460   1462   1464     9
+   1461   1460   1462   1463     9
+   1461   1460   1462   1464     9
+   1460   1462   1464   1465     9
+   1460   1462   1464   1466     9
+   1460   1462   1464   1479     9
+   1463   1462   1464   1465     9
+   1463   1462   1464   1466     9
+   1463   1462   1464   1479     9
+   1462   1464   1466   1468     9
+   1462   1464   1466   1467     9
+   1462   1464   1466   1472     9
+   1465   1464   1466   1467     9
+   1465   1464   1466   1468     9
+   1465   1464   1466   1472     9
+   1479   1464   1466   1467     9
+   1479   1464   1466   1468     9
+   1479   1464   1466   1472     9
+   1462   1464   1479   1480     9
+   1462   1464   1479   1481     9
+   1465   1464   1479   1480     9
+   1465   1464   1479   1481     9
+   1466   1464   1479   1480     9
+   1466   1464   1479   1481     9
+   1464   1466   1468   1469     9
+   1464   1466   1468   1470     9
+   1464   1466   1468   1471     9
+   1467   1466   1468   1469     9
+   1467   1466   1468   1470     9
+   1467   1466   1468   1471     9
+   1472   1466   1468   1469     9
+   1472   1466   1468   1470     9
+   1472   1466   1468   1471     9
+   1464   1466   1472   1473     9
+   1464   1466   1472   1474     9
+   1464   1466   1472   1475     9
+   1467   1466   1472   1473     9
+   1467   1466   1472   1474     9
+   1467   1466   1472   1475     9
+   1468   1466   1472   1473     9
+   1468   1466   1472   1474     9
+   1468   1466   1472   1475     9
+   1466   1472   1475   1476     9
+   1466   1472   1475   1477     9
+   1466   1472   1475   1478     9
+   1473   1472   1475   1476     9
+   1473   1472   1475   1477     9
+   1473   1472   1475   1478     9
+   1474   1472   1475   1476     9
+   1474   1472   1475   1477     9
+   1474   1472   1475   1478     9
+   1464   1479   1481   1482     9
+   1464   1479   1481   1483     9
+   1480   1479   1481   1482     9
+   1480   1479   1481   1483     9
+   1479   1481   1483   1484     9
+   1479   1481   1483   1485     9
+   1479   1481   1483   1495     9
+   1482   1481   1483   1484     9
+   1482   1481   1483   1485     9
+   1482   1481   1483   1495     9
+   1481   1483   1485   1486     9
+   1481   1483   1485   1487     9
+   1481   1483   1485   1491     9
+   1484   1483   1485   1486     9
+   1484   1483   1485   1487     9
+   1484   1483   1485   1491     9
+   1495   1483   1485   1486     9
+   1495   1483   1485   1487     9
+   1495   1483   1485   1491     9
+   1481   1483   1495   1496     9
+   1481   1483   1495   1497     9
+   1484   1483   1495   1496     9
+   1484   1483   1495   1497     9
+   1485   1483   1495   1496     9
+   1485   1483   1495   1497     9
+   1483   1485   1487   1488     9
+   1483   1485   1487   1489     9
+   1483   1485   1487   1490     9
+   1486   1485   1487   1488     9
+   1486   1485   1487   1489     9
+   1486   1485   1487   1490     9
+   1491   1485   1487   1488     9
+   1491   1485   1487   1489     9
+   1491   1485   1487   1490     9
+   1483   1485   1491   1492     9
+   1483   1485   1491   1493     9
+   1483   1485   1491   1494     9
+   1486   1485   1491   1492     9
+   1486   1485   1491   1493     9
+   1486   1485   1491   1494     9
+   1487   1485   1491   1492     9
+   1487   1485   1491   1493     9
+   1487   1485   1491   1494     9
+   1483   1495   1497   1498     9
+   1483   1495   1497   1499     9
+   1496   1495   1497   1498     9
+   1496   1495   1497   1499     9
+   1495   1497   1499   1500     9
+   1495   1497   1499   1501     9
+   1495   1497   1499   1506     9
+   1498   1497   1499   1500     9
+   1498   1497   1499   1501     9
+   1498   1497   1499   1506     9
+   1497   1499   1501   1502     9
+   1497   1499   1501   1503     9
+   1497   1499   1501   1504     9
+   1500   1499   1501   1502     9
+   1500   1499   1501   1503     9
+   1500   1499   1501   1504     9
+   1506   1499   1501   1502     9
+   1506   1499   1501   1503     9
+   1506   1499   1501   1504     9
+   1497   1499   1506   1507     9
+   1497   1499   1506   1508     9
+   1500   1499   1506   1507     9
+   1500   1499   1506   1508     9
+   1501   1499   1506   1507     9
+   1501   1499   1506   1508     9
+   1499   1501   1504   1505     9
+   1502   1501   1504   1505     9
+   1503   1501   1504   1505     9
+   1499   1506   1508   1509     9
+   1499   1506   1508   1510     9
+   1507   1506   1508   1509     9
+   1507   1506   1508   1510     9
+   1506   1508   1510   1511     9
+   1506   1508   1510   1512     9
+   1506   1508   1510   1518     9
+   1509   1508   1510   1511     9
+   1509   1508   1510   1512     9
+   1509   1508   1510   1518     9
+   1508   1510   1512   1515     9
+   1508   1510   1512   1513     9
+   1508   1510   1512   1514     9
+   1511   1510   1512   1513     9
+   1511   1510   1512   1514     9
+   1511   1510   1512   1515     9
+   1518   1510   1512   1513     9
+   1518   1510   1512   1514     9
+   1518   1510   1512   1515     9
+   1508   1510   1518   1519     9
+   1508   1510   1518   1520     9
+   1511   1510   1518   1519     9
+   1511   1510   1518   1520     9
+   1512   1510   1518   1519     9
+   1512   1510   1518   1520     9
+   1510   1512   1515   1516     9
+   1510   1512   1515   1517     9
+   1513   1512   1515   1516     9
+   1513   1512   1515   1517     9
+   1514   1512   1515   1516     9
+   1514   1512   1515   1517     9
+   1510   1518   1520   1521     9
+   1510   1518   1520   1522     9
+   1519   1518   1520   1521     9
+   1519   1518   1520   1522     9
+   1518   1520   1522   1523     9
+   1518   1520   1522   1524     9
+   1518   1520   1522   1525     9
+   1521   1520   1522   1523     9
+   1521   1520   1522   1524     9
+   1521   1520   1522   1525     9
+   1520   1522   1525   1526     9
+   1520   1522   1525   1527     9
+   1523   1522   1525   1526     9
+   1523   1522   1525   1527     9
+   1524   1522   1525   1526     9
+   1524   1522   1525   1527     9
+   1522   1525   1527   1528     9
+   1522   1525   1527   1529     9
+   1526   1525   1527   1528     9
+   1526   1525   1527   1529     9
+   1525   1527   1529   1530     9
+   1525   1527   1529   1531     9
+   1525   1527   1529   1539     9
+   1528   1527   1529   1530     9
+   1528   1527   1529   1531     9
+   1528   1527   1529   1539     9
+   1539   1529   1531   1534     9
+   1527   1529   1531   1532     9
+   1527   1529   1531   1533     9
+   1527   1529   1531   1534     9
+   1530   1529   1531   1532     9
+   1530   1529   1531   1533     9
+   1530   1529   1531   1534     9
+   1539   1529   1531   1532     9
+   1539   1529   1531   1533     9
+   1527   1529   1539   1540     9
+   1527   1529   1539   1541     9
+   1530   1529   1539   1540     9
+   1530   1529   1539   1541     9
+   1531   1529   1539   1540     9
+   1531   1529   1539   1541     9
+   1529   1531   1534   1536     9
+   1529   1531   1534   1535     9
+   1532   1531   1534   1535     9
+   1532   1531   1534   1536     9
+   1533   1531   1534   1535     9
+   1533   1531   1534   1536     9
+   1531   1534   1536   1537     9
+   1531   1534   1536   1538     9
+   1535   1534   1536   1537     9
+   1535   1534   1536   1538     9
+   1529   1539   1541   1542     9
+   1529   1539   1541   1543     9
+   1540   1539   1541   1542     9
+   1540   1539   1541   1543     9
+   1539   1541   1543   1544     9
+   1539   1541   1543   1545     9
+   1539   1541   1543   1546     9
+   1542   1541   1543   1544     9
+   1542   1541   1543   1545     9
+   1542   1541   1543   1546     9
+   1541   1543   1546   1547     9
+   1541   1543   1546   1548     9
+   1544   1543   1546   1547     9
+   1544   1543   1546   1548     9
+   1545   1543   1546   1547     9
+   1545   1543   1546   1548     9
+   1543   1546   1548   1549     9
+   1543   1546   1548   1550     9
+   1547   1546   1548   1549     9
+   1547   1546   1548   1550     9
+   1546   1548   1550   1551     9
+   1546   1548   1550   1552     9
+   1546   1548   1550   1563     9
+   1549   1548   1550   1551     9
+   1549   1548   1550   1552     9
+   1549   1548   1550   1563     9
+   1548   1550   1552   1553     9
+   1548   1550   1552   1554     9
+   1548   1550   1552   1555     9
+   1551   1550   1552   1553     9
+   1551   1550   1552   1554     9
+   1551   1550   1552   1555     9
+   1563   1550   1552   1553     9
+   1563   1550   1552   1554     9
+   1563   1550   1552   1555     9
+   1548   1550   1563   1564     9
+   1548   1550   1563   1565     9
+   1551   1550   1563   1564     9
+   1551   1550   1563   1565     9
+   1552   1550   1563   1564     9
+   1552   1550   1563   1565     9
+   1550   1552   1555   1556     9
+   1550   1552   1555   1557     9
+   1550   1552   1555   1558     9
+   1553   1552   1555   1556     9
+   1553   1552   1555   1557     9
+   1553   1552   1555   1558     9
+   1554   1552   1555   1556     9
+   1554   1552   1555   1557     9
+   1554   1552   1555   1558     9
+   1552   1555   1558   1559     9
+   1556   1555   1558   1559     9
+   1557   1555   1558   1559     9
+   1555   1558   1559   1560     9
+   1555   1558   1559   1561     9
+   1555   1558   1559   1562     9
+   1550   1563   1565   1566     9
+   1550   1563   1565   1567     9
+   1564   1563   1565   1566     9
+   1564   1563   1565   1567     9
+   1563   1565   1567   1568     9
+   1563   1565   1567   1569     9
+   1563   1565   1567   1577     9
+   1566   1565   1567   1568     9
+   1566   1565   1567   1569     9
+   1566   1565   1567   1577     9
+   1577   1567   1569   1572     9
+   1565   1567   1569   1570     9
+   1565   1567   1569   1571     9
+   1565   1567   1569   1572     9
+   1568   1567   1569   1570     9
+   1568   1567   1569   1571     9
+   1568   1567   1569   1572     9
+   1577   1567   1569   1570     9
+   1577   1567   1569   1571     9
+   1565   1567   1577   1578     9
+   1565   1567   1577   1579     9
+   1568   1567   1577   1578     9
+   1568   1567   1577   1579     9
+   1569   1567   1577   1578     9
+   1569   1567   1577   1579     9
+   1567   1569   1572   1574     9
+   1567   1569   1572   1573     9
+   1570   1569   1572   1573     9
+   1570   1569   1572   1574     9
+   1571   1569   1572   1573     9
+   1571   1569   1572   1574     9
+   1569   1572   1574   1575     9
+   1569   1572   1574   1576     9
+   1573   1572   1574   1575     9
+   1573   1572   1574   1576     9
+   1567   1577   1579   1580     9
+   1567   1577   1579   1581     9
+   1578   1577   1579   1580     9
+   1578   1577   1579   1581     9
+   1577   1579   1581   1582     9
+   1577   1579   1581   1583     9
+   1577   1579   1581   1587     9
+   1580   1579   1581   1582     9
+   1580   1579   1581   1583     9
+   1580   1579   1581   1587     9
+   1579   1581   1583   1584     9
+   1579   1581   1583   1585     9
+   1579   1581   1583   1586     9
+   1582   1581   1583   1584     9
+   1582   1581   1583   1585     9
+   1582   1581   1583   1586     9
+   1587   1581   1583   1584     9
+   1587   1581   1583   1585     9
+   1587   1581   1583   1586     9
+   1579   1581   1587   1588     9
+   1579   1581   1587   1589     9
+   1582   1581   1587   1588     9
+   1582   1581   1587   1589     9
+   1583   1581   1587   1588     9
+   1583   1581   1587   1589     9
+   1581   1587   1589   1590     9
+   1581   1587   1589   1591     9
+   1588   1587   1589   1590     9
+   1588   1587   1589   1591     9
+   1587   1589   1591   1592     9
+   1587   1589   1591   1593     9
+   1587   1589   1591   1611     9
+   1590   1589   1591   1592     9
+   1590   1589   1591   1593     9
+   1590   1589   1591   1611     9
+   1589   1591   1593   1594     9
+   1589   1591   1593   1595     9
+   1589   1591   1593   1596     9
+   1592   1591   1593   1594     9
+   1592   1591   1593   1595     9
+   1592   1591   1593   1596     9
+   1611   1591   1593   1594     9
+   1611   1591   1593   1595     9
+   1611   1591   1593   1596     9
+   1589   1591   1611   1612     9
+   1589   1591   1611   1613     9
+   1592   1591   1611   1612     9
+   1592   1591   1611   1613     9
+   1593   1591   1611   1612     9
+   1593   1591   1611   1613     9
+   1591   1593   1596   1597     9
+   1591   1593   1596   1610     9
+   1594   1593   1596   1597     9
+   1594   1593   1596   1610     9
+   1595   1593   1596   1597     9
+   1595   1593   1596   1610     9
+   1593   1596   1597   1598     9
+   1593   1596   1597   1599     9
+   1610   1596   1597   1598     9
+   1610   1596   1597   1599     9
+   1593   1596   1610   1601     9
+   1593   1596   1610   1608     9
+   1597   1596   1610   1601     9
+   1597   1596   1610   1608     9
+   1596   1597   1599   1600     9
+   1596   1597   1599   1601     9
+   1598   1597   1599   1600     9
+   1598   1597   1599   1601     9
+   1597   1599   1601   1602     9
+   1597   1599   1601   1610     9
+   1600   1599   1601   1602     9
+   1600   1599   1601   1610     9
+   1599   1601   1602   1603     9
+   1599   1601   1602   1604     9
+   1610   1601   1602   1603     9
+   1610   1601   1602   1604     9
+   1599   1601   1610   1596     9
+   1599   1601   1610   1608     9
+   1602   1601   1610   1596     9
+   1602   1601   1610   1608     9
+   1601   1602   1604   1605     9
+   1601   1602   1604   1606     9
+   1603   1602   1604   1605     9
+   1603   1602   1604   1606     9
+   1602   1604   1606   1607     9
+   1602   1604   1606   1608     9
+   1605   1604   1606   1607     9
+   1605   1604   1606   1608     9
+   1604   1606   1608   1609     9
+   1604   1606   1608   1610     9
+   1607   1606   1608   1609     9
+   1607   1606   1608   1610     9
+   1606   1608   1610   1596     9
+   1606   1608   1610   1601     9
+   1609   1608   1610   1596     9
+   1609   1608   1610   1601     9
+   1591   1611   1613   1614     9
+   1591   1611   1613   1615     9
+   1612   1611   1613   1614     9
+   1612   1611   1613   1615     9
+   1611   1613   1615   1616     9
+   1611   1613   1615   1617     9
+   1611   1613   1615   1627     9
+   1614   1613   1615   1616     9
+   1614   1613   1615   1617     9
+   1614   1613   1615   1627     9
+   1613   1615   1617   1618     9
+   1613   1615   1617   1619     9
+   1613   1615   1617   1623     9
+   1616   1615   1617   1618     9
+   1616   1615   1617   1619     9
+   1616   1615   1617   1623     9
+   1627   1615   1617   1618     9
+   1627   1615   1617   1619     9
+   1627   1615   1617   1623     9
+   1613   1615   1627   1628     9
+   1613   1615   1627   1629     9
+   1616   1615   1627   1628     9
+   1616   1615   1627   1629     9
+   1617   1615   1627   1628     9
+   1617   1615   1627   1629     9
+   1615   1617   1619   1620     9
+   1615   1617   1619   1621     9
+   1615   1617   1619   1622     9
+   1618   1617   1619   1620     9
+   1618   1617   1619   1621     9
+   1618   1617   1619   1622     9
+   1623   1617   1619   1620     9
+   1623   1617   1619   1621     9
+   1623   1617   1619   1622     9
+   1615   1617   1623   1624     9
+   1615   1617   1623   1625     9
+   1615   1617   1623   1626     9
+   1618   1617   1623   1624     9
+   1618   1617   1623   1625     9
+   1618   1617   1623   1626     9
+   1619   1617   1623   1624     9
+   1619   1617   1623   1625     9
+   1619   1617   1623   1626     9
+   1615   1627   1629   1630     9
+   1615   1627   1629   1631     9
+   1628   1627   1629   1630     9
+   1628   1627   1629   1631     9
+   1627   1629   1631   1632     9
+   1627   1629   1631   1633     9
+   1627   1629   1631   1637     9
+   1630   1629   1631   1632     9
+   1630   1629   1631   1633     9
+   1630   1629   1631   1637     9
+   1629   1631   1633   1634     9
+   1629   1631   1633   1635     9
+   1629   1631   1633   1636     9
+   1632   1631   1633   1634     9
+   1632   1631   1633   1635     9
+   1632   1631   1633   1636     9
+   1637   1631   1633   1634     9
+   1637   1631   1633   1635     9
+   1637   1631   1633   1636     9
+   1629   1631   1637   1638     9
+   1629   1631   1637   1639     9
+   1632   1631   1637   1638     9
+   1632   1631   1637   1639     9
+   1633   1631   1637   1638     9
+   1633   1631   1637   1639     9
+   1631   1637   1639   1640     9
+   1631   1637   1639   1641     9
+   1638   1637   1639   1640     9
+   1638   1637   1639   1641     9
+   1637   1639   1641   1642     9
+   1637   1639   1641   1643     9
+   1637   1639   1641   1661     9
+   1640   1639   1641   1642     9
+   1640   1639   1641   1643     9
+   1640   1639   1641   1661     9
+   1639   1641   1643   1644     9
+   1639   1641   1643   1645     9
+   1639   1641   1643   1646     9
+   1642   1641   1643   1644     9
+   1642   1641   1643   1645     9
+   1642   1641   1643   1646     9
+   1661   1641   1643   1644     9
+   1661   1641   1643   1645     9
+   1661   1641   1643   1646     9
+   1639   1641   1661   1662     9
+   1639   1641   1661   1663     9
+   1642   1641   1661   1662     9
+   1642   1641   1661   1663     9
+   1643   1641   1661   1662     9
+   1643   1641   1661   1663     9
+   1641   1643   1646   1647     9
+   1641   1643   1646   1660     9
+   1644   1643   1646   1647     9
+   1644   1643   1646   1660     9
+   1645   1643   1646   1647     9
+   1645   1643   1646   1660     9
+   1643   1646   1647   1648     9
+   1643   1646   1647   1649     9
+   1660   1646   1647   1648     9
+   1660   1646   1647   1649     9
+   1643   1646   1660   1651     9
+   1643   1646   1660   1658     9
+   1647   1646   1660   1651     9
+   1647   1646   1660   1658     9
+   1646   1647   1649   1650     9
+   1646   1647   1649   1651     9
+   1648   1647   1649   1650     9
+   1648   1647   1649   1651     9
+   1647   1649   1651   1652     9
+   1647   1649   1651   1660     9
+   1650   1649   1651   1652     9
+   1650   1649   1651   1660     9
+   1649   1651   1652   1653     9
+   1649   1651   1652   1654     9
+   1660   1651   1652   1653     9
+   1660   1651   1652   1654     9
+   1649   1651   1660   1646     9
+   1649   1651   1660   1658     9
+   1652   1651   1660   1646     9
+   1652   1651   1660   1658     9
+   1651   1652   1654   1655     9
+   1651   1652   1654   1656     9
+   1653   1652   1654   1655     9
+   1653   1652   1654   1656     9
+   1652   1654   1656   1657     9
+   1652   1654   1656   1658     9
+   1655   1654   1656   1657     9
+   1655   1654   1656   1658     9
+   1654   1656   1658   1659     9
+   1654   1656   1658   1660     9
+   1657   1656   1658   1659     9
+   1657   1656   1658   1660     9
+   1656   1658   1660   1646     9
+   1656   1658   1660   1651     9
+   1659   1658   1660   1646     9
+   1659   1658   1660   1651     9
+   1641   1661   1663   1664     9
+   1641   1661   1663   1665     9
+   1662   1661   1663   1664     9
+   1662   1661   1663   1665     9
+   1661   1663   1665   1666     9
+   1661   1663   1665   1667     9
+   1661   1663   1665   1685     9
+   1664   1663   1665   1666     9
+   1664   1663   1665   1667     9
+   1664   1663   1665   1685     9
+   1663   1665   1667   1668     9
+   1663   1665   1667   1669     9
+   1663   1665   1667   1670     9
+   1666   1665   1667   1668     9
+   1666   1665   1667   1669     9
+   1666   1665   1667   1670     9
+   1685   1665   1667   1668     9
+   1685   1665   1667   1669     9
+   1685   1665   1667   1670     9
+   1663   1665   1685   1686     9
+   1663   1665   1685   1687     9
+   1666   1665   1685   1686     9
+   1666   1665   1685   1687     9
+   1667   1665   1685   1686     9
+   1667   1665   1685   1687     9
+   1665   1667   1670   1671     9
+   1665   1667   1670   1672     9
+   1665   1667   1670   1673     9
+   1668   1667   1670   1671     9
+   1668   1667   1670   1672     9
+   1668   1667   1670   1673     9
+   1669   1667   1670   1671     9
+   1669   1667   1670   1672     9
+   1669   1667   1670   1673     9
+   1667   1670   1673   1674     9
+   1667   1670   1673   1675     9
+   1667   1670   1673   1676     9
+   1671   1670   1673   1674     9
+   1671   1670   1673   1675     9
+   1671   1670   1673   1676     9
+   1672   1670   1673   1674     9
+   1672   1670   1673   1675     9
+   1672   1670   1673   1676     9
+   1670   1673   1676   1677     9
+   1670   1673   1676   1678     9
+   1674   1673   1676   1677     9
+   1674   1673   1676   1678     9
+   1675   1673   1676   1677     9
+   1675   1673   1676   1678     9
+   1673   1676   1678   1679     9
+   1673   1676   1678   1682     9
+   1677   1676   1678   1679     9
+   1677   1676   1678   1682     9
+   1676   1678   1679   1680     9
+   1676   1678   1679   1681     9
+   1682   1678   1679   1680     9
+   1682   1678   1679   1681     9
+   1676   1678   1682   1683     9
+   1676   1678   1682   1684     9
+   1679   1678   1682   1683     9
+   1679   1678   1682   1684     9
+   1665   1685   1687   1688     9
+   1665   1685   1687   1689     9
+   1686   1685   1687   1688     9
+   1686   1685   1687   1689     9
+   1685   1687   1689   1690     9
+   1685   1687   1689   1691     9
+   1685   1687   1689   1699     9
+   1688   1687   1689   1690     9
+   1688   1687   1689   1691     9
+   1688   1687   1689   1699     9
+   1699   1689   1691   1694     9
+   1687   1689   1691   1692     9
+   1687   1689   1691   1693     9
+   1687   1689   1691   1694     9
+   1690   1689   1691   1692     9
+   1690   1689   1691   1693     9
+   1690   1689   1691   1694     9
+   1699   1689   1691   1692     9
+   1699   1689   1691   1693     9
+   1687   1689   1699   1700     9
+   1687   1689   1699   1701     9
+   1690   1689   1699   1700     9
+   1690   1689   1699   1701     9
+   1691   1689   1699   1700     9
+   1691   1689   1699   1701     9
+   1689   1691   1694   1696     9
+   1689   1691   1694   1695     9
+   1692   1691   1694   1695     9
+   1692   1691   1694   1696     9
+   1693   1691   1694   1695     9
+   1693   1691   1694   1696     9
+   1691   1694   1696   1697     9
+   1691   1694   1696   1698     9
+   1695   1694   1696   1697     9
+   1695   1694   1696   1698     9
+   1689   1699   1701   1702     9
+   1689   1699   1701   1703     9
+   1700   1699   1701   1702     9
+   1700   1699   1701   1703     9
+   1699   1701   1703   1704     9
+   1699   1701   1703   1705     9
+   1699   1701   1703   1723     9
+   1702   1701   1703   1704     9
+   1702   1701   1703   1705     9
+   1702   1701   1703   1723     9
+   1701   1703   1705   1706     9
+   1701   1703   1705   1707     9
+   1701   1703   1705   1708     9
+   1704   1703   1705   1706     9
+   1704   1703   1705   1707     9
+   1704   1703   1705   1708     9
+   1723   1703   1705   1706     9
+   1723   1703   1705   1707     9
+   1723   1703   1705   1708     9
+   1701   1703   1723   1724     9
+   1701   1703   1723   1725     9
+   1704   1703   1723   1724     9
+   1704   1703   1723   1725     9
+   1705   1703   1723   1724     9
+   1705   1703   1723   1725     9
+   1703   1705   1708   1709     9
+   1703   1705   1708   1710     9
+   1703   1705   1708   1711     9
+   1706   1705   1708   1709     9
+   1706   1705   1708   1710     9
+   1706   1705   1708   1711     9
+   1707   1705   1708   1709     9
+   1707   1705   1708   1710     9
+   1707   1705   1708   1711     9
+   1705   1708   1711   1712     9
+   1705   1708   1711   1713     9
+   1705   1708   1711   1714     9
+   1709   1708   1711   1712     9
+   1709   1708   1711   1713     9
+   1709   1708   1711   1714     9
+   1710   1708   1711   1712     9
+   1710   1708   1711   1713     9
+   1710   1708   1711   1714     9
+   1708   1711   1714   1715     9
+   1708   1711   1714   1716     9
+   1712   1711   1714   1715     9
+   1712   1711   1714   1716     9
+   1713   1711   1714   1715     9
+   1713   1711   1714   1716     9
+   1711   1714   1716   1717     9
+   1711   1714   1716   1720     9
+   1715   1714   1716   1717     9
+   1715   1714   1716   1720     9
+   1714   1716   1717   1718     9
+   1714   1716   1717   1719     9
+   1720   1716   1717   1718     9
+   1720   1716   1717   1719     9
+   1714   1716   1720   1721     9
+   1714   1716   1720   1722     9
+   1717   1716   1720   1721     9
+   1717   1716   1720   1722     9
+   1703   1723   1725   1726     9
+   1703   1723   1725   1727     9
+   1724   1723   1725   1726     9
+   1724   1723   1725   1727     9
+   1723   1725   1727   1728     9
+   1723   1725   1727   1729     9
+   1723   1725   1727   1733     9
+   1726   1725   1727   1728     9
+   1726   1725   1727   1729     9
+   1726   1725   1727   1733     9
+   1725   1727   1729   1730     9
+   1725   1727   1729   1731     9
+   1725   1727   1729   1732     9
+   1728   1727   1729   1730     9
+   1728   1727   1729   1731     9
+   1728   1727   1729   1732     9
+   1733   1727   1729   1730     9
+   1733   1727   1729   1731     9
+   1733   1727   1729   1732     9
+   1725   1727   1733   1734     9
+   1725   1727   1733   1735     9
+   1728   1727   1733   1734     9
+   1728   1727   1733   1735     9
+   1729   1727   1733   1734     9
+   1729   1727   1733   1735     9
+   1727   1729   1732    469     9
+   1730   1729   1732    469     9
+   1731   1729   1732    469     9
+   1727   1733   1735   1736     9
+   1727   1733   1735   1737     9
+   1734   1733   1735   1736     9
+   1734   1733   1735   1737     9
+   1733   1735   1737   1738     9
+   1733   1735   1737   1739     9
+   1733   1735   1737   1755     9
+   1736   1735   1737   1738     9
+   1736   1735   1737   1739     9
+   1736   1735   1737   1755     9
+   1735   1737   1739   1740     9
+   1735   1737   1739   1741     9
+   1735   1737   1739   1742     9
+   1738   1737   1739   1740     9
+   1738   1737   1739   1741     9
+   1738   1737   1739   1742     9
+   1755   1737   1739   1740     9
+   1755   1737   1739   1741     9
+   1755   1737   1739   1742     9
+   1735   1737   1755   1756     9
+   1735   1737   1755   1757     9
+   1738   1737   1755   1756     9
+   1738   1737   1755   1757     9
+   1739   1737   1755   1756     9
+   1739   1737   1755   1757     9
+   1737   1739   1742   1743     9
+   1737   1739   1742   1744     9
+   1737   1739   1742   1745     9
+   1740   1739   1742   1743     9
+   1740   1739   1742   1744     9
+   1740   1739   1742   1745     9
+   1741   1739   1742   1743     9
+   1741   1739   1742   1744     9
+   1741   1739   1742   1745     9
+   1739   1742   1745   1746     9
+   1739   1742   1745   1747     9
+   1739   1742   1745   1748     9
+   1743   1742   1745   1746     9
+   1743   1742   1745   1747     9
+   1743   1742   1745   1748     9
+   1744   1742   1745   1746     9
+   1744   1742   1745   1747     9
+   1744   1742   1745   1748     9
+   1742   1745   1748   1749     9
+   1742   1745   1748   1750     9
+   1742   1745   1748   1751     9
+   1746   1745   1748   1749     9
+   1746   1745   1748   1750     9
+   1746   1745   1748   1751     9
+   1747   1745   1748   1749     9
+   1747   1745   1748   1750     9
+   1747   1745   1748   1751     9
+   1745   1748   1751   1752     9
+   1745   1748   1751   1753     9
+   1745   1748   1751   1754     9
+   1749   1748   1751   1752     9
+   1749   1748   1751   1753     9
+   1749   1748   1751   1754     9
+   1750   1748   1751   1752     9
+   1750   1748   1751   1753     9
+   1750   1748   1751   1754     9
+   1737   1755   1757   1758     9
+   1737   1755   1757   1759     9
+   1756   1755   1757   1758     9
+   1756   1755   1757   1759     9
+   1755   1757   1759   1760     9
+   1755   1757   1759   1761     9
+   1755   1757   1759   1762     9
+   1758   1757   1759   1760     9
+   1758   1757   1759   1761     9
+   1758   1757   1759   1762     9
+   1757   1759   1762   1763     9
+   1757   1759   1762   1764     9
+   1760   1759   1762   1763     9
+   1760   1759   1762   1764     9
+   1761   1759   1762   1763     9
+   1761   1759   1762   1764     9
+   1759   1762   1764   1765     9
+   1759   1762   1764   1766     9
+   1763   1762   1764   1765     9
+   1763   1762   1764   1766     9
+   1762   1764   1766   1767     9
+   1762   1764   1766   1768     9
+   1762   1764   1766   1776     9
+   1765   1764   1766   1767     9
+   1765   1764   1766   1768     9
+   1765   1764   1766   1776     9
+   1764   1766   1768   1769     9
+   1764   1766   1768   1770     9
+   1764   1766   1768   1774     9
+   1767   1766   1768   1769     9
+   1767   1766   1768   1770     9
+   1767   1766   1768   1774     9
+   1776   1766   1768   1769     9
+   1776   1766   1768   1770     9
+   1776   1766   1768   1774     9
+   1764   1766   1776   1777     9
+   1764   1766   1776   1778     9
+   1767   1766   1776   1777     9
+   1767   1766   1776   1778     9
+   1768   1766   1776   1777     9
+   1768   1766   1776   1778     9
+   1766   1768   1770   1771     9
+   1766   1768   1770   1772     9
+   1766   1768   1770   1773     9
+   1769   1768   1770   1771     9
+   1769   1768   1770   1772     9
+   1769   1768   1770   1773     9
+   1774   1768   1770   1771     9
+   1774   1768   1770   1772     9
+   1774   1768   1770   1773     9
+   1766   1768   1774   1775     9
+   1769   1768   1774   1775     9
+   1770   1768   1774   1775     9
+   1766   1776   1778   1779     9
+   1766   1776   1778   1780     9
+   1777   1776   1778   1779     9
+   1777   1776   1778   1780     9
+   1776   1778   1780   1781     9
+   1776   1778   1780   1782     9
+   1776   1778   1780   1788     9
+   1779   1778   1780   1781     9
+   1779   1778   1780   1782     9
+   1779   1778   1780   1788     9
+   1778   1780   1782   1785     9
+   1778   1780   1782   1783     9
+   1778   1780   1782   1784     9
+   1781   1780   1782   1783     9
+   1781   1780   1782   1784     9
+   1781   1780   1782   1785     9
+   1788   1780   1782   1783     9
+   1788   1780   1782   1784     9
+   1788   1780   1782   1785     9
+   1778   1780   1788   1789     9
+   1778   1780   1788   1790     9
+   1781   1780   1788   1789     9
+   1781   1780   1788   1790     9
+   1782   1780   1788   1789     9
+   1782   1780   1788   1790     9
+   1780   1782   1785   1786     9
+   1780   1782   1785   1787     9
+   1783   1782   1785   1786     9
+   1783   1782   1785   1787     9
+   1784   1782   1785   1786     9
+   1784   1782   1785   1787     9
+   1780   1788   1790   1791     9
+   1780   1788   1790   1792     9
+   1789   1788   1790   1791     9
+   1789   1788   1790   1792     9
+   1788   1790   1792   1793     9
+   1788   1790   1792   1794     9
+   1788   1790   1792   1804     9
+   1791   1790   1792   1793     9
+   1791   1790   1792   1794     9
+   1791   1790   1792   1804     9
+   1790   1792   1794   1795     9
+   1790   1792   1794   1796     9
+   1790   1792   1794   1800     9
+   1793   1792   1794   1795     9
+   1793   1792   1794   1796     9
+   1793   1792   1794   1800     9
+   1804   1792   1794   1795     9
+   1804   1792   1794   1796     9
+   1804   1792   1794   1800     9
+   1790   1792   1804   1805     9
+   1790   1792   1804   1806     9
+   1793   1792   1804   1805     9
+   1793   1792   1804   1806     9
+   1794   1792   1804   1805     9
+   1794   1792   1804   1806     9
+   1792   1794   1796   1797     9
+   1792   1794   1796   1798     9
+   1792   1794   1796   1799     9
+   1795   1794   1796   1797     9
+   1795   1794   1796   1798     9
+   1795   1794   1796   1799     9
+   1800   1794   1796   1797     9
+   1800   1794   1796   1798     9
+   1800   1794   1796   1799     9
+   1792   1794   1800   1801     9
+   1792   1794   1800   1802     9
+   1792   1794   1800   1803     9
+   1795   1794   1800   1801     9
+   1795   1794   1800   1802     9
+   1795   1794   1800   1803     9
+   1796   1794   1800   1801     9
+   1796   1794   1800   1802     9
+   1796   1794   1800   1803     9
+   1792   1804   1806   1807     9
+   1792   1804   1806   1808     9
+   1805   1804   1806   1807     9
+   1805   1804   1806   1808     9
+   1804   1806   1808   1809     9
+   1804   1806   1808   1810     9
+   1804   1806   1808   1821     9
+   1807   1806   1808   1809     9
+   1807   1806   1808   1810     9
+   1807   1806   1808   1821     9
+   1806   1808   1810   1811     9
+   1806   1808   1810   1812     9
+   1806   1808   1810   1813     9
+   1809   1808   1810   1811     9
+   1809   1808   1810   1812     9
+   1809   1808   1810   1813     9
+   1821   1808   1810   1811     9
+   1821   1808   1810   1812     9
+   1821   1808   1810   1813     9
+   1806   1808   1821   1822     9
+   1806   1808   1821   1823     9
+   1809   1808   1821   1822     9
+   1809   1808   1821   1823     9
+   1810   1808   1821   1822     9
+   1810   1808   1821   1823     9
+   1808   1810   1813   1814     9
+   1808   1810   1813   1815     9
+   1808   1810   1813   1816     9
+   1811   1810   1813   1814     9
+   1811   1810   1813   1815     9
+   1811   1810   1813   1816     9
+   1812   1810   1813   1814     9
+   1812   1810   1813   1815     9
+   1812   1810   1813   1816     9
+   1810   1813   1816   1817     9
+   1810   1813   1816   1818     9
+   1814   1813   1816   1817     9
+   1814   1813   1816   1818     9
+   1815   1813   1816   1817     9
+   1815   1813   1816   1818     9
+   1813   1816   1818   1819     9
+   1813   1816   1818   1820     9
+   1817   1816   1818   1819     9
+   1817   1816   1818   1820     9
+   1808   1821   1823   1824     9
+   1808   1821   1823   1825     9
+   1822   1821   1823   1824     9
+   1822   1821   1823   1825     9
+   1821   1823   1825   1826     9
+   1821   1823   1825   1827     9
+   1821   1823   1825   1831     9
+   1824   1823   1825   1826     9
+   1824   1823   1825   1827     9
+   1824   1823   1825   1831     9
+   1823   1825   1827   1828     9
+   1823   1825   1827   1829     9
+   1823   1825   1827   1830     9
+   1826   1825   1827   1828     9
+   1826   1825   1827   1829     9
+   1826   1825   1827   1830     9
+   1831   1825   1827   1828     9
+   1831   1825   1827   1829     9
+   1831   1825   1827   1830     9
+   1823   1825   1831   1832     9
+   1823   1825   1831   1833     9
+   1826   1825   1831   1832     9
+   1826   1825   1831   1833     9
+   1827   1825   1831   1832     9
+   1827   1825   1831   1833     9
+   1825   1831   1833   1834     9
+   1825   1831   1833   1835     9
+   1832   1831   1833   1834     9
+   1832   1831   1833   1835     9
+   1831   1833   1835   1836     9
+   1831   1833   1835   1837     9
+   1831   1833   1835   1855     9
+   1834   1833   1835   1836     9
+   1834   1833   1835   1837     9
+   1834   1833   1835   1855     9
+   1833   1835   1837   1838     9
+   1833   1835   1837   1839     9
+   1833   1835   1837   1840     9
+   1836   1835   1837   1838     9
+   1836   1835   1837   1839     9
+   1836   1835   1837   1840     9
+   1855   1835   1837   1838     9
+   1855   1835   1837   1839     9
+   1855   1835   1837   1840     9
+   1833   1835   1855   1856     9
+   1833   1835   1855   1857     9
+   1836   1835   1855   1856     9
+   1836   1835   1855   1857     9
+   1837   1835   1855   1856     9
+   1837   1835   1855   1857     9
+   1835   1837   1840   1841     9
+   1835   1837   1840   1854     9
+   1838   1837   1840   1841     9
+   1838   1837   1840   1854     9
+   1839   1837   1840   1841     9
+   1839   1837   1840   1854     9
+   1837   1840   1841   1842     9
+   1837   1840   1841   1843     9
+   1854   1840   1841   1842     9
+   1854   1840   1841   1843     9
+   1837   1840   1854   1845     9
+   1837   1840   1854   1852     9
+   1841   1840   1854   1845     9
+   1841   1840   1854   1852     9
+   1840   1841   1843   1844     9
+   1840   1841   1843   1845     9
+   1842   1841   1843   1844     9
+   1842   1841   1843   1845     9
+   1841   1843   1845   1846     9
+   1841   1843   1845   1854     9
+   1844   1843   1845   1846     9
+   1844   1843   1845   1854     9
+   1843   1845   1846   1847     9
+   1843   1845   1846   1848     9
+   1854   1845   1846   1847     9
+   1854   1845   1846   1848     9
+   1843   1845   1854   1840     9
+   1843   1845   1854   1852     9
+   1846   1845   1854   1840     9
+   1846   1845   1854   1852     9
+   1845   1846   1848   1849     9
+   1845   1846   1848   1850     9
+   1847   1846   1848   1849     9
+   1847   1846   1848   1850     9
+   1846   1848   1850   1851     9
+   1846   1848   1850   1852     9
+   1849   1848   1850   1851     9
+   1849   1848   1850   1852     9
+   1848   1850   1852   1853     9
+   1848   1850   1852   1854     9
+   1851   1850   1852   1853     9
+   1851   1850   1852   1854     9
+   1850   1852   1854   1840     9
+   1850   1852   1854   1845     9
+   1853   1852   1854   1840     9
+   1853   1852   1854   1845     9
+   1835   1855   1857   1858     9
+   1835   1855   1857   1859     9
+   1856   1855   1857   1858     9
+   1856   1855   1857   1859     9
+   1855   1857   1859   1860     9
+   1855   1857   1859   1861     9
+   1855   1857   1859   1874     9
+   1858   1857   1859   1860     9
+   1858   1857   1859   1861     9
+   1858   1857   1859   1874     9
+   1857   1859   1861   1863     9
+   1857   1859   1861   1862     9
+   1857   1859   1861   1867     9
+   1860   1859   1861   1862     9
+   1860   1859   1861   1863     9
+   1860   1859   1861   1867     9
+   1874   1859   1861   1862     9
+   1874   1859   1861   1863     9
+   1874   1859   1861   1867     9
+   1857   1859   1874   1875     9
+   1857   1859   1874   1876     9
+   1860   1859   1874   1875     9
+   1860   1859   1874   1876     9
+   1861   1859   1874   1875     9
+   1861   1859   1874   1876     9
+   1859   1861   1863   1864     9
+   1859   1861   1863   1865     9
+   1859   1861   1863   1866     9
+   1862   1861   1863   1864     9
+   1862   1861   1863   1865     9
+   1862   1861   1863   1866     9
+   1867   1861   1863   1864     9
+   1867   1861   1863   1865     9
+   1867   1861   1863   1866     9
+   1859   1861   1867   1868     9
+   1859   1861   1867   1869     9
+   1859   1861   1867   1870     9
+   1862   1861   1867   1868     9
+   1862   1861   1867   1869     9
+   1862   1861   1867   1870     9
+   1863   1861   1867   1868     9
+   1863   1861   1867   1869     9
+   1863   1861   1867   1870     9
+   1861   1867   1870   1871     9
+   1861   1867   1870   1872     9
+   1861   1867   1870   1873     9
+   1868   1867   1870   1871     9
+   1868   1867   1870   1872     9
+   1868   1867   1870   1873     9
+   1869   1867   1870   1871     9
+   1869   1867   1870   1872     9
+   1869   1867   1870   1873     9
+   1859   1874   1876   1877     9
+   1859   1874   1876   1878     9
+   1875   1874   1876   1877     9
+   1875   1874   1876   1878     9
+   1874   1876   1878   1879     9
+   1874   1876   1878   1880     9
+   1874   1876   1878   1898     9
+   1877   1876   1878   1879     9
+   1877   1876   1878   1880     9
+   1877   1876   1878   1898     9
+   1876   1878   1880   1881     9
+   1876   1878   1880   1882     9
+   1876   1878   1880   1883     9
+   1879   1878   1880   1881     9
+   1879   1878   1880   1882     9
+   1879   1878   1880   1883     9
+   1898   1878   1880   1881     9
+   1898   1878   1880   1882     9
+   1898   1878   1880   1883     9
+   1876   1878   1898   1899     9
+   1876   1878   1898   1900     9
+   1879   1878   1898   1899     9
+   1879   1878   1898   1900     9
+   1880   1878   1898   1899     9
+   1880   1878   1898   1900     9
+   1878   1880   1883   1884     9
+   1878   1880   1883   1885     9
+   1878   1880   1883   1886     9
+   1881   1880   1883   1884     9
+   1881   1880   1883   1885     9
+   1881   1880   1883   1886     9
+   1882   1880   1883   1884     9
+   1882   1880   1883   1885     9
+   1882   1880   1883   1886     9
+   1880   1883   1886   1887     9
+   1880   1883   1886   1888     9
+   1880   1883   1886   1889     9
+   1884   1883   1886   1887     9
+   1884   1883   1886   1888     9
+   1884   1883   1886   1889     9
+   1885   1883   1886   1887     9
+   1885   1883   1886   1888     9
+   1885   1883   1886   1889     9
+   1883   1886   1889   1890     9
+   1883   1886   1889   1891     9
+   1887   1886   1889   1890     9
+   1887   1886   1889   1891     9
+   1888   1886   1889   1890     9
+   1888   1886   1889   1891     9
+   1886   1889   1891   1892     9
+   1886   1889   1891   1895     9
+   1890   1889   1891   1892     9
+   1890   1889   1891   1895     9
+   1889   1891   1892   1893     9
+   1889   1891   1892   1894     9
+   1895   1891   1892   1893     9
+   1895   1891   1892   1894     9
+   1889   1891   1895   1896     9
+   1889   1891   1895   1897     9
+   1892   1891   1895   1896     9
+   1892   1891   1895   1897     9
+   1878   1898   1900   1901     9
+   1878   1898   1900   1902     9
+   1899   1898   1900   1901     9
+   1899   1898   1900   1902     9
+   1898   1900   1902   1903     9
+   1898   1900   1902   1904     9
+   1898   1900   1902   1905     9
+   1901   1900   1902   1903     9
+   1901   1900   1902   1904     9
+   1901   1900   1902   1905     9
+   1900   1902   1905   1906     9
+   1900   1902   1905   1907     9
+   1903   1902   1905   1906     9
+   1903   1902   1905   1907     9
+   1904   1902   1905   1906     9
+   1904   1902   1905   1907     9
+   1902   1905   1907   1908     9
+   1902   1905   1907   1909     9
+   1906   1905   1907   1908     9
+   1906   1905   1907   1909     9
+   1905   1907   1909   1910     9
+   1905   1907   1909   1911     9
+   1905   1907   1909   1915     9
+   1908   1907   1909   1910     9
+   1908   1907   1909   1911     9
+   1908   1907   1909   1915     9
+   1907   1909   1911   1912     9
+   1907   1909   1911   1913     9
+   1907   1909   1911   1914     9
+   1910   1909   1911   1912     9
+   1910   1909   1911   1913     9
+   1910   1909   1911   1914     9
+   1915   1909   1911   1912     9
+   1915   1909   1911   1913     9
+   1915   1909   1911   1914     9
+   1907   1909   1915   1916     9
+   1907   1909   1915   1917     9
+   1910   1909   1915   1916     9
+   1910   1909   1915   1917     9
+   1911   1909   1915   1916     9
+   1911   1909   1915   1917     9
+   1909   1911   1914     99     9
+   1912   1911   1914     99     9
+   1913   1911   1914     99     9
+   1909   1915   1917   1918     9
+   1909   1915   1917   1919     9
+   1916   1915   1917   1918     9
+   1916   1915   1917   1919     9
+   1915   1917   1919   1920     9
+   1915   1917   1919   1921     9
+   1915   1917   1919   1939     9
+   1918   1917   1919   1920     9
+   1918   1917   1919   1921     9
+   1918   1917   1919   1939     9
+   1917   1919   1921   1922     9
+   1917   1919   1921   1923     9
+   1917   1919   1921   1924     9
+   1920   1919   1921   1922     9
+   1920   1919   1921   1923     9
+   1920   1919   1921   1924     9
+   1939   1919   1921   1922     9
+   1939   1919   1921   1923     9
+   1939   1919   1921   1924     9
+   1917   1919   1939   1940     9
+   1917   1919   1939   1941     9
+   1920   1919   1939   1940     9
+   1920   1919   1939   1941     9
+   1921   1919   1939   1940     9
+   1921   1919   1939   1941     9
+   1919   1921   1924   1925     9
+   1919   1921   1924   1926     9
+   1919   1921   1924   1927     9
+   1922   1921   1924   1925     9
+   1922   1921   1924   1926     9
+   1922   1921   1924   1927     9
+   1923   1921   1924   1925     9
+   1923   1921   1924   1926     9
+   1923   1921   1924   1927     9
+   1921   1924   1927   1928     9
+   1921   1924   1927   1929     9
+   1921   1924   1927   1930     9
+   1925   1924   1927   1928     9
+   1925   1924   1927   1929     9
+   1925   1924   1927   1930     9
+   1926   1924   1927   1928     9
+   1926   1924   1927   1929     9
+   1926   1924   1927   1930     9
+   1924   1927   1930   1931     9
+   1924   1927   1930   1932     9
+   1928   1927   1930   1931     9
+   1928   1927   1930   1932     9
+   1929   1927   1930   1931     9
+   1929   1927   1930   1932     9
+   1927   1930   1932   1933     9
+   1927   1930   1932   1936     9
+   1931   1930   1932   1933     9
+   1931   1930   1932   1936     9
+   1930   1932   1933   1934     9
+   1930   1932   1933   1935     9
+   1936   1932   1933   1934     9
+   1936   1932   1933   1935     9
+   1930   1932   1936   1937     9
+   1930   1932   1936   1938     9
+   1933   1932   1936   1937     9
+   1933   1932   1936   1938     9
+   1919   1939   1941   1942     9
+   1919   1939   1941   1943     9
+   1940   1939   1941   1942     9
+   1940   1939   1941   1943     9
+   1939   1941   1943   1944     9
+   1939   1941   1943   1945     9
+   1939   1941   1943   1958     9
+   1942   1941   1943   1944     9
+   1942   1941   1943   1945     9
+   1942   1941   1943   1958     9
+   1958   1943   1945   1948     9
+   1941   1943   1945   1946     9
+   1941   1943   1945   1947     9
+   1941   1943   1945   1948     9
+   1944   1943   1945   1946     9
+   1944   1943   1945   1947     9
+   1944   1943   1945   1948     9
+   1958   1943   1945   1946     9
+   1958   1943   1945   1947     9
+   1941   1943   1958   1959     9
+   1941   1943   1958   1960     9
+   1944   1943   1958   1959     9
+   1944   1943   1958   1960     9
+   1945   1943   1958   1959     9
+   1945   1943   1958   1960     9
+   1943   1945   1948   1949     9
+   1943   1945   1948   1950     9
+   1943   1945   1948   1954     9
+   1946   1945   1948   1949     9
+   1946   1945   1948   1950     9
+   1946   1945   1948   1954     9
+   1947   1945   1948   1949     9
+   1947   1945   1948   1950     9
+   1947   1945   1948   1954     9
+   1945   1948   1950   1951     9
+   1945   1948   1950   1952     9
+   1945   1948   1950   1953     9
+   1949   1948   1950   1951     9
+   1949   1948   1950   1952     9
+   1949   1948   1950   1953     9
+   1954   1948   1950   1951     9
+   1954   1948   1950   1952     9
+   1954   1948   1950   1953     9
+   1945   1948   1954   1955     9
+   1945   1948   1954   1956     9
+   1945   1948   1954   1957     9
+   1949   1948   1954   1955     9
+   1949   1948   1954   1956     9
+   1949   1948   1954   1957     9
+   1950   1948   1954   1955     9
+   1950   1948   1954   1956     9
+   1950   1948   1954   1957     9
+      5     25     23     24     4
+     23     27     25     26     4
+     27     41     39     40     4
+     39     43     41     42     4
+     43     61     59     60     4
+     45     48     57     49     4
+     48     51     49     50     4
+     48     55     57     58     4
+     49     53     51     52     4
+     51     55     53     54     4
+     53     57     55     56     4
+     59     63     61     62     4
+     63     68     66     67     4
+     66     70     68     69     4
+     70     92     90     91     4
+     78     83     81     82     4
+     81     84     83     87     4
+     83     85     84     86     4
+     83     88     87     89     4
+     90     94     92     93     4
+     94    102    100    101     4
+    100    104    102    103     4
+    104    117    115    116     4
+    109    113    112    114     4
+    115    119    117    118     4
+    119    136    134    135     4
+    134    138    136    137     4
+    138    146    144    145     4
+    144    148    146    147     4
+    148    156    154    155     4
+    154    158    156    157     4
+    158    166    164    165     4
+    164    168    166    167     4
+    168    183    181    182     4
+    181    185    183    184     4
+    185    205    203    204     4
+    203    207    205    206     4
+    207    229    227    228     4
+    215    220    218    219     4
+    218    221    220    224     4
+    220    222    221    223     4
+    220    225    224    226     4
+    227    231    229    230     4
+    231    246    244    245     4
+    233    236    242    237     4
+    236    240    242    243     4
+    237    240    238    239     4
+    238    242    240    241     4
+    244    248    246    247     4
+    248    253    251    252     4
+    251    255    253    254     4
+    255    272    270    271     4
+    270    274    272    273     4
+    274    284    282    283     4
+    276    280    279    281     4
+    282    286    284    285     4
+    286    298    296    297     4
+    288    293    291    292     4
+    291    294    293    295     4
+    296    300    298    299     4
+    300    319    317    318     4
+    302    305    315    306     4
+    305    308    306    307     4
+    305    313    315    316     4
+    306    310    308    309     4
+    308    313    310    311     4
+    310    315    313    314     4
+    317    321    319    320     4
+    321    343    341    342     4
+    329    334    332    333     4
+    332    335    334    338     4
+    334    336    335    337     4
+    334    339    338    340     4
+    341    345    343    344     4
+    345    350    348    349     4
+    348    352    350    351     4
+    352    371    369    370     4
+    354    357    367    358     4
+    357    360    358    359     4
+    357    365    367    368     4
+    358    362    360    361     4
+    360    365    362    363     4
+    362    367    365    366     4
+    369    373    371    372     4
+    373    382    380    381     4
+    380    384    382    383     4
+    384    401    399    400     4
+    399    403    401    402     4
+    403    408    406    407     4
+    406    410    408    409     4
+    410    422    420    421     4
+    412    417    415    416     4
+    415    418    417    419     4
+    420    424    422    423     4
+    424    446    444    445     4
+    429    432    430    431     4
+    430    434    432    433     4
+    430    429    426    443     4
+    434    437    435    436     4
+    435    439    437    438     4
+    437    441    439    440     4
+    439    443    441    442     4
+    444    448    446    447     4
+    448    462    460    461     4
+    460    464    462    463     4
+    464    472    470    471     4
+    470    474    472    473     4
+    474    482    480    481     4
+    480    484    482    483     4
+    484    492    490    491     4
+    490    494    492    493     4
+    494    514    512    513     4
+    512    516    514    515     4
+    516    534    532    533     4
+    518    521    530    522     4
+    521    524    522    523     4
+    521    528    530    531     4
+    522    526    524    525     4
+    524    528    526    527     4
+    526    530    528    529     4
+    532    536    534    535     4
+    536    549    547    548     4
+    541    545    544    546     4
+    547    551    549    550     4
+    551    560    558    559     4
+    558    562    560    561     4
+    562    574    572    573     4
+    564    569    567    568     4
+    567    570    569    571     4
+    572    576    574    575     4
+    576    594    592    593     4
+    578    581    590    582     4
+    581    584    582    583     4
+    581    588    590    591     4
+    582    586    584    585     4
+    584    588    586    587     4
+    586    590    588    589     4
+    592    596    594    595     4
+    596    608    606    607     4
+    598    603    601    602     4
+    601    604    603    605     4
+    606    610    608    609     4
+    610    622    620    621     4
+    620    624    622    623     4
+    624    639    637    638     4
+    629    634    632    633     4
+    632    635    634    636     4
+    637    641    639    640     4
+    641    649    647    648     4
+    647    651    649    650     4
+    651    663    661    662     4
+    661    665    663    664     4
+    665    677    675    676     4
+    667    672    670    671     4
+    670    673    672    674     4
+    675    679    677    678     4
+    679    701    699    700     4
+    687    692    690    691     4
+    690    693    692    696     4
+    692    694    693    695     4
+    692    697    696    698     4
+    699    703    701    702     4
+    703    715    713    714     4
+    705    710    708    709     4
+    708    711    710    712     4
+    713    717    715    716     4
+    717    729    727    728     4
+    727    731    729    730     4
+    731    741    739    740     4
+    733    737    736    738     4
+    739    743    741    742     4
+    743    748    746    747     4
+    746    750    748    749     4
+    750    759    757    758     4
+    757    761    759    760     4
+    761    773    771    772     4
+    771    775    773    774     4
+    775    785    783    784     4
+    777    781    780    782     4
+    783    787    785    786     4
+    787    806    804    805     4
+    789    792    802    793     4
+    792    795    793    794     4
+    792    800    802    803     4
+    793    797    795    796     4
+    795    800    797    798     4
+    797    802    800    801     4
+    804    808    806    807     4
+    808    813    811    812     4
+    811    815    813    814     4
+    815    832    830    831     4
+    830    834    832    833     4
+    834    851    849    850     4
+    849    853    851    852     4
+    853    868    866    867     4
+    858    863    861    862     4
+    861    864    863    865     4
+    866    870    868    869     4
+    870    887    885    886     4
+    885    889    887    888     4
+    889    901    899    900     4
+    891    896    894    895     4
+    894    897    896    898     4
+    899    903    901    902     4
+    903    912    910    911     4
+    910    914    912    913     4
+    914    936    934    935     4
+    922    927    925    926     4
+    925    928    927    931     4
+    927    929    928    930     4
+    927    932    931    933     4
+    934    938    936    937     4
+    938    960    958    959     4
+    943    946    944    945     4
+    944    948    946    947     4
+    944    943    940    957     4
+    948    951    949    950     4
+    949    953    951    952     4
+    951    955    953    954     4
+    953    957    955    956     4
+    958    962    960    961     4
+    962    984    982    983     4
+    967    970    968    969     4
+    968    972    970    971     4
+    968    967    964    981     4
+    972    975    973    974     4
+    973    977    975    976     4
+    975    979    977    978     4
+    977    981    979    980     4
+    982    986    984    985     4
+    986    994    992    993     4
+    992    996    994    995     4
+    996   1008   1006   1007     4
+    998   1003   1001   1002     4
+   1001   1004   1003   1005     4
+   1006   1010   1008   1009     4
+   1010   1020   1018   1019     4
+   1012   1016   1015   1017     4
+   1018   1022   1020   1021     4
+   1022   1027   1025   1026     4
+   1025   1029   1027   1028     4
+   1029   1051   1049   1050     4
+   1037   1042   1040   1041     4
+   1040   1043   1042   1046     4
+   1042   1044   1043   1045     4
+   1042   1047   1046   1048     4
+   1049   1053   1051   1052     4
+   1053   1065   1063   1064     4
+   1063   1066   1065   1075     4
+   1075   1079   1077   1078     4
+   1077   1081   1079   1080     4
+   1081   1086   1084   1085     4
+   1084   1088   1086   1087     4
+   1088   1097   1095   1096     4
+   1095   1099   1097   1098     4
+   1099   1121   1119   1120     4
+   1107   1112   1110   1111     4
+   1110   1113   1112   1116     4
+   1112   1114   1113   1115     4
+   1112   1117   1116   1118     4
+   1119   1123   1121   1122     4
+   1123   1135   1133   1134     4
+   1125   1130   1128   1129     4
+   1128   1131   1130   1132     4
+   1133   1137   1135   1136     4
+   1137   1154   1152   1153     4
+   1152   1156   1154   1155     4
+   1156   1164   1162   1163     4
+   1162   1166   1164   1165     4
+   1166   1178   1176   1177     4
+   1168   1173   1171   1172     4
+   1171   1174   1173   1175     4
+   1176   1180   1178   1179     4
+   1180   1197   1195   1196     4
+   1195   1198   1197   1207     4
+   1207   1211   1209   1210     4
+   1209   1213   1211   1212     4
+   1213   1221   1219   1220     4
+   1219   1223   1221   1222     4
+   1223   1232   1230   1231     4
+   1230   1234   1232   1233     4
+   1234   1242   1240   1241     4
+   1240   1244   1242   1243     4
+   1244   1261   1259   1260     4
+   1259   1263   1261   1262     4
+   1263   1280   1278   1279     4
+   1278   1282   1280   1281     4
+   1282   1291   1289   1290     4
+   1289   1293   1291   1292     4
+   1293   1302   1300   1301     4
+   1300   1304   1302   1303     4
+   1304   1314   1312   1313     4
+   1306   1310   1309   1311     4
+   1312   1316   1314   1315     4
+   1316   1333   1331   1332     4
+   1331   1335   1333   1334     4
+   1335   1347   1345   1346     4
+   1345   1349   1347   1348     4
+   1349   1357   1355   1356     4
+   1355   1359   1357   1358     4
+   1359   1368   1366   1367     4
+   1366   1370   1368   1369     4
+   1370   1384   1382   1383     4
+   1382   1386   1384   1385     4
+   1386   1398   1396   1397     4
+   1388   1393   1391   1392     4
+   1391   1394   1393   1395     4
+   1396   1400   1398   1399     4
+   1400   1408   1406   1407     4
+   1406   1410   1408   1409     4
+   1410   1418   1416   1417     4
+   1416   1420   1418   1419     4
+   1420   1440   1438   1439     4
+   1438   1442   1440   1441     4
+   1442   1462   1460   1461     4
+   1460   1464   1462   1463     4
+   1464   1481   1479   1480     4
+   1479   1483   1481   1482     4
+   1483   1497   1495   1496     4
+   1495   1499   1497   1498     4
+   1499   1508   1506   1507     4
+   1506   1510   1508   1509     4
+   1510   1520   1518   1519     4
+   1512   1516   1515   1517     4
+   1518   1522   1520   1521     4
+   1522   1527   1525   1526     4
+   1525   1529   1527   1528     4
+   1529   1541   1539   1540     4
+   1531   1536   1534   1535     4
+   1534   1537   1536   1538     4
+   1539   1543   1541   1542     4
+   1543   1548   1546   1547     4
+   1546   1550   1548   1549     4
+   1550   1565   1563   1564     4
+   1563   1567   1565   1566     4
+   1567   1579   1577   1578     4
+   1569   1574   1572   1573     4
+   1572   1575   1574   1576     4
+   1577   1581   1579   1580     4
+   1581   1589   1587   1588     4
+   1587   1591   1589   1590     4
+   1591   1613   1611   1612     4
+   1596   1599   1597   1598     4
+   1597   1601   1599   1600     4
+   1597   1596   1593   1610     4
+   1601   1604   1602   1603     4
+   1602   1606   1604   1605     4
+   1604   1608   1606   1607     4
+   1606   1610   1608   1609     4
+   1611   1615   1613   1614     4
+   1615   1629   1627   1628     4
+   1627   1631   1629   1630     4
+   1631   1639   1637   1638     4
+   1637   1641   1639   1640     4
+   1641   1663   1661   1662     4
+   1646   1649   1647   1648     4
+   1647   1651   1649   1650     4
+   1647   1646   1643   1660     4
+   1651   1654   1652   1653     4
+   1652   1656   1654   1655     4
+   1654   1658   1656   1657     4
+   1656   1660   1658   1659     4
+   1661   1665   1663   1664     4
+   1665   1687   1685   1686     4
+   1673   1678   1676   1677     4
+   1676   1679   1678   1682     4
+   1678   1680   1679   1681     4
+   1678   1683   1682   1684     4
+   1685   1689   1687   1688     4
+   1689   1701   1699   1700     4
+   1691   1696   1694   1695     4
+   1694   1697   1696   1698     4
+   1699   1703   1701   1702     4
+   1703   1725   1723   1724     4
+   1711   1716   1714   1715     4
+   1714   1717   1716   1720     4
+   1716   1718   1717   1719     4
+   1716   1721   1720   1722     4
+   1723   1727   1725   1726     4
+   1727   1735   1733   1734     4
+   1733   1737   1735   1736     4
+   1737   1757   1755   1756     4
+   1755   1759   1757   1758     4
+   1759   1764   1762   1763     4
+   1762   1766   1764   1765     4
+   1766   1778   1776   1777     4
+   1776   1780   1778   1779     4
+   1780   1790   1788   1789     4
+   1782   1786   1785   1787     4
+   1788   1792   1790   1791     4
+   1792   1806   1804   1805     4
+   1804   1808   1806   1807     4
+   1808   1823   1821   1822     4
+   1813   1818   1816   1817     4
+   1816   1819   1818   1820     4
+   1821   1825   1823   1824     4
+   1825   1833   1831   1832     4
+   1831   1835   1833   1834     4
+   1835   1857   1855   1856     4
+   1840   1843   1841   1842     4
+   1841   1845   1843   1844     4
+   1841   1840   1837   1854     4
+   1845   1848   1846   1847     4
+   1846   1850   1848   1849     4
+   1848   1852   1850   1851     4
+   1850   1854   1852   1853     4
+   1855   1859   1857   1858     4
+   1859   1876   1874   1875     4
+   1874   1878   1876   1877     4
+   1878   1900   1898   1899     4
+   1886   1891   1889   1890     4
+   1889   1892   1891   1895     4
+   1891   1893   1892   1894     4
+   1891   1896   1895   1897     4
+   1898   1902   1900   1901     4
+   1902   1907   1905   1906     4
+   1905   1909   1907   1908     4
+   1909   1917   1915   1916     4
+   1915   1919   1917   1918     4
+   1919   1941   1939   1940     4
+   1927   1932   1930   1931     4
+   1930   1933   1932   1936     4
+   1932   1934   1933   1935     4
+   1932   1937   1936   1938     4
+   1939   1943   1941   1942     4
+   1943   1959   1958   1960     4
+
+
+[ moleculetype ]
+; Name            nrexcl
+SOL          3
+
+[ atoms ]
+;   nr       type  resnr residue  atom   cgnr    charge       mass  typeB    chargeB      massB
+; residue    1 SOL rtp SOL q 0.0
+    1 OW_tip4pew      1    SOL     OW      1   0.0000     16.000   ; qtot 0.0000
+    2 HW_tip4pew      1    SOL    HW1      2   0.5242      1.008   ; qtot 0.5242
+    3 HW_tip4pew      1    SOL    HW2      3   0.5242      1.008   ; qtot 1.0484
+    4         MW      1    SOL     MW      4  -1.0484      0.000   ; qtot 0.0000
+
+[ settles ]
+; i	funct	doh	dhh
+1     1   0.09572   0.15139
+
+[ virtual_sites3 ]
+; Site  from                   funct
+4     1    2    3    1      0.106677  0.106677
+
+[ exclusions ]
+1 2 3 4
+2 1 3 4
+3 1 2 4
+4 1 2 3
+
+[ system ]
+; Name
+Protein in water
+
+[ molecules ]
+; Compound       #mols
+system1              1
+SOL               9650

--- a/test/test_chemistry_gromacs.py
+++ b/test/test_chemistry_gromacs.py
@@ -165,8 +165,8 @@ class TestGromacsTop(unittest.TestCase):
         top2 = load_file(get_fn('1aki.ff99sbildn.top', written=True))
         self._check_ff99sbildn(top2)
         self.assertTrue(diff_files(get_fn('1aki.ff99sbildn.top', written=True),
-                                   get_saved_fn('1aki.ff99sbildn.top')))
-        self.assertFalse(True)
+                                   get_saved_fn('1aki.ff99sbildn.top'),
+                                   comment=';'))
 
 class TestGromacsGro(unittest.TestCase):
     """ Tests the Gromacs GRO file parser """

--- a/test/test_chemistry_gromacs.py
+++ b/test/test_chemistry_gromacs.py
@@ -166,6 +166,7 @@ class TestGromacsTop(unittest.TestCase):
         self._check_ff99sbildn(top2)
         self.assertTrue(diff_files(get_fn('1aki.ff99sbildn.top', written=True),
                                    get_saved_fn('1aki.ff99sbildn.top')))
+        self.assertFalse(True)
 
 class TestGromacsGro(unittest.TestCase):
     """ Tests the Gromacs GRO file parser """

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -1084,7 +1084,8 @@ class TestChamberParmActions(utils.TestCaseRelative):
         self.assertTrue(utils.diff_files(get_fn('ala_ala_ala.parm7'),
                                          get_fn('test.parm7', written=True)))
         self.assertTrue(utils.diff_files(get_fn('ala_ala_ala.rst7'),
-                                         get_fn('test.rst7', written=True)))
+                                         get_fn('test.rst7', written=True),
+                                         absolute_error=0.0001))
 
     def testWriteFrcmod(self):
         """ Check that writeFrcmod fails for ChamberParm """
@@ -1911,7 +1912,8 @@ class TestAmoebaParmActions(utils.TestCaseRelative):
         self.assertTrue(utils.diff_files(get_fn('nma.parm7'),
                                          get_fn('test.parm7', written=True)))
         self.assertTrue(utils.diff_files(get_fn('nma.rst7'),
-                                         get_fn('test.rst7', written=True)))
+                                         get_fn('test.rst7', written=True),
+                                         absolute_error=0.0001))
 
     def testWriteFrcmod(self):
         """ Check that writeFrcmod fails for AmoebaParm """

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -244,7 +244,8 @@ class TestAmberParmActions(utils.TestCaseRelative):
         self.assertTrue(utils.diff_files(get_fn('trx.prmtop'),
                                          get_fn('test.parm7', written=True)))
         self.assertTrue(utils.diff_files(get_fn('trx.inpcrd'),
-                                         get_fn('test.rst7', written=True)))
+                                         get_fn('test.rst7', written=True),
+                                         absolute_error=0.0001))
 
     def testWriteFrcmod(self):
         """ Test writeFrcmod on AmberParm """
@@ -1069,7 +1070,8 @@ class TestChamberParmActions(utils.TestCaseRelative):
         self.assertTrue(utils.diff_files(get_fn('ala_ala_ala.parm7'),
                                          get_fn('test.parm7', written=True)))
         self.assertTrue(utils.diff_files(get_fn('ala_ala_ala.rst7'),
-                                         get_fn('test.rst7', written=True)))
+                                         get_fn('test.rst7', written=True),
+                                         absolute_error=0.0001))
         self._empty_writes()
         PT.outparm(parm, get_fn('test.parm7', written=True)).execute()
         self.assertEqual(len(os.listdir(get_fn('writes'))), 1)
@@ -1895,7 +1897,8 @@ class TestAmoebaParmActions(utils.TestCaseRelative):
         self.assertTrue(utils.diff_files(get_fn('nma.parm7'),
                                          get_fn('test.parm7', written=True)))
         self.assertTrue(utils.diff_files(get_fn('nma.rst7'),
-                                         get_fn('test.rst7', written=True)))
+                                         get_fn('test.rst7', written=True),
+                                         absolute_error=0.0001))
         self._empty_writes()
         PT.outparm(parm, get_fn('test.parm7', written=True)).execute()
         self.assertEqual(len(os.listdir(get_fn('writes'))), 1)

--- a/test/utils.py
+++ b/test/utils.py
@@ -115,7 +115,8 @@ def has_numpy():
     return numpy is not None
 
 def diff_files(file1, file2, ignore_whitespace=True,
-               absolute_error=None, relative_error=None):
+               absolute_error=None, relative_error=None,
+               comment=None):
     """
     Compares 2 files line-by-line
 
@@ -133,6 +134,8 @@ def diff_files(file1, file2, ignore_whitespace=True,
     relative_error : float=None
         If set, only relative differences greater than the relative error will
         trigger failures. Cannot be used with absolute_error
+    comment : str or None
+        The character to identify comments in this file
 
     Returns
     -------
@@ -174,6 +177,10 @@ def diff_files(file1, file2, ignore_whitespace=True,
         if ignore_whitespace:
             while l1 or l2:
                 if l1.strip() != l2.strip():
+                    if 'At date:' in l1 and 'At date:' in l2:
+                        l1 = f1.readline()
+                        l2 = f2.readline()
+                        continue
                     if l1.startswith('%VERSION') and l2.startswith('%VERSION'):
                         l1 = f1.readline()
                         l2 = f2.readline()
@@ -187,6 +194,10 @@ def diff_files(file1, file2, ignore_whitespace=True,
         else:
             while l1 and l2:
                 if l1 != l2:
+                    if 'At date:' in l1 and 'At date:' in l2:
+                        l1 = f1.readline()
+                        l2 = f2.readline()
+                        continue
                     if l1.startswith('%VERSION') and l2.startswith('%VERSION'):
                         l1 = f1.readline()
                         l2 = f2.readline()

--- a/test/utils.py
+++ b/test/utils.py
@@ -249,6 +249,8 @@ def detailed_diff(l1, l2, absolute_error=None, relative_error=None):
                         return False
                     if abs((wx / wy) - 1) > relative_error:
                         return False
+                elif absolute_error is None and relative_error is None:
+                    return False
     return True
 
 def which(prog):

--- a/test/utils.py
+++ b/test/utils.py
@@ -176,11 +176,11 @@ def diff_files(file1, file2, ignore_whitespace=True,
         same = True
         if ignore_whitespace:
             while l1 or l2:
+                while l1 and l1[0] == comment:
+                    l1 = f1.readline()
+                while l2 and l2[0] == comment:
+                    l2 = f2.readline()
                 if l1.strip() != l2.strip():
-                    if 'At date:' in l1 and 'At date:' in l2:
-                        l1 = f1.readline()
-                        l2 = f2.readline()
-                        continue
                     if l1.startswith('%VERSION') and l2.startswith('%VERSION'):
                         l1 = f1.readline()
                         l2 = f2.readline()


### PR DESCRIPTION
More improvements to Gromacs topology file writing.  It now optionally splits up Structures into individual molecules as well as printing out `[ virtual_sites? ]` sections and `[ settles ]` sections.

All that's lacking for the "completed" (but very initial) implementation is proper parameter parsing.