### PR TITLE
Implement remote file support in load_file

### DIFF
--- a/parmed/amber/amberformat.py
+++ b/parmed/amber/amberformat.py
@@ -427,10 +427,11 @@ class AmberFormat(object):
         except ImportError:
             return self.rdparm_slow(fname)
 
-        if slow:
+        # The optimized parser only works on local files
+        if slow or fname.startswith('http://') or fname.startswith('https://'):
             return self.rdparm_slow(fname)
 
-        # We have the optimized version
+        # We have the optimized version and a local file
         try:
             ret = _rdparm.rdparm(fname)
         except TypeError:

--- a/parmed/amber/netcdffiles.py
+++ b/parmed/amber/netcdffiles.py
@@ -194,7 +194,13 @@ class NetCDFRestart(object):
         -------
         is_fmt : bool
             True if it is an Amber NetCDF restart file. False otherwise
+
+        Notes
+        -----
+        Remote NetCDF files cannot be loaded
         """
+        if filename.startswith('http://') or filename.startswith('https://'):
+            return False
         if not HAS_NETCDF:
             return False # Can't determine...
         if not NETCDF_INITIALIZED:
@@ -532,7 +538,13 @@ class NetCDFTraj(object):
         -------
         is_fmt : bool
             True if it is an Amber NetCDF trajectory file. False otherwise
+
+        Notes
+        -----
+        Remote NetCDF files cannot be loaded
         """
+        if filename.startswith('http://') or filename.startswith('https://'):
+            return False
         if not HAS_NETCDF:
             return False # Can't determine...
         if not NETCDF_INITIALIZED:

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -174,9 +174,6 @@ class CharmmPsfFile(Structure):
         global _resre
         Structure.__init__(self)
         conv = CharmmPsfFile._convert
-        # Make sure the file exists
-        if not os.path.exists(psf_name):
-            raise IOError('Could not find PSF file %s' % psf_name)
         # Open the PSF and read the first line. It must start with "PSF"
         with closing(genopen(psf_name, 'r')) as psf:
             self.name = psf_name

--- a/parmed/formats/mol2.py
+++ b/parmed/formats/mol2.py
@@ -262,6 +262,7 @@ class Mol2File(object):
                     #   status -- ignored
                     #   comment -- ignored
                     words = line.split()
+                    if not words: continue
                     id = int(words[0])
                     resname = words[1]
                     try:

--- a/parmed/gromacs/_cpp.py
+++ b/parmed/gromacs/_cpp.py
@@ -5,6 +5,7 @@ directives like #if, #ifdef, and #define.
 Written by Jason Swails
 """
 from parmed.exceptions import PreProcessorError, PreProcessorWarning
+from parmed.utils.io import genopen
 from parmed.utils.six import string_types, iteritems, wraps
 from collections import OrderedDict
 from os import path
@@ -109,7 +110,7 @@ class CPreProcessor(object):
 
     def __init__(self, fname, defines=None, includes=None, notfound_fatal=True):
         if isinstance(fname, string_types):
-            self._fileobj = open(fname, 'r')
+            self._fileobj = genopen(fname, 'r')
             self._ownhandle = True
             curpath = path.abspath(path.split(fname)[0])
             self.filename = fname
@@ -368,7 +369,7 @@ if __name__ == '__main__':
     if opt.output is None:
         output = sys.stdout
     else:
-        output = open(opt.output, 'w')
+        output = genopen(opt.output, 'w')
 
     for line in pp:
         output.write(line)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -732,6 +732,14 @@ class TestMol2File(FileIOTestCase):
         self.assertIs(mol3.head, [a for a in mol3 if a.name == "N1'"][0])
         self.assertIs(mol3.tail, [a for a in mol3 if a.name == "C'"][0])
 
+    def testMol2FileWithBlankLines(self):
+        """ Tests parsing a Mol2 file with blank lines at the end """
+        mol2 = formats.Mol2File.parse(get_fn('tripos1.mol2'))
+        self.assertIsInstance(mol2, ResidueTemplate)
+        self.assertEqual(mol2.name, 'DAN')
+        self.assertEqual(len(mol2), 31)
+        self.assertEqual(len(mol2.bonds), 33)
+
     def testMol3Structure(self):
         """ Tests parsing a Mol3 file with 1 residue into a Structure """
         mol3 = formats.Mol2File.parse(get_fn('tripos9.mol2'), structure=True)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -835,5 +835,91 @@ class TestMol2File(FileIOTestCase):
         self.assertTrue(diff_files(get_fn('tripos9struct.mol3', written=True),
                                    get_saved_fn('tripos9struct.mol3')))
 
-if __name__ == '__main__':
-    unittest.main()
+class TestFileDownloader(unittest.TestCase):
+    """ Tests load_file with URLs for each format """
+
+    def setUp(self):
+        self.url = 'https://github.com/ParmEd/ParmEd/raw/master/test/files/'
+
+    def testDownloadOFF(self):
+        """ Tests automatic loading of downloaded OFF files """
+        off = formats.load_file(self.url + 'amino12.lib')
+        self.assertIsInstance(off, dict)
+        for key, item in iteritems(off):
+            self.assertIsInstance(item, ResidueTemplate)
+
+    def testDownloadAmberParm(self):
+        """ Tests automatic loading of downloaded AmberParm object """
+        parm = formats.load_file(self.url + 'tip4p.parm7')
+        self.assertIsInstance(parm, amber.AmberParm)
+
+    def testDownloadAmoebaParm(self):
+        """ Tests automatic loading of downloaded AmoebaParm object """
+        parm = formats.load_file(self.url + 'nma.parm7')
+        self.assertIsInstance(parm, amber.AmoebaParm)
+
+    def testDownloadChamberParm(self):
+        """ Tests automatic loading of downloaded ChamberParm object """
+        parm = formats.load_file(self.url + 'ala_ala_ala.parm7')
+        self.assertIsInstance(parm, amber.ChamberParm)
+
+    def testDownloadAmberFormat(self):
+        """ Tests automatic loading of downloaded AmberFormat object """
+        parm = formats.load_file(self.url + 'cSPCE.mdl')
+        self.assertIsInstance(parm, amber.AmberFormat)
+        self.assertNotIsInstance(parm, amber.AmberParm)
+
+    def testDownloadAmberRestart(self):
+        """ Tests automatic loading of downloaded Amber ASCII restart file """
+        parm = formats.load_file(self.url + 'trx.inpcrd')
+        self.assertIsInstance(parm, amber.AmberAsciiRestart)
+
+    def testDownloadAmberMdcrd(self):
+        """ Tests automatic loading of downloaded Amber mdcrd file """
+        crd = formats.load_file(self.url + 'tz2.truncoct.crd', natom=5827,
+                                hasbox=True)
+        self.assertIsInstance(crd, amber.AmberMdcrd)
+
+    def testDownloadCharmmPsfFile(self):
+        """ Tests automatic loading of downloaded CHARMM PSF file """
+        parm = formats.load_file(self.url + 'ala_ala_ala.psf')
+        self.assertIsInstance(parm, charmm.CharmmPsfFile)
+
+    def testDownloadCharmmCrdFile(self):
+        """ Tests automatic loading of downloaded CHARMM crd file """
+        crd = formats.load_file(self.url + 'dhfr_min_charmm.crd')
+        self.assertIsInstance(crd, charmm.CharmmCrdFile)
+
+    def testDownloadCharmmRestart(self):
+        """ Tests automatic loading of downloaded CHARMM restart file """
+        crd = formats.load_file(self.url + 'sample-charmm.rst')
+        self.assertIsInstance(crd, charmm.CharmmRstFile)
+
+    def testDownloadPDB(self):
+        """ Tests automatic loading of downloaded PDB files """
+        pdb = formats.load_file(self.url + '4lzt.pdb')
+        self.assertIsInstance(pdb, Structure)
+        self.assertEqual(len(pdb.atoms), 1164)
+
+    def testDownloadCIF(self):
+        """ Tests automatic loading of downloaded PDBx/mmCIF files """
+        cif = formats.load_file(self.url + '4LZT.cif')
+        self.assertIsInstance(cif, Structure)
+        self.assertEqual(len(cif.atoms), 1164)
+
+    def testDownloadMol2(self):
+        """ Tests automatic loading of downloaded mol2 and mol3 files """
+        mol2 = formats.load_file(self.url + 'test_multi.mol2')
+        self.assertIsInstance(mol2, ResidueTemplateContainer)
+        mol3 = formats.load_file(self.url + 'tripos9.mol2')
+        self.assertIsInstance(mol3, ResidueTemplate)
+
+    def testDownloadGromacsTop(self):
+        """ Tests automatic loading of downloaded Gromacs topology file """
+        top = formats.load_file(self.url + '1aki.charmm27.top')
+        self.assertIsInstance(top, gromacs.GromacsTopologyFile)
+
+    def testDownloadGromacsGro(self):
+        """ Tests automatic loading of downloaded Gromacs GRO file """
+        gro = formats.load_file(self.url + '1aki.ff99sbildn.gro')
+        self.assertIsInstance(gro, Structure)

--- a/test/test_parmed_genopen.py
+++ b/test/test_parmed_genopen.py
@@ -119,3 +119,7 @@ class TestGenopen(FileIOTestCase):
         except ValueError as e:
             self.assertEqual(str(e), 'Cannot write or append a webpage')
 
+    def testReadBadURL(self):
+        """ Tests proper exception handling of non-existent URL """
+        self.assertRaises(IOError, lambda: genopen('http://asdkfjasdf.lib'))
+


### PR DESCRIPTION
A couple notes here:

- Remote NetCDF files do not work -- the NetCDF implementations require a fd
  attribute, which urlopen-returned objects don't have (at least in Py2; Py3
  hasn't been checked)
- The optimized Amber topology file reader only supports local files, so urls
  force the use of the "slow" (i.e., pure python) reader. In this case, the
  parser will likely not be rate-limiting (the network will be).

Tests were added first in TDD-style.