### PR TITLE
Make SeriousParmWarning fatal by default in Python

### DIFF
--- a/parmed/scripts.py
+++ b/parmed/scripts.py
@@ -111,8 +111,8 @@ def clapp():
         print(splash)
     
     # Set our warning filter
-    if opt.strict:
-        warnings.filterwarnings('error', category=SeriousParmWarning)
+    if not opt.strict:
+        warnings.filterwarnings('always', category=SeriousParmWarning)
     
     # Set our overwrite preferences
     Action.overwrite = opt.overwrite

--- a/parmed/tools/exceptions.py
+++ b/parmed/tools/exceptions.py
@@ -1,6 +1,7 @@
 """ Exceptions used in parmed script """
 from sys import stderr
 from parmed.exceptions import ParmedError, ParmedWarning, InputError
+import warnings
 
 class ParmError(ParmedError):
     """ Base parmed error """
@@ -18,6 +19,9 @@ class ParmWarning(ParmedWarning):
 
 class SeriousParmWarning(ParmWarning):
     """ These warnings are more serious, and are fatal in strict operation """
+
+# By default, make SeriousParmWarning fatal
+warnings.filterwarnings('error', category=SeriousParmWarning)
 
 class ChangeRadiiError(ParmError):
     pass

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -703,11 +703,6 @@ class TestAmberParmActions(utils.FileIOTestCase, utils.TestCaseRelative):
         act = PT.printBonds(gasparm, '@3', '@1')
         self.assertEqual(str(act), saved.PRINT_BONDS_2MASKS)
 
-    def testUnhandledArguments(self):
-        """ Test that unhandled arguments raise fatal error by default """
-        self.assertRaises(exc.UnhandledArgumentWarning, lambda:
-                PT.printBonds(gasparm, 1))
-
     def testPrintAngles(self):
         """ Test printAngles on AmberParm """
         act = PT.printAngles(gasparm, '@1')

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -703,6 +703,11 @@ class TestAmberParmActions(utils.FileIOTestCase, utils.TestCaseRelative):
         act = PT.printBonds(gasparm, '@3', '@1')
         self.assertEqual(str(act), saved.PRINT_BONDS_2MASKS)
 
+    def testUnhandledArguments(self):
+        """ Test that unhandled arguments raise fatal error by default """
+        self.assertRaises(exc.UnhandledArgumentWarning, lambda:
+                PT.printBonds(gasparm, 1))
+
     def testPrintAngles(self):
         """ Test printAngles on AmberParm """
         act = PT.printAngles(gasparm, '@1')


### PR DESCRIPTION
Fixes #277 