### PR TITLE
Stop overriding TrackedList.__getitem__ and __getslice__

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -3910,7 +3910,7 @@ class TrackedList(list):
         return list.__init__(self, *args)
 
     def __repr__(self):
-        return 'TrackedList(%s)' % list.__repr__(self)
+        return '%s(%s)' % (type(self).__name__, list.__repr__(self))
 
     @_changes
     def __delitem__(self, item):

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -3909,6 +3909,9 @@ class TrackedList(list):
         self.needs_indexing = False
         return list.__init__(self, *args)
 
+    def __repr__(self):
+        return 'TrackedList(%s)' % list.__repr__(self)
+
     @_changes
     def __delitem__(self, item):
         """ Deletes items and slices. Make sure all items """
@@ -3977,14 +3980,6 @@ class TrackedList(list):
 
     def __mul__(self, fac):
         return TrackedList(list.__mul__(self, fac))
-
-    def __getitem__(self, thing):
-        if isinstance(thing, slice):
-            return TrackedList(list.__getitem__(self, thing))
-        return list.__getitem__(self, thing)
-
-    def __getslice__(self, start, end):
-        return TrackedList(list.__getslice__(self, start, end))
 
     def index_members(self):
         """

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -610,7 +610,7 @@ class TestObjectAPIs(unittest.TestCase):
         mylist2 = topologyobjects.TrackedList(reversed(range(20)))
         self.assertFalse(mylist.changed)
         self.assertIsInstance(mylist[0], int)
-        self.assertIsInstance(mylist[0:5], topologyobjects.TrackedList)
+        self.assertIsInstance(mylist[0:5], list)
         self.assertIsInstance(mylist + mylist2, topologyobjects.TrackedList)
         self.assertIsInstance(mylist * 2, topologyobjects.TrackedList)
         mylist += mylist2


### PR DESCRIPTION
`TrackedList.__getitem__` was one of the costliest functions in supercell.parm7
parsing (as part of the `_load_dihedrals` function). Profilers indicate that a
*lot* of time is spent in `TrackedList.__getitem__`. By no longer overriding this
function, this *should* push `TrackedList.__getitem__` into C code (as that is
where the Python list is implemented).