### PR TITLE
Improves behavior of slicing

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1060,7 +1060,7 @@ class Structure(object):
                     else:
                         # The selected chain is not in the system. Cannot
                         # possibly select *any* atoms. Bail now for speed
-                        return None
+                        return type(self)()
                 elif isinstance(chainsel, slice):
                     # Build an ordered set of chains
                     chains = [self.residues[0].chain]
@@ -1075,7 +1075,7 @@ class Structure(object):
                         break
                 else:
                     # No requested chain is present. Bail now for speed
-                    return None
+                    return type(self)()
                 has_chain = True
             # Residue selection can either be by name or index
             if isinstance(ressel, slice):
@@ -1142,7 +1142,7 @@ class Structure(object):
         sumsel = sum(selection)
         if sumsel == 0:
             # No atoms selected. Return None
-            return None
+            return type(self)()
         # The cumulative sum of selection will give our index + 1 of each
         # selected atom into the new structure
         scan = [selection[0]]

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1143,9 +1143,6 @@ class Structure(object):
         if sumsel == 0:
             # No atoms selected. Return None
             return None
-        if sumsel == 1:
-            # 1 atom selected; return that atom
-            return self.atoms[selection.index(1)]
         # The cumulative sum of selection will give our index + 1 of each
         # selected atom into the new structure
         scan = [selection[0]]
@@ -3401,6 +3398,32 @@ class Structure(object):
                     (-1, len(self.atoms), 3))
             self._coordinates = coords
         return self
+
+    #===================================================
+
+    # For the bool-ness of Structure. An empty structure evaluates to
+    # boolean-false, but this means that the structure must have no atoms,
+    # residues, topological features, or parameter types at all.
+
+    def __bool__(self):
+        return bool(self.atoms or self.residues or self.bonds or self.angles or
+                    self.dihedrals or self.impropers or self.rb_torsions or
+                    self.cmaps or self.torsion_torsions or self.stretch_bends or
+                    self.out_of_plane_bends or self.trigonal_angles or
+                    self.torsion_torsions or self.pi_torsions or
+                    self.urey_bradleys or self.chiral_frames or
+                    self.multipole_frames or self.adjusts or self.acceptors or
+                    self.donors or self.groups or self.bond_types or
+                    self.angle_types or self.dihedral_types or
+                    self.urey_bradley_types or self.improper_types or
+                    self.rb_torsion_types or self.cmap_types or
+                    self.trigonal_angle_types or self.out_of_plane_bend_types or
+                    self.pi_torsion_types or self.torsion_torsion_types or
+                    self.adjust_types)
+
+    def __nonzero__(self):
+        # For Python 2
+        return self.__bool__()
 
     #===================================================
 

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -49,6 +49,11 @@ class TestStructureAPI(unittest.TestCase):
             self.assertEqual(residue.atoms[-1].idx - residue.atoms[0].idx + 1,
                              len(residue))
 
+    def testBool(self):
+        """ Tests bool-ness of Structure """
+        self.assertTrue(bool(self.s))
+        self.assertFalse(bool(structure.Structure()))
+
     def testAddAtomToResidue(self):
         """ Tests the Structure.add_atom_to_residue method """
         s = self.s

--- a/test/test_parmed_structure_slicing.py
+++ b/test/test_parmed_structure_slicing.py
@@ -1,15 +1,17 @@
 """
 Tests the fancy indexing and slicing capabilities of Structure
 """
-import utils
-import parmed as chem
+from collections import defaultdict
+import parmed as pmd
+from parmed.utils.six import iteritems
 from parmed.utils.six.moves import range, zip
 import random
 import unittest
+import utils
 
-parm = chem.load_file(utils.get_fn('trx.prmtop'))
-pdb1 = chem.load_file(utils.get_fn('4lzt.pdb'))
-pdb2 = chem.load_file(utils.get_fn('1kip.cif'))
+parm = pmd.load_file(utils.get_fn('trx.prmtop'))
+pdb1 = pmd.load_file(utils.get_fn('4lzt.pdb'))
+pdb2 = pmd.load_file(utils.get_fn('1kip.cif'))
 
 class TestStructureSlicing(unittest.TestCase):
     """ Tests the fancy slicing/indexing of Structure """
@@ -22,6 +24,28 @@ class TestStructureSlicing(unittest.TestCase):
             self.assertIs(atom, pdb1[i])
         for i, atom in enumerate(pdb2.atoms):
             self.assertIs(atom, pdb2[i])
+
+    def testTwoIntIndex(self):
+        """ Tests simple Structure indexing w/ residue and atom (int, int) """
+        for i, res in enumerate(parm.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], parm[i,j])
+        for i, res in enumerate(pdb1.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], pdb1[i,j])
+        for i, res in enumerate(pdb2.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], pdb2[i,j])
+
+    def testThreeSimpleIndex(self):
+        """ Tests simple indexing with chain, residue, and atom ID """
+        chains = defaultdict(pmd.TrackedList)
+        for res in pdb2.residues:
+            chains[res.chain].append(res)
+        for chain_name, chain in iteritems(chains):
+            for i, res in enumerate(chain):
+                for j, atom in enumerate(res):
+                    self.assertIs(atom, pdb2[chain_name, i, j])
 
     def testSimpleSlice(self):
         """ Tests simple atom slicing """
@@ -46,15 +70,15 @@ class TestStructureSlicing(unittest.TestCase):
         self.assertEqual(len(sl33.atoms), 19)
 
         # Check that the resulting types of the slices are correct
-        self.assertIsInstance(sl11, chem.amber.AmberParm)
-        self.assertIsInstance(sl21, chem.Structure)
-        self.assertIsInstance(sl31, chem.Structure)
-        self.assertIsInstance(sl12, chem.amber.AmberParm)
-        self.assertIsInstance(sl22, chem.Structure)
-        self.assertIsInstance(sl32, chem.Structure)
-        self.assertIsInstance(sl13, chem.amber.AmberParm)
-        self.assertIsInstance(sl23, chem.Structure)
-        self.assertIsInstance(sl33, chem.Structure)
+        self.assertIsInstance(sl11, pmd.amber.AmberParm)
+        self.assertIsInstance(sl21, pmd.Structure)
+        self.assertIsInstance(sl31, pmd.Structure)
+        self.assertIsInstance(sl12, pmd.amber.AmberParm)
+        self.assertIsInstance(sl22, pmd.Structure)
+        self.assertIsInstance(sl32, pmd.Structure)
+        self.assertIsInstance(sl13, pmd.amber.AmberParm)
+        self.assertIsInstance(sl23, pmd.Structure)
+        self.assertIsInstance(sl33, pmd.Structure)
 
         # Check that the atoms sliced out are correct
         for atom in sl11.atoms:

--- a/test/test_parmed_structure_slicing.py
+++ b/test/test_parmed_structure_slicing.py
@@ -47,6 +47,29 @@ class TestStructureSlicing(unittest.TestCase):
                 for j, atom in enumerate(res):
                     self.assertIs(atom, pdb2[chain_name, i, j])
 
+    def testSingleAtomSlice(self):
+        """ Test that non-trivial, single-atom selections give a Structure """
+        sel1 = parm['@1']
+        sel2 = parm[:1]
+        self.assertIsInstance(sel1, pmd.Structure)
+        self.assertIsInstance(sel2, pmd.Structure)
+        self.assertEqual(len(sel1.atoms), 1)
+        self.assertEqual(len(sel2.atoms), 1)
+
+    def testEmptyStructure(self):
+        sel1 = parm[10000000:]
+        sel2 = pdb1['@NOTHING']
+        sel3 = pdb2['G',:,:]
+        sel4 = parm['NOTHING',:]
+        self.assertFalse(sel1)
+        self.assertFalse(sel2)
+        self.assertFalse(sel3)
+        self.assertFalse(sel4)
+        self.assertIsInstance(sel1, pmd.amber.AmberParm)
+        self.assertIsInstance(sel2, pmd.Structure)
+        self.assertIsInstance(sel3, pmd.Structure)
+        self.assertIsInstance(sel4, pmd.amber.AmberParm)
+
     def testSimpleSlice(self):
         """ Tests simple atom slicing """
         sl11 = parm[:10]


### PR DESCRIPTION
This PR closes #267 (and #274)

The new behaviors here:

- Selecting a slice, a mask, or a mask array will *always* return a `Structure` (or subclass) instance, even if it only selects a single atom.
- Selecting a single atom, by either `struct[int]`, `struct[int, int]` or `struct[str, int, int]` (which amounts to picking a single atom, a single atom from a single residue, or a single atom from a single residue from a single chain) still returns just an `Atom`, but runs orders of magnitude faster now (returns almost instantly, as you would expect it should, except for chain selections since chains need not be contiguously listed in a PDB file)
- Selections involving slices and Amber masks that do not select *anything* return an empty `Structure` instance instead of `None`
- Truthiness was added to `Structure`, and behaves like other Python containers (empty is `False`, anything else is `True`). This way, empty selections still return something `False`-y