### PR TITLE
Improve performance of Amber topology file parsing

### DIFF
--- a/parmed/periodic_table.py
+++ b/parmed/periodic_table.py
@@ -6,7 +6,6 @@ by the element's symbol. For consistency with AMBER, a fictitious element
 or any other meaningful attribute. It's just a container to put an extra 
 charge 
 """
-from collections import OrderedDict
 from parmed.utils.six import iteritems
 
 # Data descriptions:

--- a/parmed/periodic_table.py
+++ b/parmed/periodic_table.py
@@ -227,12 +227,7 @@ Phase = { 'H'  : 'Gas'          ,'He' : 'Gas'          ,'Li' : 'Solid'        ,
           'LP' : 'N/A'          ,'Lp' : 'N/A'
 }
 
-# Have a set of sorted masses so we can optimize element_by_mass
-tmp = sorted(list(Mass.items()), key=lambda x: x[1])
-_sorted_masses = OrderedDict()
-for _, __ in tmp:
-    _sorted_masses[_] = __
-del _, __, tmp
+_sorted_masses = sorted(Mass.items(), key=lambda x: x[1])
 
 def element_by_mass(mass):
     """
@@ -255,10 +250,10 @@ def element_by_mass(mass):
     masses have changed -- particularly in the case of Hydrogen mass
     repartitioning.
     """
-    diff = mass
+    diff = mass + 1
     best_guess = 'EP'
 
-    for element, element_mass in iteritems(_sorted_masses):
+    for element, element_mass in _sorted_masses:
         d = abs(element_mass - mass)
         if d < diff:
             best_guess = element

--- a/parmed/periodic_table.py
+++ b/parmed/periodic_table.py
@@ -6,8 +6,6 @@ by the element's symbol. For consistency with AMBER, a fictitious element
 or any other meaningful attribute. It's just a container to put an extra 
 charge 
 """
-from parmed.utils.six import iteritems
-
 # Data descriptions:
 #
 #  KNOWN_ELEMENTS: number of known elements

--- a/parmed/periodic_table.py
+++ b/parmed/periodic_table.py
@@ -6,6 +6,8 @@ by the element's symbol. For consistency with AMBER, a fictitious element
 or any other meaningful attribute. It's just a container to put an extra 
 charge 
 """
+from collections import OrderedDict
+from parmed.utils.six import iteritems
 
 # Data descriptions:
 #
@@ -225,6 +227,13 @@ Phase = { 'H'  : 'Gas'          ,'He' : 'Gas'          ,'Li' : 'Solid'        ,
           'LP' : 'N/A'          ,'Lp' : 'N/A'
 }
 
+# Have a set of sorted masses so we can optimize element_by_mass
+tmp = sorted(list(Mass.items()), key=lambda x: x[1])
+_sorted_masses = OrderedDict()
+for _, __ in tmp:
+    _sorted_masses[_] = __
+del _, __, tmp
+
 def element_by_mass(mass):
     """
     Determine the element that has a mass closest to the input mass
@@ -249,10 +258,13 @@ def element_by_mass(mass):
     diff = mass
     best_guess = 'EP'
 
-    for element in Element:
-        if abs(Mass[element] - mass) < diff:
+    for element, element_mass in iteritems(_sorted_masses):
+        d = abs(element_mass - mass)
+        if d < diff:
             best_guess = element
-            diff = abs(Mass[element] - mass)
+            diff = d
+        else:
+            break
 
     return best_guess
 


### PR DESCRIPTION
Profiling Amber topology file reading for dhfr_cmap_pbc.parm7 yielded the following report:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    56057    1.608    0.000    2.054    0.000 periodic_table.py:228(element_by_mass)
    56057    1.206    0.000    1.380    0.000 topologyobjects.py:433(__init__)
  6872938    0.447    0.000    0.447    0.000 {abs}
        1    0.395    0.395    0.395    0.395 {parmed.amber._rdparm.rdparm}
        1    0.375    0.375    0.804    0.804 _amberparm.py:1430(_load_bond_info)
        1    0.290    0.290    2.659    2.659 _amberparm.py:471(load_atom_info)
        1    0.248    0.248    2.090    2.090 _amberparm.py:1346(_load_atoms_and_residues)
```

Determining element by mass is the most expensive operation, since it loops through every element to pull out the best match.  This PR removes the cost of this function almost completely by comparing the masses with a sorted list of atomic masses and bailing out as soon as one mass is farther from the target than the one before it.  Since ~1/2 of the atoms are hydrogen and the remainder are almost always C, N, or O for most systems, this reduces the time spent in `element_by_mass` substantially, as indicated by the new profiler output:

```
   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    56057    1.172    0.000    1.329    0.000 topologyobjects.py:433(__init__)
        1    0.379    0.379    0.379    0.379 {parmed.amber._rdparm.rdparm}
        1    0.347    0.347    0.735    0.735 _amberparm.py:1430(_load_bond_info)
        1    0.267    0.267    0.590    0.590 _amberparm.py:471(load_atom_info)
   358403    0.198    0.000    0.198    0.000 {hasattr}
   358393    0.174    0.000    0.372    0.000 topologyobjects.py:3981(__getitem__)
    56057    0.141    0.000    0.302    0.000 topologyobjects.py:4034(add_atom)
        1    0.132    0.132    0.132    0.132 _amberparm.py:1385(_load_extra_exclusions)
    56057    0.120    0.000    0.133    0.000 topologyobjects.py:4487(__init__)
        1    0.101    0.101    1.846    1.846 _amberparm.py:1346(_load_atoms_and_residues)
   449320    0.094    0.000    0.094    0.000 {isinstance}
    56091    0.089    0.000    0.196    0.000 topologyobjects.py:1632(__init__)
   162536    0.081    0.000    0.104    0.000 topologyobjects.py:3872(new_func)
    56057    0.075    0.000    0.093    0.000 periodic_table.py:229(element_by_mass)
```

It's now ~20x faster than the previous version for this example.  Note that this PR will only improve efficiency if the prmtop file does *not* have an `ATOMIC_NUMBER` section.  Otherwise, `element_by_mass` is never called.

Overall, this is good for a ~30% speed boost in `dhfr_cmap_pbc.parm7` parsing.  For newer topology files, this should make no difference, though (but `element_by_mass` is used in other places as well, so this should be a good win).