### PR TITLE
OpenMM Topology/System -> Structure conversion

### DIFF
--- a/chemistry/amber/_amberparm.py
+++ b/chemistry/amber/_amberparm.py
@@ -342,16 +342,15 @@ class AmberParm(AmberFormat, Structure):
             if dt.phi_k == 0 and dt.per == 0:
                 dt.per = 1.0
             elif dt.per == 0:
-                warnings.warn('Periodicity of 0 detected with non-zero force '
-                              'constant. Changing periodicity to 1 and force '
-                              'constant to 0 to ensure 1-4 nonbonded pairs are '
-                              'properly identified. This might cause a shift '
-                              'in the energy, but will leave forces unaffected',
-                              AmberParmWarning)
+                warn('Periodicity of 0 detected with non-zero force constant. '
+                     'Changing periodicity to 1 and force constant to 0 to '
+                     'ensure 1-4 nonbonded pairs are properly identified. This '
+                     'might cause a shift in the energy, but will leave forces '
+                     'unaffected', AmberParmWarning)
                 dt.phi_k = 0.0
                 dt.per = 1.0
         inst.remake_parm()
-        inst._set_nonbonded_tables()
+        inst._set_nonbonded_tables(nbfixes)
 
         return inst
 
@@ -1812,7 +1811,7 @@ class AmberParm(AmberFormat, Structure):
                     i, j = min(i, j-1), max(i, j-1)
                     eps = abs(eps)
                     eps14 = abs(eps14)
-                    idx = data['NONBONDED_PARM_INDEX'][ntypes*i+j] - 1
+                    idx = self.parm_data['NONBONDED_PARM_INDEX'][ntypes*i+j] - 1
                     self.parm_data['LENNARD_JONES_ACOEF'][idx] = eps * rmin**12
                     self.parm_data['LENNARD_JONES_BCOEF'][idx] = 2*eps * rmin**6
 
@@ -2020,9 +2019,9 @@ class AmberParm(AmberFormat, Structure):
             zero_angle.list = self.angle_types
         if n14: # See if there is some ambiguity here
             if not self.adjusts and len(scalings) > 1:
-                warnings.warn('Multiple 1-4 scaling factors detected. Using '
-                              'the most-used values scee=%f scnb=%f' %
-                              (scee, scnb), AmberParmWarning)
+                warn('Multiple 1-4 scaling factors detected. Using the '
+                     'most-used values scee=%f scnb=%f' % (scee, scnb),
+                     AmberParmWarning)
         return n13, n14
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chemistry/amber/_chamberparm.py
+++ b/chemistry/amber/_chamberparm.py
@@ -24,12 +24,13 @@ from __future__ import division, print_function
 
 from chemistry.amber._amberparm import AmberParm
 from chemistry.constants import NTYPES, NATYP, IFBOX, TINY, NATOM
-from chemistry.exceptions import AmberParmError
+from chemistry.exceptions import AmberParmError, AmberParmWarning
 from chemistry.topologyobjects import (UreyBradley, Improper, Cmap, BondType,
                                        ImproperType, CmapType, ExtraPoint)
 from chemistry.utils.six.moves import zip, range
 import copy
 from math import sqrt
+import warnings
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/chemistry/amber/_tinkerparm.py
+++ b/chemistry/amber/_tinkerparm.py
@@ -24,7 +24,7 @@ from __future__ import division, print_function, absolute_import
 
 from chemistry.amber._amberparm import AmberParm
 from chemistry.amber.amberformat import AmberFormat
-from chemistry.constants import NATOM, NRES, IFBOX, DEG_TO_RAD, RAD_TO_DEG
+from chemistry.constants import NATOM, NRES, IFBOX, RAD_TO_DEG
 from chemistry import (Bond, BondType, PiTorsion, AngleType, OutOfPlaneBendType,
                 DihedralType, UreyBradley, Angle, TrigonalAngle, OutOfPlaneBend,
                 Dihedral, StretchBend, TorsionTorsion, ChiralFrame,

--- a/chemistry/charmm/psf.py
+++ b/chemistry/charmm/psf.py
@@ -12,14 +12,12 @@ from chemistry import (Bond, Angle, Dihedral, Improper, AcceptorDonor, Group,
                        Cmap, UreyBradley, NoUreyBradley, Structure, Atom)
 from chemistry.exceptions import (CharmmPSFError, MoleculeError,
                 CharmmPSFWarning, MissingParameter, CharmmPsfEOF)
-from chemistry.structure import needs_openmm, app, mm
-from chemistry import unit as u
+from chemistry.structure import needs_openmm
 from chemistry.utils.io import genopen
 from chemistry.utils.six import wraps
 from chemistry.utils.six.moves import zip, range
 from contextlib import closing
 from copy import copy
-from math import sqrt
 import os
 import re
 import warnings

--- a/chemistry/exceptions.py
+++ b/chemistry/exceptions.py
@@ -174,3 +174,6 @@ class PreProcessorError(ChemError):
 
 class PreProcessorWarning(ChemWarning):
     """ If there is something we should warn about in preprocessing """
+
+class OpenMMWarning(ChemWarning):
+    """ If there is something we should warn when processing OpenMM objects """

--- a/chemistry/formats/registry.py
+++ b/chemistry/formats/registry.py
@@ -107,7 +107,7 @@ def load_file(filename, *args, **kwargs):
         try:
             if cls.id_format(filename):
                 break
-        except UnicodeDecodeError as e:
+        except UnicodeDecodeError:
             continue
     else:
         # We found no file format

--- a/chemistry/gromacs/gromacsgro.py
+++ b/chemistry/gromacs/gromacsgro.py
@@ -224,8 +224,9 @@ class GromacsGroFile(object):
                 ydim[1] = max(ydim[1], atom.xy)
                 zdim[0] = min(zdim[0], atom.xz)
                 zdim[1] = max(zdim[1], atom.xz)
-            dest.write('%10.5f'*3 % (xdim[1]-xdim[0]+5, ydim[1]-ydim[0]+5,
-                                     zdim[1]-zdim[0]+5))
+            dest.write('%10.5f'*3 % ((xdim[1]-xdim[0]+5)/10,
+                                     (ydim[1]-ydim[0]+5)/10,
+                                     (zdim[1]-zdim[0]+5)/10))
             dest.write('\n')
         if own_handle:
             dest.close()

--- a/chemistry/gromacs/gromacstop.py
+++ b/chemistry/gromacs/gromacstop.py
@@ -618,7 +618,7 @@ class GromacsTopologyFile(Structure):
                 elif current_section == 'nonbond_params':
                     words = line.split()
                     a1, a2 = words[:2]
-                    func = int(words[2])
+#                   func = int(words[2])
                     sig, eps = (float(x) for x in words[3:5])
                     sig *= 10 # Convert to Angstroms
                     eps *= u.kilojoule.conversion_factor_to(u.kilocalorie)
@@ -1044,7 +1044,6 @@ class GromacsTopologyFile(Structure):
             for dihedral in struct.dihedrals:
                 if dihedral.type is None: continue
                 if isinstance(dihedral.type, DihedralTypeList):
-                    fudgeQQ = fudgeLJ = None
                     for dt in dihedral.type:
                         if dt.scee:
                             scee_values.add(dt.scee)

--- a/chemistry/openmm/__init__.py
+++ b/chemistry/openmm/__init__.py
@@ -8,3 +8,4 @@ from chemistry.openmm.reporters import (
 )
 from chemistry.openmm import utils
 from chemistry.openmm.topsystem import load_topology
+

--- a/chemistry/openmm/__init__.py
+++ b/chemistry/openmm/__init__.py
@@ -7,3 +7,4 @@ from chemistry.openmm.reporters import (
         ProgressReporter, EnergyMinimizerReporter,
 )
 from chemistry.openmm import utils
+from chemistry.openmm.topsystem import load_topology

--- a/chemistry/openmm/reporters.py
+++ b/chemistry/openmm/reporters.py
@@ -5,26 +5,14 @@ from chemistry.geometry import box_vectors_to_lengths_and_angles
 from chemistry.amber.netcdffiles import NetCDFTraj
 from chemistry.amber.readparm import Rst7
 from chemistry import unit as u
-from chemistry.utils.six import wraps
+from chemistry.utils.decorators import needs_openmm
 from chemistry.utils.six.moves import range
 from math import isnan, isinf
 try:
-    import simtk.openmm as mm
-    HAS_OPENMM = True
+    from simtk import openmm as mm
 except ImportError:
-    HAS_OPENMM = False
-from time import time as timeofday
-
-def needs_openmm(fcn):
-    global HAS_OPENMM
-    @wraps(fcn)
-    def new_fcn(*args, **kwargs):
-        if not HAS_OPENMM:
-            raise ImportError('Could not find or import OpenMM')
-        return fcn(*args, **kwargs)
-
-    return new_fcn
-
+    pass
+from time import time
 VELUNIT = u.angstrom / u.picosecond
 FRCUNIT = u.kilocalorie_per_mole / u.angstrom
 
@@ -727,8 +715,8 @@ class ProgressReporter(StateDataReporter):
         """
         if self._startTime is None:
             # First time this is called, initialize the timers
-            self._startTime = timeofday()
-            self._lastReportTime = timeofday()
+            self._startTime = time()
+            self._lastReportTime = time()
             self._timeStep = simulation.integrator.getStepSize()
             self._timeStep = self._timeStep.value_in_unit(u.nanosecond)
             self._firstStep = simulation.currentStep
@@ -751,7 +739,7 @@ class ProgressReporter(StateDataReporter):
         # Query for the values
         values = self._constructReportValues(simulation, state)
 
-        now = timeofday()
+        now = time()
 
         total_time = now - self._startTime
         partial_time = now - self._lastReportTime

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -193,7 +193,7 @@ def _process_dihedral(struct, force):
         i, j, k, l, per, phase, phi_k = force.getTorsionParameters(ii)
         ai, aj = struct.atoms[i], struct.atoms[j]
         ak, al = struct.atoms[k], struct.atoms[l]
-        key = (per, phase._value, k._value)
+        key = (per, phase._value, phi_k._value)
         if key in typemap:
             dihed_type = typemap[key]
         else:
@@ -311,7 +311,7 @@ def _process_nonbonded(struct, force):
             atom_type = AtomType(atype_name, None, atom.mass,
                                  atom.atomic_number)
         atom.charge = chg.value_in_unit(u.elementary_charge)
-        rmin = sig.value_in_unit(u.angstroms) * 2**(-1/6) / 2 # to rmin/2
+        rmin = sig.value_in_unit(u.angstroms) * 2**(1/6) / 2 # to rmin/2
         eps = eps.value_in_unit(u.kilocalories_per_mole)
         atom_type.set_lj_params(eps, rmin)
         atom.atom_type = atom_type

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -264,12 +264,14 @@ def _process_rbtorsion(struct, force):
         try:
             key = (c0._value, c1._value, c2._value,
                    c3._value, c4._value, c5._value)
+            f = 1
         except AttributeError:
             key = (c0, c1, c2, c3, c4, c5)
+            f = u.kilojoules_per_mole
         if key in typemap:
             dihed_type = typemap[key]
         else:
-            dihed_type = RBTorsionType(c0, c1, c2, c3, c4, c5)
+            dihed_type = RBTorsionType(c0*f, c1*f, c2*f, c3*f, c4*f, c5*f)
             typemap[key] = dihed_type
             struct.rb_torsion_types.append(dihed_type)
         struct.rb_torsions.append(Dihedral(ai, aj, ak, al, type=dihed_type))

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -1,0 +1,69 @@
+"""
+Convert an OpenMM Topology into a Structure instance, optionally filling in
+parameters from a System
+"""
+from __future__ import division, print_function, absolute_import
+
+__all__ = ['load_topology']
+
+try:
+    import simtk.openmm as mm
+    HAS_OPENMM = True
+except ImportError:
+    HAS_OPENMM = False
+
+from chemistry.structure import Structure
+from chemistry.topologyobjects import (Atom, Bond, BondType, Angle, AngleType,
+        Dihedral, DihedralType, Improper, ImproperType, Residue, AtomType,
+        ExtraPoint)
+from chemistry import unit as u
+
+def load_topology(topology, system=None):
+    """
+    Creates a :class:`chemistry.structure.Structure` instance from an OpenMM
+    Topology, optionally filling in parameters from a System
+
+    Parameters
+    ----------
+    topology : :class:`simtk.openmm.app.Topology`
+        The Topology instance with the list of atoms and bonds for this system
+    system : :class:`simtk.openmm.System`, optional
+        If provided, parameters from this System will be applied to the
+        Structure
+
+    Returns
+    -------
+    struct : :class:`Structure <chemistry.structure.Structure>`
+        The structure from the provided topology
+
+    Notes
+    -----
+    Due to its flexibility with CustomForces, it is entirely possible that the
+    functional form of the potential will be unknown to ParmEd. This function
+    will try to use the energy expression to identify supported potential types
+    that are implemented as CustomForce objects. In particular, quadratic
+    improper torsions, when recognized, will be extracted.
+
+    Other CustomForces, including the CustomNonbondedForce used to implement
+    NBFIX (off-diagonal L-J modifications) and the 12-6-4 potential, will not be
+    processed and will result in an unknown functional form
+    """
+    struct = Structure()
+    atommap = dict()
+    for c in topology.chains():
+        chain = c.id
+        for r in c.residues():
+            residue = r.name
+            resid = r.index
+            for a in r.atoms():
+                if a.element is None:
+                    atom = ExtraPoint(name=a.name)
+                else:
+                    atom = Atom(atomic_number=a.element.atomic_number,
+                                name=a.name, mass=a.element.mass)
+                struct.add_atom(atom, residue, resid, chain)
+                atommap[a] = atom
+    for a1, a2 in topology.bonds():
+        struct.bonds.append(Bond(atommap[a1], atommap[a2]))
+
+    return struct

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -280,7 +280,7 @@ def _process_improper(struct, force):
         i, j, k, l, (psi_k, psi_eq) = force.getTorsionParameters(ii)
         ai, aj = struct.atoms[i], struct.atoms[j]
         ak, al = struct.atoms[k], struct.atoms[l]
-        key = (psi_k._value, psi_eq._value)
+        key = (psi_k, psi_eq)
         if key in typemap:
             imp_type = typemap[key]
         else:

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -6,18 +6,25 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['load_topology']
 
-try:
-    import simtk.openmm as mm
-    HAS_OPENMM = True
-except ImportError:
-    HAS_OPENMM = False
-
+from chemistry.exceptions import OpenMMWarning
+from chemistry.periodic_table import Element
 from chemistry.structure import Structure
 from chemistry.topologyobjects import (Atom, Bond, BondType, Angle, AngleType,
-        Dihedral, DihedralType, Improper, ImproperType, Residue, AtomType,
-        ExtraPoint)
+        Dihedral, DihedralType, Improper, ImproperType, AtomType, ExtraPoint,
+        UreyBradley, NonbondedExceptionType, NonbondedException, Cmap, CmapType,
+        RBTorsionType)
 from chemistry import unit as u
+from chemistry.utils.decorators import needs_openmm
+from chemistry.utils.six import iteritems
+from chemistry.utils.six.moves import range
+from collections import defaultdict
+try:
+    import simtk.openmm as mm
+except ImportError:
+    pass
+import warnings
 
+@needs_openmm
 def load_topology(topology, system=None):
     """
     Creates a :class:`chemistry.structure.Structure` instance from an OpenMM
@@ -66,4 +73,278 @@ def load_topology(topology, system=None):
     for a1, a2 in topology.bonds():
         struct.bonds.append(Bond(atommap[a1], atommap[a2]))
 
+    if system is None:
+        return struct
+
+    # We have a system, try to extract parameters from it
+    if len(struct.atoms) != system.getNumParticles():
+        raise TypeError('Topology and System have different numbers of atoms '
+                '(%d vs. %d)' % (len(struct.atoms), system.getNumParticles()))
+
+    processed_forces = set()
+    ignored_forces = (mm.CMMotionRemover, mm.AndersenThermostat,
+                      mm.MonteCarloBarostat, mm.MonteCarloAnisotropicBarostat,
+                      mm.MonteCarloMembraneBarostat, mm.CustomExternalForce,
+                      mm.GBSAOBCForce, mm.CustomGBForce)
+
+    for force in system.getForces():
+        if isinstance(force, mm.HarmonicBondForce):
+            if (mm.HarmonicBondForce in processed_forces and
+                    mm.HarmonicAngleForce in processed_forces):
+                # Try to process this HarmonicBondForce as a Urey-Bradley term
+                _process_urey_bradley(struct, force)
+            else:
+                _process_bond(struct, force)
+        elif isinstance(force, mm.HarmonicAngleForce):
+            _process_angle(struct, force)
+        elif isinstance(force, mm.PeriodicTorsionForce):
+            _process_dihedral(struct, force)
+        elif isinstance(force, mm.RBTorsionForce):
+            _process_rbtorsion(struct, force)
+        elif isinstance(force, mm.CustomTorsionForce):
+            if not _process_improper(struct, force):
+                struct.unknown_functional = True
+                warnings.warn('Unknown functional form of CustomTorsionForce',
+                              OpenMMWarning)
+        elif isinstance(force, mm.CMAPTorsionForce):
+            _process_cmap(struct, force)
+        elif isinstance(force, mm.NonbondedForce):
+            _process_nonbonded(struct, force)
+        elif isinstance(force, ignored_forces):
+            continue
+        else:
+            struct.unknown_functional = True
+            warnings.warn('Unsupported Force type %s' % type(force).__name__,
+                          OpenMMWarning)
+
     return struct
+
+def _process_bond(struct, force):
+    """ Adds bond parameters to the structure """
+    typemap = dict()
+    for ii in range(force.getNumBonds()):
+        i, j, req, k = force.getBondParameters(ii)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        key = (req._value, k._value)
+        if key in typemap:
+            bond_type = typemap[key]
+        else:
+            bond_type = BondType(k*0.5, req)
+            typemap[key] = bond_type
+            struct.bond_types.append(bond_type)
+        if aj in ai.bond_partners:
+            for bond in ai.bonds:
+                if aj in bond:
+                    break
+            else:
+                raise RuntimeError('aj in ai.bond_partners, but couldn\'t find '
+                                   'that bond!')
+            bond.type = bond_type
+        else:
+            struct.bonds.append(Bond(ai, aj, type=bond_type))
+    struct.bond_types.claim()
+
+def _process_angle(struct, force):
+    """ Adds angle parameters to the structure """
+    typemap = dict()
+    for ii in range(force.getNumAngles()):
+        i, j, k, theteq, frc_k = force.getAngleParameters(ii)
+        key = (theteq._value, frc_k._value)
+        ai, aj, ak = struct.atoms[i], struct.atoms[j], struct.atoms[k]
+        if key in typemap:
+            angle_type = typemap[key]
+        else:
+            angle_type = AngleType(frc_k*0.5, theteq)
+            typemap[key] = angle_type
+            struct.angle_types.append(angle_type)
+        struct.angles.append(Angle(ai, aj, ak, type=angle_type))
+    struct.angle_types.claim()
+
+def _process_urey_bradley(struct, force):
+    """ Adds Urey-Bradley parameters to the structure """
+    if not struct.angles:
+        warnings.warn('Adding what seems to be Urey-Bradley terms before '
+                      'Angles. This is unexpected, but the parameters will '
+                      'all be present in one form or another.', OpenMMWarning)
+    typemap = dict()
+    for ii in range(force.getNumBonds()):
+        i, j, req, k = force.getBondParameters(ii)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        key = (req._value, k._value)
+        if struct.angles and ai not in aj.angle_partners:
+            warnings.warn('Adding what seems to be Urey-Bradley terms, but '
+                          'atoms %d and %d do not appear to be angled to each '
+                          'other. Parameters will all be present, but may not '
+                          'be in expected places.' % (ai.idx, aj.idx),
+                          OpenMMWarning)
+        if key in typemap:
+            urey_type = typemap[key]
+        else:
+            urey_type = BondType(k*0.5, req)
+            typemap[key] = urey_type
+            struct.urey_bradley_types.append(urey_type)
+        struct.urey_bradleys.append(UreyBradley(ai, aj, type=urey_type))
+    struct.urey_bradley_types.claim()
+
+def _process_dihedral(struct, force):
+    """ Adds periodic torsions to the structure """
+    typemap = dict()
+    for ii in range(force.getNumTorsions()):
+        i, j, k, l, per, phase, phi_k = force.getTorsionParameters(ii)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        ak, al = struct.atoms[k], struct.atoms[l]
+        key = (per, phase._value, k._value)
+        if key in typemap:
+            dihed_type = typemap[key]
+        else:
+            dihed_type = DihedralType(phi_k, per, phase)
+            typemap[key] = dihed_type
+            struct.dihedral_types.append(dihed_type)
+        improper = (ai in ak.bond_partners and aj in ak.bond_partners and
+                    al in ak.bond_partners)
+        struct.dihedrals.append(Dihedral(ai, aj, ak, al, improper=improper,
+                                         type=dihed_type))
+    struct.dihedral_types.claim()
+
+def _process_rbtorsion(struct, force):
+    """ Adds Ryckaert-Bellemans torsions to the structure """
+    typemap = dict()
+    for ii in range(force.getNumTorsions()):
+        i, j, k, l, c0, c1, c2, c3, c4, c5 = force.getTorsionParameters(ii)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        ak, al = struct.atoms[k], struct.atoms[l]
+        key = (c0._value, c1._value, c2._value, c3._value, c4._value, c5._value)
+        if key in typemap:
+            dihed_type = typemap[key]
+        else:
+            dihed_type = RBTorsionType(c0, c1, c2, c3, c4, c5)
+            typemap[key] = dihed_type
+            struct.rb_torsion_types.append(dihed_type)
+        struct.rb_torsions.append(Dihedral(ai, aj, ak, al, type=dihed_type))
+    struct.rb_torsion_types.claim()
+
+def _process_improper(struct, force):
+    """ Processes a CustomTorsionForce and looks at the energy expression to see
+    if it's a quadratic improper torsion. Then adds the parameters if applicable
+
+    Returns
+    -------
+    is_improper : bool
+        Returns True if the energy expression is recognized as a quadratic
+        improper, and False otherwise
+    """
+    eqn = force.getEnergyFunction().replace(' ', '')
+    # Don't try to be fancy with regexes for fear of making a possible mistake.
+    # ParmEd and OpenMM use only these two eqns for the improper torsions:
+    #  k*(theta-theta0)^2 vs. 0.5*k*(theta-theta0)^2
+    # So only recognize the above 2 forms
+    if eqn not in ('0.5*k*(theta-theta0)^2', 'k*(theta-theta0)^2'):
+        return False
+    if eqn == '0.5*k*(theta-theta0)^2':
+        fac = 0.5
+    else:
+        fac = 1
+    typemap = dict()
+    for ii in range(force.getNumTorsions()):
+        # All formulations put k first and equilibrium angle second, in radians
+        i, j, k, l, (psi_k, psi_eq) = force.getTorsionParameters(ii)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        ak, al = struct.atoms[k], struct.atoms[l]
+        key = (psi_k._value, psi_eq._value)
+        if key in typemap:
+            imp_type = typemap[key]
+        else:
+            imp_type = ImproperType(psi_k*fac*u.kilojoule_per_mole/u.radian**2,
+                                    psi_eq*u.radian)
+            typemap[key] = imp_type
+            struct.improper_types.append(imp_type)
+        struct.impropers.append(Improper(ai, aj, ak, al, type=imp_type))
+    struct.improper_types.claim()
+    return True
+
+def _process_cmap(struct, force):
+    """ Adds CMAPs to the structure """
+    # store the list of cmap types
+    cmap_types = []
+    for ii in range(force.getNumMaps()):
+        size, grid = force.getMapParameters(ii)
+        # Future-proof in case units start getting added to these maps
+        if u.is_quantity(grid):
+            typ = CmapType(size, grid)
+        else:
+            typ = CmapType(size, grid*u.kilojoules_per_mole)
+        cmap_types.append(typ)
+        typ.grid = typ.grid.T.switch_range()
+        typ.used = False
+    # Add all cmaps
+    for ii in range(force.getNumTorsions()):
+        mapidx, ii, ij, ik, il, ji, jj, jk, jl = force.getTorsionParameters(ii)
+        if ij != ji or ik != jj or il != jk:
+            warnings.warn('Non-continuous CMAP torsions detected. Not '
+                          'supported.', OpenMMWarning)
+            continue
+        ai, aj, ak = struct.atoms[ii], struct.atoms[ij], struct.atoms[ik]
+        al, am = struct.atoms[il], struct.atoms[jl]
+        cmap_type = cmap_types[mapidx]
+        cmap_type.used = True
+        struct.cmaps.append(Cmap(ai, aj, ak, al, am, type=cmap_type))
+    for cmap_type in cmap_types:
+        if cmap_type.used:
+            struct.cmap_types.append(cmap_type)
+    struct.cmap_types.claim()
+
+def _process_nonbonded(struct, force):
+    """ Adds nonbonded parameters to the structure """
+    typemap = dict()
+    element_typemap = defaultdict(int)
+    assert force.getNumParticles() == len(struct.atoms), "Atom # mismatch"
+    for i in range(force.getNumParticles()):
+        atom = struct.atoms[i]
+        chg, sig, eps = force.getParticleParameters(i)
+        atype_name = Element[atom.atomic_number]
+        key = (atype_name, sig._value, eps._value)
+        if key in typemap:
+            atom_type = typemap[key]
+        else:
+            element_typemap[atype_name] += 1
+            atype_name = '%s%d' % (atype_name, element_typemap[atype_name])
+            atom_type = AtomType(atype_name, None, atom.mass,
+                                 atom.atomic_number)
+        atom.charge = chg.value_in_unit(u.elementary_charge)
+        rmin = sig.value_in_unit(u.angstroms) * 2**(-1/6) / 2 # to rmin/2
+        eps = eps.value_in_unit(u.kilocalories_per_mole)
+        atom_type.set_lj_params(eps, rmin)
+        atom.atom_type = atom_type
+        atom.type = atom_type.name
+
+    explicit_exceptions = defaultdict(set)
+    bond_graph_exceptions = defaultdict(set)
+    for atom in struct.atoms:
+        for a2 in atom.bond_partners:
+            bond_graph_exceptions[atom].add(a2)
+            for a3 in a2.bond_partners:
+                bond_graph_exceptions[atom].add(a3)
+
+    # TODO should we compress exception types?
+    for ii in range(force.getNumExceptions()):
+        i, j, q, sig, eps = force.getExceptionParameters(ii)
+        q = q.value_in_unit(u.elementary_charge**2)
+        sig = sig.value_in_unit(u.angstrom)
+        eps = eps.value_in_unit(u.kilocalorie_per_mole)
+        ai, aj = struct.atoms[i], struct.atoms[j]
+        if q == 0 and (sig == 0 or eps == 0):
+            explicit_exceptions[ai].add(aj)
+            explicit_exceptions[aj].add(ai)
+            continue
+        nbtype = NonbondedExceptionType(sig*2**(1/6), eps,
+                                        q/(ai.charge*aj.charge))
+        struct.adjusts.append(NonbondedException(ai, aj, type=nbtype))
+        struct.adjust_types.append(nbtype)
+    struct.adjust_types.claim()
+
+    # Check that all of our exceptions are accounted for
+    for ai, exceptions in iteritems(bond_graph_exceptions):
+        if exceptions - explicit_exceptions[ai]:
+            warnings.warn('Detected incomplete exceptions. Not supported.',
+                          OpenMMWarning)
+            struct.unknown_functional = True

--- a/chemistry/openmm/topsystem.py
+++ b/chemistry/openmm/topsystem.py
@@ -82,17 +82,12 @@ def load_topology(topology, system=None):
     for a1, a2 in topology.bonds():
         struct.bonds.append(Bond(atommap[a1], atommap[a2]))
 
-    if hasattr(topology, 'getPeriodicBoxVectors'):
-        vectors = topology.getPeriodicBoxVectors()
-        if vectors is not None:
-            leng, ang = box_vectors_to_lengths_and_angles(*vectors)
-            leng = leng.value_in_unit(u.angstroms)
-            ang = ang.value_in_unit(u.degrees)
-            struct.box = [leng[0], leng[1], leng[2], ang[0], ang[1], ang[2]]
-    else:
-        lengths = topology.getUnitCellDimensions()
-        if lengths is not None:
-            struct.box = [lengths[0], lengths[1], lengths[2], 90.0, 90.0, 90.0]
+    vectors = topology.getPeriodicBoxVectors()
+    if vectors is not None:
+        leng, ang = box_vectors_to_lengths_and_angles(*vectors)
+        leng = leng.value_in_unit(u.angstroms)
+        ang = ang.value_in_unit(u.degrees)
+        struct.box = [leng[0], leng[1], leng[2], ang[0], ang[1], ang[2]]
 
     if struct.box is not None:
         struct.box = create_array(struct.box)
@@ -111,12 +106,7 @@ def load_topology(topology, system=None):
                       mm.MonteCarloMembraneBarostat, mm.CustomExternalForce,
                       mm.GBSAOBCForce, mm.CustomGBForce)
 
-    if hasattr(system, 'usesPeriodicBoundaryConditions'):
-        get_vectors = system.usesPeriodicBoundaryConditions()
-    else:
-        get_vectors = struct.box is not None
-
-    if get_vectors:
+    if system.usesPeriodicBoundaryConditions():
         vectors = system.getDefaultPeriodicBoxVectors()
         leng, ang = box_vectors_to_lengths_and_angles(*vectors)
         leng = leng.value_in_unit(u.angstroms)

--- a/chemistry/structure.py
+++ b/chemistry/structure.py
@@ -30,16 +30,15 @@ from chemistry.geometry import (box_lengths_and_angles_to_vectors,
         box_vectors_to_lengths_and_angles)
 from chemistry.residue import WATER_NAMES
 from chemistry.topologyobjects import (AtomList, ResidueList, TrackedList,
-        AngleType, DihedralType, DihedralTypeList, BondType, ImproperType,
-        CmapType, OutOfPlaneBendType, StretchBendType, TorsionTorsionType,
-        Bond, Angle, Dihedral, UreyBradley, Improper, Cmap, TrigonalAngle,
-        OutOfPlaneBend, PiTorsion, StretchBend, TorsionTorsion, ChiralFrame,
-        MultipoleFrame, NonbondedException, AcceptorDonor, Group, Atom,
-        ExtraPoint, TwoParticleExtraPointFrame, ThreeParticleExtraPointFrame,
-        OutOfPlaneExtraPointFrame, RBTorsionType)
+        DihedralTypeList, Bond, Angle, Dihedral, UreyBradley, Improper, Cmap,
+        TrigonalAngle, OutOfPlaneBend, PiTorsion, StretchBend, TorsionTorsion,
+        NonbondedException, AcceptorDonor, Group, Atom, ExtraPoint,
+        TwoParticleExtraPointFrame, ChiralFrame, MultipoleFrame,
+        ThreeParticleExtraPointFrame, OutOfPlaneExtraPointFrame)
 from chemistry import unit as u
 from chemistry.utils import tag_molecules
-from chemistry.utils.six import string_types, wraps, integer_types, iteritems
+from chemistry.utils.decorators import needs_openmm
+from chemistry.utils.six import string_types, integer_types, iteritems
 from chemistry.utils.six.moves import zip, range
 from chemistry.vec3 import Vec3
 from copy import copy
@@ -68,14 +67,6 @@ try:
         reducePeriodicBoxVectors = None
 except ImportError:
     app = mm = None
-
-def needs_openmm(func):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        if app is None or mm is None:
-            raise ImportError('Could not find OpenMM Python bindings')
-        return func(*args, **kwargs)
-    return wrapped
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -2187,7 +2178,7 @@ class Structure(object):
             for c1 in atom.children:
                 force.addException(c1.idx, a2.idx, 0.0, 0.5, 0.0, True)
             for c2 in a2.children:
-                force.addException(angle.atom1.idx, c2.idx, 0.0, 0.5, 0.0, True)
+                force.addException(atom.idx, c2.idx, 0.0, 0.5, 0.0, True)
             for c1 in atom.children:
                 for c2 in a2.children:
                     force.addException(c1.idx, c2.idx, 0.0, 0.5, 0.0, True)

--- a/chemistry/structure.py
+++ b/chemistry/structure.py
@@ -60,11 +60,7 @@ except ImportError:
 try:
     from simtk.openmm import app
     from simtk import openmm as mm
-    try:
-        from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
-    except ImportError:
-        # OpenMM version is too old... only orthorhombic cells supported
-        reducePeriodicBoxVectors = None
+    from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
 except ImportError:
     app = mm = None
 
@@ -1338,14 +1334,11 @@ class Structure(object):
             top.addBond(atoms[bond.atom1.idx], atoms[bond.atom2.idx])
         # Set the unit cell dimensions
         if self.box is not None:
-            if reducePeriodicBoxVectors is None:
-                top.setUnitCellDimensions(self.box[:3]*u.angstroms)
-            else:
-                top.setPeriodicBoxVectors(
-                        reducePeriodicBoxVectors(
-                            box_lengths_and_angles_to_vectors(*self.box)
-                        )
-                )
+            top.setPeriodicBoxVectors(
+                    reducePeriodicBoxVectors(
+                        box_lengths_and_angles_to_vectors(*self.box)
+                    )
+            )
         return top
 
     #===================================================
@@ -1634,16 +1627,9 @@ class Structure(object):
         if removeCMMotion:
             system.addForce(mm.CMMotionRemover())
         if self.box is not None:
-            if reducePeriodicBoxVectors is None:
-                # This version of OpenMM does *not* support triclinics
-                if self.box[3] != 90 or self.box[4] != 90 or self.box[5] != 90:
-                    raise ValueError('OpenMM version %s only supports '
-                                     'orthorhombic unit cells' % mm.__version__)
-                system.setDefaultPeriodicBoxVectors(*self.box_vectors)
-            else:
-                system.setDefaultPeriodicBoxVectors(
-                        *reducePeriodicBoxVectors(self.box_vectors)
-                )
+            system.setDefaultPeriodicBoxVectors(
+                    *reducePeriodicBoxVectors(self.box_vectors)
+            )
         self.omm_set_virtual_sites(system)
         return system
 

--- a/chemistry/utils/decorators.py
+++ b/chemistry/utils/decorators.py
@@ -1,0 +1,22 @@
+""" A list of helpful decorators for use throughout ParmEd """
+
+__all__ = ['needs_openmm']
+
+from chemistry.utils.six import wraps
+try:
+    import simtk.openmm as mm
+    HAS_OPENMM = True
+    del mm
+except ImportError:
+    HAS_OPENMM = False
+
+def needs_openmm(fcn):
+    global HAS_OPENMM
+    @wraps(fcn)
+    def new_fcn(*args, **kwargs):
+        if not HAS_OPENMM:
+            raise ImportError('Could not find or import OpenMM')
+        return fcn(*args, **kwargs)
+
+    return new_fcn
+

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -16,7 +16,7 @@ conda config --add channels http://conda.binstar.org/omnia
 
 if [ -z "$NO_NUMPY" ]; then
     conda create -y -n myenv python=$PYTHON_VERSION \
-        numpy scipy netcdf4 pandas nose openmm
+        numpy scipy netcdf4 pandas nose openmm-dev
 else
     # Do not install the full numpy/scipy stack
     conda create -y -n myenv python=$PYTHON_VERSION nose

--- a/test/test_openmm_amber.py
+++ b/test/test_openmm_amber.py
@@ -12,6 +12,7 @@ except ImportError:
     has_openmm = False
 
 from chemistry.amber import AmberParm, ChamberParm, Rst7
+from chemistry.openmm import load_topology
 import chemistry.unit as u
 from chemistry.utils.six.moves import range, zip
 from copy import copy
@@ -23,13 +24,7 @@ import utils
 get_fn = utils.get_fn
 
 if has_openmm:
-    # Make sure all precisions are double
-    for i in range(mm.Platform.getNumPlatforms()):
-        plat = mm.Platform.getPlatform(i)
-        if plat.getName() == 'CUDA':
-            plat.setPropertyDefaultValue('CudaPrecision', 'double')
-        if plat.getName() == 'OpenCL':
-            plat.setPropertyDefaultValue('OpenCLPrecision', 'double')
+    CPU = mm.Platform.getPlatformByName('CPU')
 
 
 # OpenMM NonbondedForce methods are enumerated values. From NonbondedForce.h,
@@ -87,7 +82,7 @@ class TestAmberParm(utils.TestCaseRelative):
                                    rigidWater=True,
                                    flexibleConstraints=False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 # Etot   =     -1756.2018  EKtot   =       376.7454  EPtot      =     -2132.9472
@@ -121,6 +116,25 @@ class TestAmberParm(utils.TestCaseRelative):
                 else:
                     self.assertAlmostEqual(x1, x2, delta=2e-2)
 
+    def testRoundTripEP(self):
+        """ Test ParmEd -> OpenMM round trip with Amber EPs and PME """
+        parm = AmberParm(get_fn('tip4p.parm7'), get_fn('tip4p.rst7'))
+        system = parm.createSystem(nonbondedMethod=app.PME,
+                                   nonbondedCutoff=8*u.angstroms,
+                                   constraints=app.HBonds,
+                                   rigidWater=True,
+                                   flexibleConstraints=False)
+        system2 = load_topology(parm.topology, system).createSystem(
+                                    nonbondedMethod=app.PME,
+                                    nonbondedCutoff=8*u.angstroms,
+                                    constraints=app.HBonds,
+                                    rigidWater=True,
+                                    flexibleConstraints=False)
+        con1 = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
+        con2 = mm.Context(system2, mm.VerletIntegrator(0.001), CPU)
+        e1 = decomposed_energy(con1, parm)
+        e2 = decomposed_energy(con2, parm)
+
     def testEPEnergy2(self):
         """ Tests AmberParm handling of extra points in TIP5P water """
         parm = AmberParm(get_fn('tip5p.parm7'), get_fn('tip5p.rst7'))
@@ -130,7 +144,7 @@ class TestAmberParm(utils.TestCaseRelative):
                                    rigidWater=True,
                                    flexibleConstraints=False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 0)
@@ -169,7 +183,7 @@ class TestAmberParm(utils.TestCaseRelative):
         parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
         system = parm.createSystem() # Default, no cutoff
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -183,12 +197,28 @@ class TestAmberParm(utils.TestCaseRelative):
         self.assertRelativeEqual(energies['dihedral'], 24.3697, places=4)
         self.assertRelativeEqual(energies['nonbond'], -30.2355, places=3)
 
+    def testRoundTrip(self):
+        """ Test ParmEd -> OpenMM round trip with Amber gas phase """
+        parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
+        system = parm.createSystem()
+        system2 = load_topology(parm.topology, system).createSystem()
+        con1 = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
+        con2 = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
+        con1.setPositions(parm.positions)
+        con2.setPositions(parm.positions)
+        e1 = decomposed_energy(con1, parm)
+        e2 = decomposed_energy(con2, parm)
+        self.assertAlmostEqual(e1['bond'], e2['bond'])
+        self.assertAlmostEqual(e1['angle'], e2['angle'])
+        self.assertAlmostEqual(e1['dihedral'], e2['dihedral'])
+        self.assertAlmostEqual(e1['nonbond'], e2['nonbond'])
+
     def testGB1Energy(self): # HCT (igb=1)
         """ Compare Amber and OpenMM GB (igb=1) energies (w/ and w/out salt) """
         parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
         system = parm.createSystem(implicitSolvent=app.HCT)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -203,7 +233,7 @@ class TestAmberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.HCT,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -221,7 +251,7 @@ class TestAmberParm(utils.TestCaseRelative):
         parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
         system = parm.createSystem(implicitSolvent=app.OBC1)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -236,7 +266,7 @@ class TestAmberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.OBC1,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -254,7 +284,7 @@ class TestAmberParm(utils.TestCaseRelative):
         parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
         system = parm.createSystem(implicitSolvent=app.OBC2)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -269,7 +299,7 @@ class TestAmberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.OBC2,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -289,7 +319,7 @@ class TestAmberParm(utils.TestCaseRelative):
         PT.loadRestrt(parm, get_fn('ash.rst7')).execute() # Load crds into copy
         system = parm.createSystem(implicitSolvent=app.GBn)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -304,7 +334,7 @@ class TestAmberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.GBn,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -324,7 +354,7 @@ class TestAmberParm(utils.TestCaseRelative):
         PT.loadRestrt(parm, get_fn('ash.rst7')).execute() # Load crds into copy
         system = parm.createSystem(implicitSolvent=app.GBn2)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -339,7 +369,7 @@ class TestAmberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.GBn2,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -357,7 +387,7 @@ class TestAmberParm(utils.TestCaseRelative):
         parm = AmberParm(get_fn('ash.parm7'), get_fn('ash.rst7'))
         system = parm.createSystem() # Default, no cutoff
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(Rst7.open(get_fn('ash.rst7')).positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -379,7 +409,7 @@ class TestAmberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =     250.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -400,7 +430,7 @@ class TestAmberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =     250.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -424,7 +454,7 @@ class TestAmberParm(utils.TestCaseRelative):
             if isinstance(force, mm.NonbondedForce):
                 force.setUseDispersionCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =     250.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -447,7 +477,7 @@ class TestAmberParm(utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before
@@ -473,7 +503,7 @@ class TestAmberParm(utils.TestCaseRelative):
                 self.assertTrue(force.getUseLongRangeCorrection())
                 force.setUseLongRangeCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =   193.6
@@ -497,7 +527,7 @@ class TestAmberParm(utils.TestCaseRelative):
                 self.assertTrue(force.getUseLongRangeCorrection())
                 force.setUseLongRangeCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 26.3947079, places=3)
@@ -514,7 +544,7 @@ class TestAmberParm(utils.TestCaseRelative):
             if isinstance(force, mm.CustomNonbondedForce):
                 self.assertTrue(force.getUseLongRangeCorrection())
         integrator = mm.VerletIntegrator(1*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 0.9675961, places=3)
@@ -771,7 +801,7 @@ class TestChamberParm(utils.TestCaseRelative):
                            get_fn('ala_ala_ala.rst7'))
         system = parm.createSystem() # Default, no cutoff
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -795,7 +825,7 @@ class TestChamberParm(utils.TestCaseRelative):
                            get_fn('ala_ala_ala.rst7'))
         system = parm.createSystem(implicitSolvent=app.HCT)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -814,7 +844,7 @@ class TestChamberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.HCT,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -837,7 +867,7 @@ class TestChamberParm(utils.TestCaseRelative):
                            get_fn('ala_ala_ala.rst7'))
         system = parm.createSystem(implicitSolvent=app.OBC1)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -856,7 +886,7 @@ class TestChamberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.OBC1,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -879,7 +909,7 @@ class TestChamberParm(utils.TestCaseRelative):
                            get_fn('ala_ala_ala.rst7'))
         system = parm.createSystem(implicitSolvent=app.OBC2)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -898,7 +928,7 @@ class TestChamberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.OBC2,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -923,7 +953,7 @@ class TestChamberParm(utils.TestCaseRelative):
         PT.loadRestrt(parm, get_fn('ala_ala_ala.rst7')).execute()
         system = parm.createSystem(implicitSolvent=app.GBn)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -942,7 +972,7 @@ class TestChamberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.GBn,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -967,7 +997,7 @@ class TestChamberParm(utils.TestCaseRelative):
         PT.loadRestrt(parm, get_fn('ala_ala_ala.rst7')).execute()
         system = parm.createSystem(implicitSolvent=app.GBn2)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -986,7 +1016,7 @@ class TestChamberParm(utils.TestCaseRelative):
         system = parm.createSystem(implicitSolvent=app.GBn2,
                                    implicitSolventSaltConc=1.0*u.molar)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -1009,7 +1039,7 @@ class TestChamberParm(utils.TestCaseRelative):
                            get_fn('ala_ala_ala.rst7'))
         system = parm.createSystem() # Default, no cutoff
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         rst = Rst7.open(get_fn('ala_ala_ala.rst7')).positions
         sim.context.setPositions(rst)
         energies = decomposed_energy(sim.context, parm)
@@ -1035,7 +1065,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #Bond         =            1.1324222     Angle        =            1.0688008
@@ -1063,7 +1093,7 @@ class TestChamberParm(utils.TestCaseRelative):
             elif isinstance(force, mm.CustomNonbondedForce):
                 force.setUseLongRangeCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #Bond         =            1.1324222     Angle        =            1.0688008
@@ -1088,7 +1118,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before
@@ -1112,7 +1142,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -1142,7 +1172,7 @@ class TestChamberParm(utils.TestCaseRelative):
             if isinstance(force, mm.NonbondedForce):
                 force.setUseDispersionCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -1171,7 +1201,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before

--- a/test/test_openmm_charmm.py
+++ b/test/test_openmm_charmm.py
@@ -32,7 +32,7 @@ from chemistry.amber.readparm import Rst7
 from chemistry.charmm import (CharmmPsfFile, CharmmCrdFile, CharmmRstFile,
                               CharmmParameterSet)
 from chemistry.exceptions import CharmmPSFWarning
-from chemistry import unit as u
+from chemistry import unit as u, openmm
 from chemistry.utils.six.moves import range
 from copy import copy
 from math import sqrt
@@ -60,237 +60,7 @@ if has_openmm:
     param36 = CharmmParameterSet(get_fn('par_all36_prot.prm'),
                                  get_fn('toppar_water_ions.str'))
 
-    # Make sure all precisions are double
-    for i in range(mm.Platform.getNumPlatforms()):
-        plat = mm.Platform.getPlatform(i)
-        if plat.getName() == 'CUDA':
-            plat.setPropertyDefaultValue('CudaPrecision', 'double')
-        if plat.getName() == 'OpenCL':
-            plat.setPropertyDefaultValue('OpenCLPrecision', 'double')
-
-@unittest.skipIf(not has_openmm, "Cannot test without OpenMM")
-class TestCharmmFiles(utils.TestCaseRelative):
-
-    def setUp(self):
-        if charmm_solv.box is None:
-            charmm_solv.box = [95.387, 80.381, 80.225, 90, 90, 90]
-        if charmm_nbfix.box is None:
-            charmm_nbfix.box = [3.271195e1, 3.299596e1, 3.300715e1, 90, 90, 90]
-
-    def testGasEnergy(self):
-        """ Compare OpenMM and CHARMM gas phase energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=4)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=4)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=4)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=4)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=4)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=4)
-        self.assertRelativeEqual(energies['nonbond'], 9.2210, places=4)
-
-    def testGB1Energy(self): # HCT (uses mbondi radii internally)
-        """ Compare OpenMM and CHARMM GB (igb=1) energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22, implicitSolvent=app.HCT)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -102.1598379, places=5)
-        system = parm.createSystem(param22, implicitSolvent=app.HCT,
-                                   implicitSolventSaltConc=1.0*u.molar)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -102.5012873, places=5)
-
-    def testGB2Energy(self): # OBC1 (uses mbondi2 radii internally)
-        """ Compare OpenMM and CHARMM GB (igb=2) energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22, implicitSolvent=app.OBC1)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -107.8675, places=4)
-        system = parm.createSystem(param22, implicitSolvent=app.OBC1,
-                                   implicitSolventSaltConc=1.0*u.molar)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -108.2129, places=4)
-
-    def testGB5Energy(self): # OBC2 (uses mbondi2 radii internally)
-        """ Compare OpenMM and CHARMM GB (igb=5) energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22, implicitSolvent=app.OBC2)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -103.6186, places=4)
-        system = parm.createSystem(param22, implicitSolvent=app.OBC2,
-                                   implicitSolventSaltConc=1.0*u.molar)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -103.9603, places=4)
-
-    def testGB7Energy(self): # GBn (uses bondi radii internally)
-        """ Compare OpenMM and CHARMM GB (igb=7) energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22, implicitSolvent=app.GBn)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -109.4987850, places=5)
-        system = parm.createSystem(param22, implicitSolvent=app.GBn,
-                                   implicitSolventSaltConc=1.0*u.molar)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -109.8465917, places=5)
-
-    def testGB8Energy(self): # GBn2 (uses mbondi3 radii internally)
-        """ Compare OpenMM and CHARMM GB (igb=8) energies """
-        parm = charmm_gas
-        system = parm.createSystem(param22, implicitSolvent=app.GBn2)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -108.1396, places=4)
-        system = parm.createSystem(param22, implicitSolvent=app.GBn2,
-                                   implicitSolventSaltConc=1.0*u.molar)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_gas_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
-        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
-        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
-        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
-        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
-        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
-        self.assertRelativeEqual(energies['nonbond'], -108.4858, places=4)
-
-    def testPME(self):
-        """ Compare OpenMM and CHARMM PME energies """
-        parm = charmm_solv
-        system = parm.createSystem(param22, nonbondedMethod=app.PME,
-                                   nonbondedCutoff=8*u.angstrom)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_solv_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
-        self.assertRelativeEqual(energies['angle'], 5018.3206306, places=5)
-        self.assertRelativeEqual(energies['urey'], 29.6489539, places=5)
-        self.assertRelativeEqual(energies['dihedral'], 740.9486106, places=5)
-        self.assertRelativeEqual(energies['improper'], 14.2418054, places=5)
-        self.assertRelativeEqual(energies['cmap'], -216.1422183, places=5)
-        self.assertRelativeEqual(energies['nonbond'], -242262.368372, places=5)
-
-    def testDispersionCorrection(self):
-        """ Compare OpenMM and CHARMM PME energies w/out vdW correction """
-        parm = charmm_solv
-        system = parm.createSystem(param22, nonbondedMethod=app.PME,
-                                   nonbondedCutoff=8*u.angstroms,)
-        for force in system.getForces():
-            if isinstance(force, mm.NonbondedForce):
-                force.setUseDispersionCorrection(False)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_solv_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
-        self.assertRelativeEqual(energies['angle'], 5018.3206306, places=5)
-        self.assertRelativeEqual(energies['urey'], 29.6489539, places=5)
-        self.assertRelativeEqual(energies['dihedral'], 740.9486106, places=5)
-        self.assertRelativeEqual(energies['improper'], 14.2418054, places=5)
-        self.assertRelativeEqual(energies['cmap'], -216.1422183, places=5)
-        self.assertRelativeEqual(energies['nonbond'], -240681.958902, places=5)
-
-    def testNBFIX(self):
-        """ Test energies of systems with NBFIX modifications """
-        parm = charmm_nbfix
-        system = parm.createSystem(param36, nonbondedMethod=app.PME,
-                                   nonbondedCutoff=8*u.angstroms)
-        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=mm.Platform.getPlatformByName('CPU'))
-        sim.context.setPositions(charmm_nbfix_crds.positions)
-        energies = decomposed_energy(sim.context, parm)
-        self.assertAlmostEqual(energies['bond'], 1.1324212, places=4)
-        self.assertAlmostEqual(energies['angle'], 1.06880188, places=4)
-        self.assertAlmostEqual(energies['urey'], 0.06142407, places=4)
-        self.assertAlmostEqual(energies['dihedral'], 7.81143025, places=4)
-        self.assertAlmostEqual(energies['improper'], 0, places=4)
-        self.assertAlmostEqual(energies['cmap'], 0.126790, places=4)
-        self.assertRelativeEqual(energies['nonbond'], 6514.283116, places=4)
+    CPU = mm.Platform.getPlatformByName('CPU')
 
 def decomposed_energy(context, parm, NRG_UNIT=u.kilocalories_per_mole):
     """ Gets a decomposed energy for a given system """
@@ -312,6 +82,249 @@ def decomposed_energy(context, parm, NRG_UNIT=u.kilocalories_per_mole):
     s = context.getState(getEnergy=True, groups=1<<parm.CMAP_FORCE_GROUP)
     energies['cmap'] = s.getPotentialEnergy().value_in_unit(NRG_UNIT)
     return energies
+
+@unittest.skipIf(not has_openmm, "Cannot test without OpenMM")
+class TestCharmmFiles(utils.TestCaseRelative):
+
+    def setUp(self):
+        if charmm_solv.box is None:
+            charmm_solv.box = [95.387, 80.381, 80.225, 90, 90, 90]
+        if charmm_nbfix.box is None:
+            charmm_nbfix.box = [3.271195e1, 3.299596e1, 3.300715e1, 90, 90, 90]
+
+    def testGasEnergy(self):
+        """ Compare OpenMM and CHARMM gas phase energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=4)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=4)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=4)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=4)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=4)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=4)
+        self.assertRelativeEqual(energies['nonbond'], 9.2210, places=4)
+
+    def testRoundTrip(self):
+        """ Test ParmEd -> OpenMM round trip with CHARMM gas phase """
+        parm = charmm_gas
+        system = parm.createSystem(param22)
+        system2 = openmm.load_topology(parm.topology, system).createSystem()
+        con1 = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
+        con2 = mm.Context(system2, mm.VerletIntegrator(0.001), CPU)
+        con1.setPositions(charmm_gas_crds.positions)
+        con2.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(con1, parm)
+        energies2 = decomposed_energy(con2, parm)
+        self.assertAlmostEqual(energies['bond'], energies2['bond'])
+        self.assertAlmostEqual(energies['angle'], energies2['angle'])
+        self.assertAlmostEqual(energies['urey'], energies2['urey'])
+        self.assertAlmostEqual(energies['dihedral'], energies2['dihedral'])
+        self.assertAlmostEqual(energies['improper'], energies2['improper'])
+        self.assertAlmostEqual(energies['cmap'], energies2['cmap'])
+        self.assertRelativeEqual(energies['nonbond'], energies2['nonbond'])
+
+    def testGB1Energy(self): # HCT (uses mbondi radii internally)
+        """ Compare OpenMM and CHARMM GB (igb=1) energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22, implicitSolvent=app.HCT)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -102.1598379, places=5)
+        system = parm.createSystem(param22, implicitSolvent=app.HCT,
+                                   implicitSolventSaltConc=1.0*u.molar)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -102.5012873, places=5)
+
+    def testGB2Energy(self): # OBC1 (uses mbondi2 radii internally)
+        """ Compare OpenMM and CHARMM GB (igb=2) energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22, implicitSolvent=app.OBC1)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -107.8675, places=4)
+        system = parm.createSystem(param22, implicitSolvent=app.OBC1,
+                                   implicitSolventSaltConc=1.0*u.molar)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -108.2129, places=4)
+
+    def testGB5Energy(self): # OBC2 (uses mbondi2 radii internally)
+        """ Compare OpenMM and CHARMM GB (igb=5) energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22, implicitSolvent=app.OBC2)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -103.6186, places=4)
+        system = parm.createSystem(param22, implicitSolvent=app.OBC2,
+                                   implicitSolventSaltConc=1.0*u.molar)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -103.9603, places=4)
+
+    def testGB7Energy(self): # GBn (uses bondi radii internally)
+        """ Compare OpenMM and CHARMM GB (igb=7) energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22, implicitSolvent=app.GBn)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -109.4987850, places=5)
+        system = parm.createSystem(param22, implicitSolvent=app.GBn,
+                                   implicitSolventSaltConc=1.0*u.molar)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -109.8465917, places=5)
+
+    def testGB8Energy(self): # GBn2 (uses mbondi3 radii internally)
+        """ Compare OpenMM and CHARMM GB (igb=8) energies """
+        parm = charmm_gas
+        system = parm.createSystem(param22, implicitSolvent=app.GBn2)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -108.1396, places=4)
+        system = parm.createSystem(param22, implicitSolvent=app.GBn2,
+                                   implicitSolventSaltConc=1.0*u.molar)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_gas_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.3351, places=3)
+        self.assertAlmostEqual(energies['angle'], 14.1158, places=3)
+        self.assertAlmostEqual(energies['urey'], 0.3669, places=3)
+        self.assertAlmostEqual(energies['dihedral'], 14.2773, places=3)
+        self.assertAlmostEqual(energies['improper'], 0.3344, places=3)
+        self.assertAlmostEqual(energies['cmap'], -0.5239, places=3)
+        self.assertRelativeEqual(energies['nonbond'], -108.4858, places=4)
+
+    def testPME(self):
+        """ Compare OpenMM and CHARMM PME energies """
+        parm = charmm_solv
+        system = parm.createSystem(param22, nonbondedMethod=app.PME,
+                                   nonbondedCutoff=8*u.angstrom)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_solv_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
+        self.assertRelativeEqual(energies['angle'], 5018.3206306, places=5)
+        self.assertRelativeEqual(energies['urey'], 29.6489539, places=5)
+        self.assertRelativeEqual(energies['dihedral'], 740.9486106, places=5)
+        self.assertRelativeEqual(energies['improper'], 14.2418054, places=5)
+        self.assertRelativeEqual(energies['cmap'], -216.1422183, places=5)
+        self.assertRelativeEqual(energies['nonbond'], -242262.368372, places=5)
+
+    def testDispersionCorrection(self):
+        """ Compare OpenMM and CHARMM PME energies w/out vdW correction """
+        parm = charmm_solv
+        system = parm.createSystem(param22, nonbondedMethod=app.PME,
+                                   nonbondedCutoff=8*u.angstroms,)
+        for force in system.getForces():
+            if isinstance(force, mm.NonbondedForce):
+                force.setUseDispersionCorrection(False)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_solv_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
+        self.assertRelativeEqual(energies['angle'], 5018.3206306, places=5)
+        self.assertRelativeEqual(energies['urey'], 29.6489539, places=5)
+        self.assertRelativeEqual(energies['dihedral'], 740.9486106, places=5)
+        self.assertRelativeEqual(energies['improper'], 14.2418054, places=5)
+        self.assertRelativeEqual(energies['cmap'], -216.1422183, places=5)
+        self.assertRelativeEqual(energies['nonbond'], -240681.958902, places=5)
+
+    def testNBFIX(self):
+        """ Test energies of systems with NBFIX modifications """
+        parm = charmm_nbfix
+        system = parm.createSystem(param36, nonbondedMethod=app.PME,
+                                   nonbondedCutoff=8*u.angstroms)
+        integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
+        sim.context.setPositions(charmm_nbfix_crds.positions)
+        energies = decomposed_energy(sim.context, parm)
+        self.assertAlmostEqual(energies['bond'], 1.1324212, places=4)
+        self.assertAlmostEqual(energies['angle'], 1.06880188, places=4)
+        self.assertAlmostEqual(energies['urey'], 0.06142407, places=4)
+        self.assertAlmostEqual(energies['dihedral'], 7.81143025, places=4)
+        self.assertAlmostEqual(energies['improper'], 0, places=4)
+        self.assertAlmostEqual(energies['cmap'], 0.126790, places=4)
+        self.assertRelativeEqual(energies['nonbond'], 6514.283116, places=4)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds support for loading a Structure from an OpenMM `Topology` instance, optionally filling in parameters from a populated `System` object.

Round-tripping (i.e., Amber files -> ParmEd -> OpenMM -> ParmEd -> OpenMM) gives identical forces and energies for the standard Amber potential terms (still need to check CHARMM and Gromacs tests).  Among other things, this allows you to convert an OpenMM Topology/System combo into an Amber prmtop file.

Still needed:

- [x] Round-trip tests for CHARMM FF systems
- [x] Round-trip tests for Gromacs systems (using R-B torsions)
- [x] Format conversion tests (OpenMM -> Amber, OpenMM -> Gromacs)
- [x] Accept a system XML file name instead of a System object.