### PR TITLE
Remove a keyword argument that was causing DihedralType() to crash

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -83,8 +83,7 @@ class _DihedralTerm(object):
             self.type = dihedraltype
         else:
             self.type = DihedralType(pk / self.idivf, float(periodicity),
-                                    float(phase), float(scee), float(scnb),
-                                    improper=improper)
+                                     float(phase), float(scee), float(scnb))
 
     def parmline(self, multiterm=False):
         if self.dihtype == 'improper' or not multiterm:


### PR DESCRIPTION
Hi Jason,

In creating the .frcmod object, I ran into the following error message:

```
leeping@not0rious:~/projects/VSP27-Protein/XMLConvert$ ./oxml-aprm.py Checked/a99sc-v2-r1/a99sc-v2-r1.xml
Traceback (most recent call last):
  File "./oxml-aprm.py", line 124, in <module>
    parameters._DihedralTerm(pk=k, phase=f, periodicity=p, dihtype=dtyp))
  File "/home/leeping/local/lib/python2.7/site-packages/parmed/amber/parameters.py", line 87, in __init__
    improper=improper)
TypeError: __init__() got an unexpected keyword argument 'improper'
```

It turns out that `DihedralType` doesn't take an "improper" argument although `Dihedral` does.  I believe that deleting the keyword argument in `amber/parameters.py` doesn't have any ill effects.  Can you confirm this?

Thanks,

- Lee-Ping
