### PR TITLE
chamberparm's FORCE_FIELD_TYPE should now always contain CHARMM

### DIFF
--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -761,7 +761,6 @@ def ConvertFromPSF(struct, params, title=''):
         if 'CHARMM' not in pset: # needed to trigger "charmm_active"...
             pset = 'CHARMM: %s' % pset
         fftype.extend([len(params.parametersets), pset])
-    print(fftype)
     # Convert atom types back to integers if that's how they started
     if int_starting:
         for atom in struct.atoms:

--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -755,11 +755,13 @@ def ConvertFromPSF(struct, params, title=''):
             atom.type = str(atom.atom_type)
     parm = ChamberParm.from_structure(struct)
     parm.parm_data['FORCE_FIELD_TYPE'] = fftype = []
+    if params.parametersets == []:
+        params.parametersets.append('')
     for pset in params.parametersets:
         if 'CHARMM' not in pset: # needed to trigger "charmm_active"...
             pset = 'CHARMM: %s' % pset
         fftype.extend([len(params.parametersets), pset])
-
+    print(fftype)
     # Convert atom types back to integers if that's how they started
     if int_starting:
         for atom in struct.atoms:

--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -761,6 +761,7 @@ def ConvertFromPSF(struct, params, title=''):
         if 'CHARMM' not in pset: # needed to trigger "charmm_active"...
             pset = 'CHARMM: %s' % pset
         fftype.extend([len(params.parametersets), pset])
+
     # Convert atom types back to integers if that's how they started
     if int_starting:
         for atom in struct.atoms:


### PR DESCRIPTION
Hi Jason,

This addresses an issue encountered when using parmed's chamber command with certain parameter files, including 'par_all36_cgenff.prm' and 'par_opls_aam.inp'. If I understand correctly, the use of the CHARMM force field and its unique terms with a given parm file is triggered by the presence of the string 'CHARMM' under the flag 'FORCE_FIELD_TYPE'. For most CHARMM force field files (e.g. CHARMM36), this will be already be present in the first line of the header of the parameter infile, which parmed copies to this flag. If it is not present in that line, parmed prepends it. However, this action is taken inside a loop over a list that may be empty. With this update, parmed now checks that this array contains at least an empty string.

Best,
Karl