### PR TITLE
Properly recognize OMM versions that are too old.

### DIFF
--- a/parmed/utils/decorators.py
+++ b/parmed/utils/decorators.py
@@ -5,8 +5,14 @@ __all__ = ['needs_openmm']
 from parmed.utils.six import wraps
 try:
     import simtk.openmm as mm
+    import simtk.openmm.app as app
     HAS_OPENMM = True
-    del mm
+    try:
+        from simtk.openmm.app.internal import unitcell
+    except ImportError:
+        SUPPORTED_VERSION = False
+    else:
+        SUPPORTED_VERSION = True
 except ImportError:
     HAS_OPENMM = False
 
@@ -16,6 +22,8 @@ def needs_openmm(fcn):
     def new_fcn(*args, **kwargs):
         if not HAS_OPENMM:
             raise ImportError('Could not find or import OpenMM')
+        if not SUPPORTED_VERSION:
+            raise ImportError('You must have at least OpenMM 6.3 installed')
         return fcn(*args, **kwargs)
 
     return new_fcn


### PR DESCRIPTION
Gives a helpful error message if OMM is available, but is too old to work with ParmEd.