### PR TITLE
Improvements to CIF and PDB parser/writer

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -936,7 +936,13 @@ class CIFFile(object):
                                                auth.getRowList()])
             reflns = cont.getObj('reflns')
             if reflns is not None:
-                struct.resolution = float(reflns.getValue('d_resolution_high'))
+                res = reflns.getValue('d_resolution_high')
+                if res != '?':
+                    try:
+                        struct.resolution = float(res)
+                    except ValueError:
+                        warnings.warn('Could not convert resolution (%s) to '
+                                      'float' % res)
             cite = cont.getObj('citation_author')
             if cite is not None:
                 nameidx = cite.getAttributeIndex('name')

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 
 from contextlib import closing
 import io
-import itertools
 import ftplib
 try:
     import gzip

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -6,7 +6,7 @@ import utils
 
 import numpy as np
 from parmed import amber, charmm, exceptions, formats, gromacs
-from parmed import (Structure, read_PDB, write_PDB, read_CIF,
+from parmed import (Structure, read_PDB, write_PDB, read_CIF, write_CIF,
                     download_PDB, download_CIF)
 from parmed.modeller import ResidueTemplate, ResidueTemplateContainer
 from parmed.utils.six import iteritems
@@ -223,13 +223,14 @@ class TestChemistryPDBStructure(FileIOTestCase):
     def testPdbWriteModels(self):
         """ Test PDB file writing from NMR structure with models """
         pdbfile = read_PDB(self.models)
-        self.assertEqual(pdbfile.get_coordinates('all').shape[0], 20)
+        self.assertEqual(pdbfile.get_coordinates('all').shape, (20, 451, 3))
         self.assertEqual(len(pdbfile.atoms), 451)
         output = StringIO()
         write_PDB(pdbfile, output)
         output.seek(0)
         pdbfile2 = read_PDB(output)
         self.assertEqual(len(pdbfile2.atoms), 451)
+        self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
         self._compareInputOutputPDBs(pdbfile, pdbfile2)
 
     def testPdbWriteXtal(self):
@@ -591,6 +592,18 @@ class TestChemistryCIFStructure(FileIOTestCase):
     def testDownload(self):
         """ Test CIF downloading on 4LZT """
         self._check4lzt(download_CIF('4lzt'))
+
+    def testCIFModels(self):
+        """ Test CIF parsing/writing NMR structure with 20 models (2koc) """
+        cif = download_CIF('2koc')
+        self.assertEqual(cif.get_coordinates('all').shape, (20, 451, 3))
+        self.assertEqual(len(cif.atoms), 451)
+        output = StringIO()
+        write_CIF(cif, output)
+        output.seek(0)
+        pdbfile2 = read_CIF(output)
+        self.assertEqual(len(pdbfile2.atoms), 451)
+        self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
 
     def _check4lzt(self, cif):
         pdb = read_PDB(self.lztpdb)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -491,6 +491,7 @@ class TestChemistryPDBStructure(FileIOTestCase):
             self.assertEqual(obj.doi, '10.1107/S0907444997013656')
             self.assertEqual(obj.volume, '54')
             self.assertEqual(obj.page, '522')
+            self.assertEqual(obj.resolution, 0.95)
         # Check the TER card is picked up
         for i, residue in enumerate(obj.residues):
             if i == 128:
@@ -640,6 +641,7 @@ class TestChemistryCIFStructure(FileIOTestCase):
         self.assertEqual(cif.volume, '54, 46, 46')
         self.assertEqual(cif.doi, '10.1107/S0907444997013656')
         self.assertEqual(cif.pmid, '9761848')
+        self.assertEqual(cif.resolution, 0.95)
 
 class TestMol2File(FileIOTestCase):
     """ Tests the correct parsing and processing of mol2 files """


### PR DESCRIPTION
The following additions were made to the PDB and CIF parsers:

- Parse X-Ray resolution from both CIF and PDB files with test cases (Closes #297)
- Fixes CIF parser when molecule has multiple models (e.g., PDB ID 2KOC), and adds test
- Adds ability to write PDB and CIF files with multiple `MODEL`s, with corresponding tests
- Simplifies coordinate handling in the writing routines by eliminating the now-vestigial numpy-free support. Just use `ndarray` for all of the coordinates, which significantly simplifies the code.