### PR TITLE
Fix Mol2 file writing when `Structure` does not have defined types

### DIFF
--- a/parmed/formats/mol2.py
+++ b/parmed/formats/mol2.py
@@ -444,7 +444,8 @@ class Mol2File(object):
                     except AttributeError:
                         z = 0
                     dest.write('%8d %-8s %10.4f %10.4f %10.4f %-8s %6d %-8s' % (
-                               j, atom.name, x, y, z, atom.type, i+1, res.name))
+                               j, atom.name, x, y, z,
+                               atom.type.strip() or atom.name, i+1, res.name))
                     if printchg:
                         dest.write(' %10.6f\n' % atom.charge)
                     else:

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -746,6 +746,14 @@ class TestMol2File(FileIOTestCase):
         self.assertEqual(len(mol2), 31)
         self.assertEqual(len(mol2.bonds), 33)
 
+    def testMol2FileWithNoTypeNames(self):
+        """ Tests writing a Mol2 without types uses names instead """
+        struct = read_PDB(get_fn('2koc.pdb'))
+        output = StringIO()
+        formats.Mol2File.write(struct, output)
+        output.seek(0)
+        mol2 = formats.Mol2File.parse(output, structure=True)
+
     def testMol3Structure(self):
         """ Tests parsing a Mol3 file with 1 residue into a Structure """
         mol3 = formats.Mol2File.parse(get_fn('tripos9.mol2'), structure=True)


### PR DESCRIPTION
Fixes #287 