### PR TITLE
Add option to write standard PDB resnames to PDB and CIF files

### DIFF
--- a/parmed/residue.py
+++ b/parmed/residue.py
@@ -114,9 +114,10 @@ class AminoAcidResidue(BiomolecularResidue):
         residue : :class:`AminoAcidResidue`
             The residue corresponding to the given key
 
-        Notes
-        -----
-        If the symbol is not defined, a KeyError is raised
+        Raises
+        ------
+        KeyError if ``key`` is not a symbol, abbreviation, or case-insensitive
+        name of an amino acid residue, or any of its abbreviations.
         """
         if len(key) == 1:
             return cls._all_residues_by_symbol[key.upper()]
@@ -199,9 +200,10 @@ class DNAResidue(BiomolecularResidue):
         residue : :class:`DNAResidue`
             The residue corresponding to the given key
 
-        Notes
-        -----
-        If the symbol is not defined, a KeyError is raised
+        Raises
+        ------
+        KeyError if ``key`` is not a recognized residue name or abbreviation for
+        an DNA residue.
         """
         try:
             if key[-1] in '35':
@@ -246,9 +248,10 @@ class RNAResidue(DNAResidue):
         residue : :class:`RNAResidue`
             The residue corresponding to the given key
 
-        Notes
-        -----
-        If the symbol is not defined, a KeyError is raised
+        Raises
+        ------
+        KeyError if ``key`` is not a recognized residue name or abbreviation for
+        an RNA residue.
         """
         try:
             if key[-1] in '35':

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -5,7 +5,7 @@ from __future__ import division
 import utils
 
 import numpy as np
-from parmed import amber, charmm, exceptions, formats, gromacs
+from parmed import amber, charmm, exceptions, formats, gromacs, residue
 from parmed import (Structure, read_PDB, write_PDB, read_CIF, write_CIF,
                     download_PDB, download_CIF)
 from parmed.modeller import ResidueTemplate, ResidueTemplateContainer
@@ -295,6 +295,18 @@ class TestChemistryPDBStructure(FileIOTestCase):
         # A that has an occupancy of 0.37 and conformer B with occupancy 0.63
         self.assertEqual(pdbfile3.residues[84][4].xx, -4.162)
         self.assertEqual(pdbfile4.residues[84][4].xx, -4.157)
+
+    def testPdbWriteStandardNames(self):
+        """ Test PDB file writing converting to standard names """
+        parm = formats.load_file(get_fn('trx.prmtop'), get_fn('trx.inpcrd'))
+        output = StringIO()
+        write_PDB(parm, output, standard_resnames=True)
+        output.seek(0)
+        pdb = read_PDB(output)
+        for res in pdb.residues:
+            self.assertEqual(
+                    residue.AminoAcidResidue.get(res.name).abbr, res.name
+            )
 
     def testAnisouRead(self):
         """ Tests that read_PDB properly reads ANISOU records """
@@ -611,6 +623,18 @@ class TestChemistryCIFStructure(FileIOTestCase):
         pdbfile2 = read_CIF(output)
         self.assertEqual(len(pdbfile2.atoms), 451)
         self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
+
+    def testCIFWriteStandardNames(self):
+        """ Test PDBx/mmCIF file writing converting to standard names """
+        parm = formats.load_file(get_fn('trx.prmtop'), get_fn('trx.inpcrd'))
+        output = StringIO()
+        write_CIF(parm, output, standard_resnames=True)
+        output.seek(0)
+        pdb = read_CIF(output)
+        for res in pdb.residues:
+            self.assertEqual(
+                    residue.AminoAcidResidue.get(res.name).abbr, res.name
+            )
 
     def _check4lzt(self, cif):
         pdb = read_PDB(self.lztpdb)


### PR DESCRIPTION
Add the ability to write standardized PDB residue names for amino and nucleic
acid residues. This converts common nicknames for various protomers/tautomers
used by programs like Amber to distinguish between them.