### PR TITLE
Always allow `structure` keyword in `load_file` and ignore it when it's not used

### DIFF
--- a/parmed/formats/registry.py
+++ b/parmed/formats/registry.py
@@ -127,10 +127,22 @@ def load_file(filename, *args, **kwargs):
         if not arg in kwargs:
             raise TypeError('%s constructor expects %s keyword argument' %
                             name, arg)
+    # Pass on the "structure" keyword IFF the target function accepts a target
+    # keyword. Otherwise, get rid of it.
     if hasattr(cls, 'parse'):
+        _prune_structure(cls.parse, kwargs)
         return cls.parse(filename, *args, **kwargs)
     elif hasattr(cls, 'open_old'):
+        _prune_structure(cls.open_old, kwargs)
         return cls.open_old(filename, *args, **kwargs)
     elif hasattr(cls, 'open'):
+        _prune_structure(cls.open, kwargs)
         return cls.open(filename, *args, **kwargs)
+    _prune_structure(cls.__init__, kwargs)
     return cls(filename, *args, **kwargs)
+
+def _prune_structure(func, kwargs):
+    if 'structure' in kwargs:
+        if ('structure' not in
+                func.func_code.co_varnames[:func.func_code.co_argcount]):
+            kwargs.pop('structure')

--- a/parmed/formats/registry.py
+++ b/parmed/formats/registry.py
@@ -144,5 +144,5 @@ def load_file(filename, *args, **kwargs):
 def _prune_structure(func, kwargs):
     if 'structure' in kwargs:
         if ('structure' not in
-                func.func_code.co_varnames[:func.func_code.co_argcount]):
+                func.__code__.co_varnames[:func.__code__.co_argcount]):
             kwargs.pop('structure')

--- a/parmed/formats/registry.py
+++ b/parmed/formats/registry.py
@@ -65,6 +65,13 @@ def load_file(filename, *args, **kwargs):
         The name of the file to try to parse. If the filename starts with
         http:// or https://, it is treated like a URL and the file will be
         loaded directly from its remote location on the web
+    structure : object, optional
+        For some classes, such as the Mol2 file class, the default return object
+        is not a Structure, but can be made to return a Structure if the
+        ``structure=True`` keyword argument is passed. To facilitate writing
+        easy code, the ``structure`` keyword is always processed and only passed
+        on to the correct file parser if that parser accepts the structure
+        keyword. There is no default, as each parser has its own default.
     *args : other positional arguments
         Some formats accept positional arguments. These will be passed along
     **kwargs : other options

--- a/parmed/tools/parmlist.py
+++ b/parmed/tools/parmlist.py
@@ -7,7 +7,6 @@ from __future__ import print_function, division, absolute_import
 
 from parmed.utils.six import string_types
 from parmed.structure import Structure
-from parmed.formats.mol2 import Mol2File
 from parmed.formats.registry import load_file
 from parmed.exceptions import FormatNotFound
 from parmed.tools.exceptions import DuplicateParm, ParmIndexError, ParmError
@@ -35,19 +34,8 @@ class ParmList(object):
         if isinstance(parm, string_types):
             if parm in self._parm_names:
                 raise DuplicateParm('%s already in ParmList' % parm)
-            # Mol2 file by default parses to a ResidueTemplate. So we need to
-            # special-case this instance
             try:
-                is_mol2 = Mol2File.id_format(parm)
-            except:
-                # Bare except since we don't know what exception could be raised
-                # and it doesn't really matter
-                is_mol2 = False
-            try:
-                if is_mol2:
-                    parm = load_file(parm, structure=True)
-                else:
-                    parm = load_file(parm)
+                parm = load_file(parm, structure=True)
             except FormatNotFound:
                 raise ParmError('Could not determine file type of %s' % parm)
             if not isinstance(parm, Structure):

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -134,6 +134,12 @@ class TestFileLoader(unittest.TestCase):
                 formats.load_file(get_fn('../test_parmed_formats.py')))
         self.assertRaises(IOError, lambda: formats.load_file('no_file'))
 
+    def testStructureKeyword(self):
+        """ Tests that the structure argument is special-cased in load_file """
+        mol2 = formats.load_file(get_fn('tripos9.mol2'), structure=True)
+        self.assertIsInstance(mol2, Structure)
+        pdb = formats.load_file(get_fn('4lzt.pdb'), structure=True)
+
 class TestChemistryPDBStructure(FileIOTestCase):
     
     def setUp(self):


### PR DESCRIPTION
This closes #290 (and other related threads; it's been brought up a couple times).

This is done in a way that should be future-proof against any parser that may support that argument in the future.  It looks at the argument names and discards `structure` from `**kwargs` IFF `structure` is not found in that argument list.