### PR TITLE
Go back to using the CPU platform

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -13,7 +13,7 @@ conda config --add channels omnia
 
 if [ -z "$MINIMAL_PACKAGES" ]; then
     conda create -y -n myenv python=$PYTHON_VERSION \
-        numpy scipy netcdf4 pandas nose openmm
+        numpy scipy netcdf4 pandas nose openmm-dev
     conda update -y -n myenv --all
 else
     # Do not install the full numpy/scipy stack

--- a/test/test_openmm_amber.py
+++ b/test/test_openmm_amber.py
@@ -27,7 +27,6 @@ get_fn = utils.get_fn
 
 if has_openmm:
     CPU = mm.Platform.getPlatformByName('CPU')
-    Reference = mm.Platform.getPlatformByName('Reference')
 
 
 # OpenMM NonbondedForce methods are enumerated values. From NonbondedForce.h,
@@ -86,7 +85,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                                    rigidWater=True,
                                    flexibleConstraints=False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 # Etot   =     -1756.2018  EKtot   =       376.7454  EPtot      =     -2132.9472
@@ -136,8 +135,8 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                                     constraints=app.HBonds,
                                     rigidWater=True,
                                     flexibleConstraints=True)
-        con1 = mm.Context(system, mm.VerletIntegrator(0.001), Reference)
-        con2 = mm.Context(system2, mm.VerletIntegrator(0.001), Reference)
+        con1 = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
+        con2 = mm.Context(system2, mm.VerletIntegrator(0.001), CPU)
         con1.setPositions(parm.positions)
         con2.setPositions(parm.positions)
         e1 = decomposed_energy(con1, parm)
@@ -173,7 +172,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                                    rigidWater=True,
                                    flexibleConstraints=False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 0)
@@ -489,8 +488,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator,
-                             platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =     250.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -516,8 +514,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
             if isinstance(force, mm.NonbondedForce):
                 force.setUseDispersionCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator,
-                             platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =     250.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -541,8 +538,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator,
-                             platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before
@@ -569,8 +565,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
                 self.assertTrue(force.getUseLongRangeCorrection())
                 force.setUseLongRangeCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator,
-                             platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =   193.6
@@ -613,7 +608,7 @@ class TestAmberParm(utils.FileIOTestCase, utils.TestCaseRelative):
             if isinstance(force, mm.CustomNonbondedForce):
                 self.assertTrue(force.getUseLongRangeCorrection())
         integrator = mm.VerletIntegrator(1*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 0.9675961, places=3)
@@ -1145,7 +1140,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #Bond         =            1.1324222     Angle        =            1.0688008
@@ -1174,7 +1169,7 @@ class TestChamberParm(utils.TestCaseRelative):
             elif isinstance(force, mm.CustomNonbondedForce):
                 force.setUseLongRangeCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #Bond         =            1.1324222     Angle        =            1.0688008
@@ -1200,7 +1195,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before
@@ -1225,7 +1220,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms,
                                    ewaldErrorTolerance=1e-5)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -1256,7 +1251,7 @@ class TestChamberParm(utils.TestCaseRelative):
             if isinstance(force, mm.NonbondedForce):
                 force.setUseDispersionCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         energies = decomposed_energy(sim.context, parm)
 #NSTEP =        0   TIME(PS) =       0.000  TEMP(K) =     0.00  PRESS =     0.0
@@ -1286,7 +1281,7 @@ class TestChamberParm(utils.TestCaseRelative):
                                    flexibleConstraints=False,
                                    constraints=app.HBonds)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(parm.positions)
         # The only thing that changes here compared to the other periodic tests
         # is the bond energy, which should be slightly smaller than before

--- a/test/test_openmm_charmm.py
+++ b/test/test_openmm_charmm.py
@@ -61,7 +61,6 @@ if has_openmm:
                                  get_fn('toppar_water_ions.str'))
 
     CPU = mm.Platform.getPlatformByName('CPU')
-    Reference = mm.Platform.getPlatformByName('Reference')
 
 def decomposed_energy(context, parm, NRG_UNIT=u.kilocalories_per_mole):
     """ Gets a decomposed energy for a given system """
@@ -287,7 +286,7 @@ class TestCharmmFiles(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstrom)
         self.assertEqual(parm.combining_rule, 'lorentz')
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(charmm_solv_crds.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
@@ -308,7 +307,7 @@ class TestCharmmFiles(utils.TestCaseRelative):
             if isinstance(force, mm.NonbondedForce):
                 force.setUseDispersionCorrection(False)
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(charmm_solv_crds.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertRelativeEqual(energies['bond'], 8578.9872739, places=5)
@@ -326,7 +325,7 @@ class TestCharmmFiles(utils.TestCaseRelative):
                                    nonbondedCutoff=8*u.angstroms)
         self.assertEqual(parm.combining_rule, 'lorentz')
         integrator = mm.VerletIntegrator(1.0*u.femtoseconds)
-        sim = app.Simulation(parm.topology, system, integrator, platform=Reference)
+        sim = app.Simulation(parm.topology, system, integrator, platform=CPU)
         sim.context.setPositions(charmm_nbfix_crds.positions)
         energies = decomposed_energy(sim.context, parm)
         self.assertAlmostEqual(energies['bond'], 1.1324212, places=4)

--- a/test/test_openmm_gromacs.py
+++ b/test/test_openmm_gromacs.py
@@ -9,7 +9,6 @@ try:
     import simtk.openmm.app as app
     has_openmm = True
     CPU = mm.Platform.getPlatformByName('CPU')
-    Reference = mm.Platform.getPlatformByName('Reference')
 except ImportError:
     from parmed.amber.readparm import AmberParm, ChamberParm, Rst7
     has_openmm = False
@@ -205,7 +204,7 @@ class TestGromacsTop(utils.TestCaseRelative):
                                   constraints=app.HBonds,
                                   nonbondedCutoff=0.9*u.nanometers,
                                   ewaldErrorTolerance=1.0e-5)
-        context = mm.Context(system, mm.VerletIntegrator(0.001), Reference)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
         context.setPositions(top.positions)
         energies = energy_decomposition(top, context, nrg=u.kilojoules_per_mole)
 
@@ -235,7 +234,7 @@ class TestGromacsTop(utils.TestCaseRelative):
                                   constraints=app.HBonds,
                                   nonbondedCutoff=0.9*u.nanometers,
                                   ewaldErrorTolerance=1.0e-5)
-        context = mm.Context(system, mm.VerletIntegrator(0.001), Reference)
+        context = mm.Context(system, mm.VerletIntegrator(0.001), CPU)
         context.setPositions(top.positions)
         energies = energy_decomposition(top, context, nrg=u.kilojoules_per_mole)
 

--- a/test/test_openmm_reporters.py
+++ b/test/test_openmm_reporters.py
@@ -8,7 +8,6 @@ try:
     import simtk.openmm as mm
     from simtk.openmm import app
     has_openmm = True
-    Reference = mm.Platform.getPlatformByName('Reference')
     CPU = mm.Platform.getPlatformByName('CPU')
 except ImportError:
     has_openmm = False
@@ -259,7 +258,7 @@ class TestTrajRestartReporter(utils.FileIOTestCase):
                                          nonbondedCutoff=8*u.angstroms)
         integrator = mm.LangevinIntegrator(300*u.kelvin, 5.0/u.picoseconds,
                                            1.0*u.femtoseconds)
-        sim = app.Simulation(amber_solv.topology, system, integrator, Reference)
+        sim = app.Simulation(amber_solv.topology, system, integrator, CPU)
         sim.context.setPositions(amber_solv.positions)
         sim.reporters.extend([
                 NetCDFReporter(get_fn('traj.nc', written=True), 1,


### PR DESCRIPTION
Convert back to using the CPU platform for PME and pull in the openmm-dev
package from conda. See if the recent change to the CPU PME plugin fixes the
weird hangs that I was seeing with Travis *all the time*.