### PR TITLE
Add Structure.save function

### DIFF
--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -33,6 +33,7 @@ def _catchindexerror(func):
         try:
             return func(*args, **kwargs)
         except IndexError as e:
+            raise
             raise CharmmError('Array is too short: %s' % e)
 
     return newfunc

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -33,7 +33,6 @@ def _catchindexerror(func):
         try:
             return func(*args, **kwargs)
         except IndexError as e:
-            raise
             raise CharmmError('Array is too short: %s' % e)
 
     return newfunc

--- a/parmed/formats/psf.py
+++ b/parmed/formats/psf.py
@@ -209,7 +209,11 @@ class PSFFile(object):
         if len(struct.atoms) % 8 != 0: dest.write('\n')
         dest.write('\n')
         # Group section
-        dest.write((intfmt*2) % (len(struct.groups), struct.groups.nst2))
+        try:
+            nst2 = struct.groups.nst2
+        except AttributeError:
+            nst2 = 0
+        dest.write((intfmt*2) % (len(struct.groups), nst2))
         dest.write(' !NGRP NST2\n')
         for i, gp in enumerate(struct.groups):
             dest.write((intfmt*3) % (gp.bs, gp.type, gp.move))

--- a/parmed/formats/psf.py
+++ b/parmed/formats/psf.py
@@ -7,7 +7,7 @@ from parmed.charmm import CharmmPsfFile
 from parmed.charmm.psf import set_molecules
 from parmed.formats.registry import FileFormatType
 from parmed.utils.io import genopen
-from parmed.utils.six import add_metaclass
+from parmed.utils.six import add_metaclass, string_types
 from parmed.utils.six.moves import range
 
 @add_metaclass(FileFormatType)
@@ -111,8 +111,12 @@ class PSFFile(object):
         else:
             dest.write('EXT') # EXT is always active
         dest.write('\n\n')
-        dest.write(intfmt % len(struct.title) + ' !NTITLE\n')
-        dest.write('\n'.join(struct.title) + '\n\n')
+        if isinstance(struct.title, string_types):
+            dest.write(intfmt % 1 + ' !NTITLE\n')
+            dest.write('%s\n\n' % struct.title)
+        else:
+            dest.write(intfmt % len(struct.title) + ' !NTITLE\n')
+            dest.write('\n'.join(struct.title) + '\n\n')
         # Now time for the atoms
         dest.write(intfmt % len(struct.atoms) + ' !NATOM\n')
         # atmfmt1 is for CHARMM format (i.e., atom types are integers)
@@ -134,7 +138,7 @@ class PSFFile(object):
             if hasattr(atom, 'props'):
                 dest.write(atmstr + '   '.join(atom.props) + '\n')
             else:
-                dest.write('\n')
+                dest.write('%s\n' % atmstr)
         dest.write('\n')
         # Bonds
         dest.write(intfmt % len(struct.bonds) + ' !NBOND: bonds\n')

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1098,6 +1098,7 @@ class GromacsTopologyFile(Structure):
         gmxtop.improper_types = struct.improper_types
         gmxtop.cmap_types = struct.cmap_types
         gmxtop.rb_torsion_types = struct.rb_torsion_types
+        gmxtop.urey_bradley_types = struct.urey_bradley_types
         if (struct.trigonal_angles or
                 struct.out_of_plane_bends or
                 struct.pi_torsions or

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1292,16 +1292,16 @@ class Structure(object):
 
     #===================================================
 
-    def save(self, fname, kind=None, **kwargs):
+    def save(self, fname, format=None, **kwargs):
         """
         Saves the current Structure in the requested file format. Supported
         formats can be specified explicitly or determined by file-name
         extension. The following formats are supported, with the recognized
-        suffix and ``kind`` keyword shown in parentheses:
+        suffix and ``format`` keyword shown in parentheses:
 
             - PDB (.pdb, pdb)
             - PDBx/mmCIF (.cif, cif)
-            - Amber topology file (.prmtop/.parm, amber)
+            - Amber topology file (.prmtop/.parm7, amber)
             - CHARMM PSF file (.psf, charmm)
             - Gromacs topology file (.top, gromacs)
             - Gromacs GRO file (.gro, gro)
@@ -1311,10 +1311,10 @@ class Structure(object):
         Parameters
         ----------
         fname : str
-            Name of the file to save. If ``kind`` is ``None`` (see below), the
+            Name of the file to save. If ``format`` is ``None`` (see below), the
             file type will be determined based on the filename extension. If the
             type cannot be determined, a ValueError is raised.
-        kind : str, optional
+        format : str, optional
             The case-insensitive keyword specifying what type of file ``fname``
             should be saved as. If ``None`` (default), the file type will be
             determined from filename extension of ``fname``
@@ -1324,7 +1324,7 @@ class Structure(object):
 
         Raises
         ------
-        ValueError if either filename extension or ``kind`` are not recognized
+        ValueError if either filename extension or ``format`` are not recognized
         TypeError if the structure cannot be converted to the desired format for
         whatever reason
         """
@@ -1340,33 +1340,33 @@ class Structure(object):
                 '.mol2' : 'MOL2',
                 '.mol3' : 'MOL3',
         }
-        if kind is not None:
-            kind = kind.upper()
+        if format is not None:
+            format = format.upper()
         else:
             _, ext = os.path.splitext(fname)
             if ext in ('.bz2', '.gz'):
                 ext = os.path.splitext(ext)[1]
             try:
-                kind = extmap[ext]
+                format = extmap[ext]
             except KeyError:
                 raise ValueError('Could not determine file type of %s' % fname)
         # Dispatch
-        if kind == 'PDB':
+        if format == 'PDB':
             self.write_pdb(fname, **kwargs)
-        elif kind == 'CIF':
+        elif format == 'CIF':
             self.write_cif(fname, **kwargs)
-        elif kind == 'PSF':
+        elif format == 'PSF':
             self.write_psf(fname, **kwargs)
-        elif kind == 'GRO':
+        elif format == 'GRO':
             gromacs.GromacsGroFile.write(self, fname, **kwargs)
-        elif kind == 'MOL2':
+        elif format == 'MOL2':
             formats.Mol2File.write(self, fname, **kwargs)
-        elif kind == 'MOL3':
+        elif format == 'MOL3':
             formats.Mol2File.write(self, fname, mol3=True, **kwargs)
-        elif kind == 'GROMACS':
+        elif format == 'GROMACS':
             s = gromacs.GromacsTopologyFile.from_structure(self)
             s.write(fname, **kwargs)
-        elif kind == 'AMBER':
+        elif format == 'AMBER':
             if (self.trigonal_angles or self.out_of_plane_bends or
                     self.torsion_torsions or self.pi_torsions or
                     self.stretch_bends or self.chiral_frames or
@@ -1386,7 +1386,7 @@ class Structure(object):
                         raise
                 s.write_parm(fname, **kwargs)
         else:
-            raise ValueError('No file type matching %s' % kind)
+            raise ValueError('No file type matching %s' % format)
 
     #===================================================
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -40,7 +40,7 @@ from parmed.topologyobjects import (AtomList, ResidueList, TrackedList,
         DihedralTypeList, Bond, Angle, Dihedral, UreyBradley, Improper, Cmap,
         TrigonalAngle, OutOfPlaneBend, PiTorsion, StretchBend, TorsionTorsion,
         NonbondedException, AcceptorDonor, Group, Atom, ExtraPoint,
-        TwoParticleExtraPointFrame, ChiralFrame, MultipoleFrame,
+        TwoParticleExtraPointFrame, ChiralFrame, MultipoleFrame, NoUreyBradley,
         ThreeParticleExtraPointFrame, OutOfPlaneExtraPointFrame)
 from parmed import unit as u
 from parmed.utils import tag_molecules
@@ -538,6 +538,7 @@ class Structure(object):
                 )
                 c.dihedrals[-1]._funct = d._funct
         for ub in self.urey_bradleys:
+            if ub.type is NoUreyBradley: continue
             c.urey_bradleys.append(
                     UreyBradley(atoms[ub.atom1.idx], atoms[ub.atom2.idx],
                                 ub.type and c.urey_bradley_types[ub.type.idx])

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1343,7 +1343,7 @@ class Structure(object):
         if kind is not None:
             kind = kind.upper()
         else:
-            _, ext = os.path.splitext(fname)[1]
+            _, ext = os.path.splitext(fname)
             if ext in ('.bz2', '.gz'):
                 ext = os.path.splitext(ext)[1]
             try:

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -644,7 +644,7 @@ class TestStructureSave(unittest.TestCase):
         except OSError:
             pass
 
-    def savePDB(self):
+    def testSavePDB(self):
         """ Test saving various Structure instances as a PDB """
         self.sys1.save(get_fn('test.pdb', written=True))
         self.sys2.save(get_fn('test2.pdb', written=True))
@@ -656,7 +656,7 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual([a.name for a in self.sys2.atoms], [a.name for a in x2.atoms])
         self.assertEqual([a.name for a in self.sys3.atoms], [a.name for a in x3.atoms])
 
-    def saveCIF(self):
+    def testSaveCIF(self):
         """ Test saving various Structure instances as a PDBx/mmCIF """
         self.sys1.save(get_fn('test.cif', written=True))
         self.sys2.save(get_fn('test2.cif', written=True))
@@ -668,7 +668,7 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual([a.name for a in self.sys2.atoms], [a.name for a in x2.atoms])
         self.assertEqual([a.name for a in self.sys3.atoms], [a.name for a in x3.atoms])
 
-    def saveMol2(self):
+    def testSaveMol2(self):
         """ Test saving various Structure instances as Mol2 files """
         self.sys1.save(get_fn('test.mol2', written=True))
         self.sys2.save(get_fn('test2.mol2', written=True))
@@ -683,7 +683,7 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual(len(self.sys2.bonds), len(x2.bonds))
         self.assertEqual(len(self.sys3.bonds), len(x3.bonds))
 
-    def saveMol3(self):
+    def testSaveMol3(self):
         """ Test saving various Structure instances as Mol3 files """
         self.sys1.save(get_fn('test.mol3', written=True))
         x1 = pmd.formats.Mol2File.parse(get_fn('test.mol3', written=True), structure=True)
@@ -696,7 +696,7 @@ class TestStructureSave(unittest.TestCase):
             else:
                 self.assertFalse(True)
 
-    def saveAmberParm(self):
+    def testSaveAmberParm(self):
         """ Test saving various Structure instances as Amber prmtop files """
         self.sys1.save(get_fn('test.parm7', written=True))
         self.sys2.save(get_fn('test2.parm7', written=True))
@@ -736,7 +736,7 @@ class TestStructureSave(unittest.TestCase):
             self.assertAlmostEqual(a1.rmin, a2.rmin)
             self.assertAlmostEqual(abs(a1.epsilon), abs(a2.epsilon))
 
-    def savePSF(self):
+    def testSavePSF(self):
         """ Test saving various Structure instances as CHARMM PSF files """
         self.sys1.save(get_fn('test.psf', written=True))
         self.sys2.save(get_fn('test2.psf', written=True))
@@ -764,7 +764,7 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual(len(self.sys2.cmaps), len(x2.cmaps))
         self.assertEqual(len(self.sys3.cmaps), len(x3.cmaps))
 
-    def saveGromacs(self):
+    def testSaveGromacs(self):
         """ Test saving various Structure instances as GROMACS top files """
         self.sys1.save(get_fn('test.top', written=True))
         self.sys2.save(get_fn('test2.top', written=True))
@@ -792,7 +792,7 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual(len(self.sys2.cmaps), len(x2.cmaps))
         self.assertEqual(len(self.sys3.cmaps), len(x3.cmaps))
 
-    def saveGRO(self):
+    def testSaveGRO(self):
         """ Test saving various Structure instances as a PDB """
         self.sys1.save(get_fn('test.gro', written=True))
         self.sys2.save(get_fn('test2.gro', written=True))

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -744,9 +744,6 @@ class TestStructureSave(unittest.TestCase):
         x1 = pmd.charmm.CharmmPsfFile(get_fn('test.psf', written=True))
         x2 = pmd.charmm.CharmmPsfFile(get_fn('test2.psf', written=True))
         x3 = pmd.charmm.CharmmPsfFile(get_fn('test3.psf', written=True))
-        self.assertIsInstance(x1, pmd.charmm.CharmmPsfFile)
-        self.assertIsInstance(x2, pmd.charmm.CharmmPsfFile)
-        self.assertIsInstance(x3, pmd.charmm.CharmmPsfFile)
         # Check equivalence of topologies
         self.assertEqual([a.name for a in self.sys1.atoms], [a.name for a in x1.atoms])
         self.assertEqual([a.name for a in self.sys2.atoms], [a.name for a in x2.atoms])
@@ -766,6 +763,46 @@ class TestStructureSave(unittest.TestCase):
         self.assertEqual(len(self.sys1.cmaps), len(x1.cmaps))
         self.assertEqual(len(self.sys2.cmaps), len(x2.cmaps))
         self.assertEqual(len(self.sys3.cmaps), len(x3.cmaps))
+
+    def saveGromacs(self):
+        """ Test saving various Structure instances as GROMACS top files """
+        self.sys1.save(get_fn('test.top', written=True))
+        self.sys2.save(get_fn('test2.top', written=True))
+        self.sys3.save(get_fn('test3.top', written=True))
+        x1 = pmd.gromacs.GromacsTopologyFile(get_fn('test.top', written=True))
+        x2 = pmd.gromacs.GromacsTopologyFile(get_fn('test2.top', written=True))
+        x3 = pmd.gromacs.GromacsTopologyFile(get_fn('test3.top', written=True))
+        # Check equivalence of topologies
+        self.assertEqual([a.name for a in self.sys1.atoms], [a.name for a in x1.atoms])
+        self.assertEqual([a.name for a in self.sys2.atoms], [a.name for a in x2.atoms])
+        self.assertEqual([a.name for a in self.sys3.atoms], [a.name for a in x3.atoms])
+        self.assertEqual(len(self.sys1.bonds), len(x1.bonds))
+        self.assertEqual(len(self.sys2.bonds), len(x2.bonds))
+        self.assertEqual(len(self.sys3.bonds), len(x3.bonds))
+        self.assertEqual(len(self.sys1.angles), len(x1.angles))
+        self.assertEqual(len(self.sys2.angles), len(x2.angles))
+        self.assertEqual(len(self.sys3.angles), len(x3.angles))
+        self.assertEqual(len(self.sys1.dihedrals), len(x1.dihedrals))
+        self.assertEqual(len(self.sys2.dihedrals), len(x2.dihedrals))
+        self.assertEqual(len(self.sys3.dihedrals), len(x3.dihedrals))
+        self.assertEqual(len(self.sys1.impropers), len(x1.impropers))
+        self.assertEqual(len(self.sys2.impropers), len(x2.impropers))
+        self.assertEqual(len(self.sys3.impropers), len(x3.impropers))
+        self.assertEqual(len(self.sys1.cmaps), len(x1.cmaps))
+        self.assertEqual(len(self.sys2.cmaps), len(x2.cmaps))
+        self.assertEqual(len(self.sys3.cmaps), len(x3.cmaps))
+
+    def saveGRO(self):
+        """ Test saving various Structure instances as a PDB """
+        self.sys1.save(get_fn('test.gro', written=True))
+        self.sys2.save(get_fn('test2.gro', written=True))
+        self.sys3.save(get_fn('test3.gro', written=True))
+        x1 = pmd.gromacs.GromacsGroFile.parse(get_fn('test.gro', written=True))
+        x2 = pmd.gromacs.GromacsGroFile.parse(get_fn('test2.gro', written=True))
+        x3 = pmd.gromacs.GromacsGroFile.parse(get_fn('test3.gro', written=True))
+        self.assertEqual([a.name for a in self.sys1.atoms], [a.name for a in x1.atoms])
+        self.assertEqual([a.name for a in self.sys2.atoms], [a.name for a in x2.atoms])
+        self.assertEqual([a.name for a in self.sys3.atoms], [a.name for a in x3.atoms])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows you to write the desired format in a *single* place, with any
necessary conversions being done for you automatically. It also handles
Amber-style formats as well as possible, determining in most instances whether a
structure can be cast as a ChamberParm when AmberParm is not flexible enough.
File type is determined from filename extension *or* explicit direction.

This also fixes writing PSF files from Structure instances that were *not*
parsed from PSFs (since the `groups` list did not have a `nst2` attribute.

This fixes #106.