### PR TITLE
Fix small bug in PDB parser

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -255,7 +255,7 @@ class PDBFile(object):
                     atnum, atname, altloc = line[6:11], line[12:16], line[16]
                     resname, chain = line[17:21], line[21]
                     resid, inscode = line[22:resend], line[26]
-                    x, y, z = line[30:38], line[38:46], line[47:54]
+                    x, y, z = line[30:38], line[38:46], line[46:54]
                     occupancy, bfactor = line[54:60], line[60:66]
                     elem, chg = line[76:78], line[78:80]
                     segid = line[72:76].strip() # CHARMM-specific

--- a/test/files/bigz.pdb
+++ b/test/files/bigz.pdb
@@ -1,0 +1,37 @@
+REMARK *                                                                              
+REMARK   DATE:     8/ 5/ 9     14:44:19      CREATED BY USER: mjw                     
+ATOM      1  N   ALA A   1    -100.024-100.103-100.101  1.00  0.00      AAL 
+ATOM      2  HT1 ALA A   1       0.027  -1.132  -0.239  1.00  0.00      AAL 
+ATOM      3  HT2 ALA A   1      -0.805   0.163   0.471  1.00  0.00      AAL 
+ATOM      4  HT3 ALA A   1      -0.059   0.384  -1.019  1.00  0.00      AAL 
+ATOM      5  CA  ALA A   1       1.247   0.375   0.636  1.00  0.00      AAL 
+ATOM      6  HA  ALA A   1       0.814   0.861   1.495  1.00  0.00      AAL 
+ATOM      7  CB  ALA A   1       2.057  -0.772   1.289  1.00  0.00      AAL 
+ATOM      8  HB1 ALA A   1       3.136  -0.752   1.032  1.00  0.00      AAL 
+ATOM      9  HB2 ALA A   1       1.990  -0.641   2.395  1.00  0.00      AAL 
+ATOM     10  HB3 ALA A   1       1.656  -1.782   1.063  1.00  0.00      AAL 
+ATOM     11  C   ALA A   1       1.956   1.579   0.036  1.00  0.00      AAL 
+ATOM     12  O   ALA A   1       1.219   2.525  -0.201  1.00  0.00      AAL 
+ATOM     13  N   ALA A   2       3.289   1.631  -0.202  1.00  0.00      AAL 
+ATOM     14  HN  ALA A   2       3.939   0.868  -0.174  1.00  0.00      AAL 
+ATOM     15  CA  ALA A   2       3.990   2.909  -0.215  1.00  0.00      AAL 
+ATOM     16  HA  ALA A   2       3.742   3.440   0.695  1.00  0.00      AAL 
+ATOM     17  CB  ALA A   2       3.662   3.802  -1.434  1.00  0.00      AAL 
+ATOM     18  HB1 ALA A   2       4.192   4.778  -1.358  1.00  0.00      AAL 
+ATOM     19  HB2 ALA A   2       3.956   3.311  -2.382  1.00  0.00      AAL 
+ATOM     20  HB3 ALA A   2       2.577   4.027  -1.467  1.00  0.00      AAL 
+ATOM     21  C   ALA A   2       5.487   2.654  -0.128  1.00  0.00      AAL 
+ATOM     22  O   ALA A   2       5.889   1.489  -0.137  1.00  0.00      AAL 
+ATOM     23  N   ALA A   3       6.275   3.733  -0.037  1.00  0.00      AAL 
+ATOM     24  HN  ALA A   3       5.963   4.691  -0.028  1.00  0.00      AAL 
+ATOM     25  CA  ALA A   3       7.707   3.802   0.068  1.00  0.00      AAL 
+ATOM     26  HA  ALA A   3       8.160   3.418  -0.833  1.00  0.00      AAL 
+ATOM     27  CB  ALA A   3       8.233   3.093   1.333  1.00  0.00      AAL 
+ATOM     28  HB1 ALA A   3       9.342   3.149   1.356  1.00  0.00      AAL 
+ATOM     29  HB2 ALA A   3       7.835   3.593   2.240  1.00  0.00      AAL 
+ATOM     30  HB3 ALA A   3       7.923   2.030   1.332  1.00  0.00      AAL 
+ATOM     31  C   ALA A   3       8.018   5.323   0.136  1.00  0.00      AAL 
+ATOM     32  OT1 ALA A   3       7.032   6.119   0.127  1.00  0.00      AAL 
+ATOM     33  OT2 ALA A   3       9.219   5.692   0.188  1.00  0.00      AAL 
+TER      34      ALA A   3
+END

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -233,6 +233,13 @@ class TestChemistryPDBStructure(FileIOTestCase):
         self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
         self._compareInputOutputPDBs(pdbfile, pdbfile2)
 
+    def testPdbBigCoordinates(self):
+        """ Test proper PDB coordinate parsing for large coordinates """
+        pdbfile = read_PDB(get_fn('bigz.pdb'))
+        self.assertAlmostEqual(pdbfile.coordinates[0,0], -100.024)
+        self.assertAlmostEqual(pdbfile.coordinates[0,1], -100.103)
+        self.assertAlmostEqual(pdbfile.coordinates[0,2], -100.101)
+
     def testPdbWriteXtal(self):
         """ Test PDB file writing from a Xtal structure """
         pdbfile = read_PDB(self.pdb)


### PR DESCRIPTION
This is a fairly rare bug and occurs when one of the Z-coordinates of a PDB file is the full 8 characters.  Reported by Rohith Mohan on the Amber mailing list.