### PR TITLE
Fix some small issues with the interactive interpreter

### DIFF
--- a/parmed/scripts.py
+++ b/parmed/scripts.py
@@ -175,6 +175,7 @@ def clapp():
                     for line in f:
                         if line.startswith('# Log started on'): continue
                         readline.add_history(line.rstrip())
+                    f.close()
             try:
                 logfile = open(opt.logfile, 'a')
             except IOError:

--- a/parmed/tools/checkvalidity.py
+++ b/parmed/tools/checkvalidity.py
@@ -214,7 +214,7 @@ def check_validity(parm, warnings):
                           'disulfide bond?', MissingDisulfide)
             break
 
-    if parm.coords is not None:
+    if parm.coordinates is not None:
         # Check if we think any disulfide bonds might be missing.
         mask = AmberMask(parm, ':CYS,CYM@SG')
         s_atms = []


### PR DESCRIPTION
- Exit following bad commands *only* if the commands are being read from a
  script or file. If they are being typed in, do not quit following bad commands

- Correctly catch fatal warnings in addition to hard errors in the interactive
  interpreter (when reading stdin from a TTY, that is).

Fixes #243 