### PR TITLE
Support IPython-like help syntax in parmed CLI

### DIFF
--- a/parmed/tools/parmed_cmd.py
+++ b/parmed/tools/parmed_cmd.py
@@ -115,6 +115,8 @@ class ParmedCmd(cmd.Cmd):
             return None, None, line
         elif line[0] == '?':
             line = 'help ' + line[1:]
+        elif line[-1] == '?' and len(line.split()) == 1:
+            line = 'help ' + line[:-1]
         elif line[0] == '!':
             if hasattr(self, 'do_shell'):
                 line = 'shell ' + line[1:]


### PR DESCRIPTION
Doesn't hurt.  Works in addition to existing modes.  You can now get help in the
following 3 ways:

```
help <command>
?<command>
<command>?
```