### PR TITLE
Try to fix the molecule ordering problem in Gromacs topologies

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1442,8 +1442,20 @@ class GromacsTopologyFile(Structure):
                 dest.write('\n\n')
                 # Molecules
                 dest.write('[ molecules ]\n; Compound       #mols\n')
-                for i, (molecule, num) in enumerate(molecules):
-                    dest.write('%-15s %6d\n' % (names[i], num))
+                total_mols = sum(len(m[1]) for m in molecules)
+                i = 0
+                while i < total_mols:
+                    for j, (molecule, lst) in enumerate(molecules):
+                        if i in lst:
+                            break
+                    else:
+                        raise RuntimeError('Could not find molecule %d in list'
+                                           % i)
+                    ii = i
+                    while ii < total_mols and ii in lst:
+                        ii += 1
+                    dest.write('%-15s %6d\n' % (names[j], ii-i))
+                    i = ii
             elif isinstance(combine, string_types) and combine.lower() == 'all':
                 GromacsTopologyFile._write_molecule(self, dest, 'system',
                                     params, parameters == 'inline')

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1254,10 +1254,10 @@ class Structure(object):
 
         Returns
         -------
-        [structs, counts] : list of (:class:`Structure`, int) tuples
+        [structs, counts] : list of (:class:`Structure`, list) tuples
             List of all molecules in the order that they appear first in the
-            parent structure accompanied by the number of times that molecule
-            appears in the Structure
+            parent structure accompanied by the list of the molecule numbers
+            in which that molecule appears in the Structure
         """
         tag_molecules(self)
         mollist = [atom.marked for atom in self.atoms]
@@ -1281,7 +1281,7 @@ class Structure(object):
                 res = sel[0].residue
                 names = tuple(a.name for a in res)
                 if (res.name, len(res), names) in res_molecules:
-                    counts[res_molecules[(res.name, len(res), names)]] += 1
+                    counts[res_molecules[(res.name, len(res), names)]].add(i)
                     continue
                 else:
                     res_molecules[(res.name, len(res), names)] = len(structs)
@@ -1301,7 +1301,7 @@ class Structure(object):
                         else:
                             if a1.type != a2.type: break
                     else:
-                        counts[j] += 1
+                        counts[j].add(i)
                         is_duplicate = True
                         break
             if not is_duplicate:
@@ -1313,7 +1313,7 @@ class Structure(object):
                                mol.residue.insertion_code)
                     mol = s
                 structs.append(mol)
-                counts.append(1)
+                counts.append(set([i]))
         return list(zip(structs, counts))
 
     #===================================================

--- a/test/files/12.DPPC/topol3.top
+++ b/test/files/12.DPPC/topol3.top
@@ -1,0 +1,12 @@
+#include "DPPC_2.itp"
+
+; System specifications
+[ system ]
+DPPC Bilayer
+
+[ molecules ]
+; molecule name nr.
+DPPC 4
+SOL	122
+DPPC 4
+SOL 122

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -655,13 +655,13 @@ class TestAmberParmSlice(unittest.TestCase):
         parm = readparm.AmberParm(get_fn('solv.prmtop'))
         parts = parm.split()
         # Make sure the sum of the parts is equal to the whole
-        natom = sum(len(part[0].atoms)*part[1] for part in parts)
+        natom = sum(len(part[0].atoms)*len(part[1]) for part in parts)
         self.assertEqual(len(parm.atoms), natom)
         self.assertEqual(len(parts), 4) # 4 types of molecules
-        self.assertEqual(parts[0][1], 1)
-        self.assertEqual(parts[1][1], 1)
-        self.assertEqual(parts[2][1], 8)
-        self.assertEqual(parts[3][1], 9086)
+        self.assertEqual(len(parts[0][1]), 1)
+        self.assertEqual(len(parts[1][1]), 1)
+        self.assertEqual(len(parts[2][1]), 8)
+        self.assertEqual(len(parts[3][1]), 9086)
 
     def testSplit2(self):
         """ Tests splitting distinct single-residue molecules with same name """
@@ -680,8 +680,8 @@ class TestAmberParmSlice(unittest.TestCase):
         self.assertEqual(len(parts), 2)
         self.assertEqual(len(parts[0][0].atoms), len(parm.atoms))
         self.assertEqual(len(parts[1][0].atoms), len(parm2.atoms))
-        self.assertEqual(parts[0][1], 20)
-        self.assertEqual(parts[1][1], 30)
+        self.assertEqual(len(parts[0][1]), 20)
+        self.assertEqual(len(parts[1][1]), 30)
 
     def testAdd(self):
         """ Tests combining AmberParm instances """

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -228,6 +228,20 @@ class TestGromacsTop(FileIOTestCase):
         self.assertEqual(parm.combining_rule, 'geometric')
         self.assertEqual(parm.defaults.comb_rule, 3)
 
+    def testMoleculeOrdering(self):
+        """ Tests non-contiguous atoms in Gromacs topology file writes """
+        warnings.filterwarnings('ignore', category=GromacsWarning)
+        parm = load_file(os.path.join(get_fn('12.DPPC'), 'topol3.top'))
+        parm.write(get_fn('topol3.top', written=True))
+        parm2 = load_file(get_fn('topol3.top', written=True))
+        self.assertEqual(len(parm.atoms), len(parm2.atoms))
+        self.assertEqual(len(parm.residues), len(parm2.residues))
+        for r1, r2 in zip(parm.residues, parm2.residues):
+            self.assertEqual(r1.name, r2.name)
+            for a1, a2 in zip(r1.atoms, r2.atoms):
+                self.assertEqual(a1.name, a2.name)
+                self.assertEqual(a1.type, a2.type)
+
 class TestGromacsGro(FileIOTestCase):
     """ Tests the Gromacs GRO file parser """
 


### PR DESCRIPTION
Attempt to fix #292 

@mpharrigan -- try this PR out and see if it does the trick.  The `[ molecules ]` section gets a lot longer, since I decided against reordering the atoms.  If I reordered atoms, then the following would *not* work:

```Python
parm.save('gmx.top', format='gromacs')
parm.save('gmx.gro')
```

Since the ordering on `gmx.top` would change relative to `parm`, and the generated GRO file wouldn't match.  You'd have to do something like this instead:

```Python
top = parm.gromacs.GromacsTopologyFile.from_structure(parm)
top.write('gmx.top')
top.save('gmx.gro')
```

And there would be really no good way of catching this mistake.  It's better if everything can have the same order (not always possible).  Let me know if this PR fixes the issues you're seeing and I'll merge it.