### PR TITLE
Attempt to make TrackedList.__getitem__ a little cheaper.

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -3979,10 +3979,9 @@ class TrackedList(list):
         return TrackedList(list.__mul__(self, fac))
 
     def __getitem__(self, thing):
-        retval = list.__getitem__(self, thing)
-        if hasattr(thing, 'indices'):
-            return TrackedList(retval)
-        return retval
+        if isinstance(thing, slice):
+            return TrackedList(list.__getitem__(self, thing))
+        return list.__getitem__(self, thing)
 
     def __getslice__(self, start, end):
         return TrackedList(list.__getslice__(self, start, end))


### PR DESCRIPTION
This gives a slight improvement in indexing a `TrackedList`.  It seems that `TrackedList.__getitem__` is one of the routines that `supercell.parm7` spends the most time in, which indicates it's unnecessarily expensive.  I should probably stop overriding it and just settle with a slice returning a `list` instead of a `TrackedList`...  We'll see how much that breaks.

In the meantime, this gives a ~10% performance boost (reducing parsing time from 10 to 9 seconds on my desktop).  Not too much.

At this point, the bottleneck *seems* to be `Atom` instantiation. There's nothing that I can see to address that short of migrating to Cython.  (Of course, you could just use PyPy instead :)).