### PR TITLE
Make multiplication operator on Structure commutative

### DIFF
--- a/doc/structure.rst
+++ b/doc/structure.rst
@@ -366,7 +366,7 @@ like with combination, replication can be done both in-place and not::
     <AmberParm 13 atoms; 1 residues; 13 bonds; parametrized>
     >>> phenol * 2
     <AmberParm 26 atoms; 2 residues; 26 bonds; parametrized>
-    >>> phenol * 100
+    >>> 100 * phenol # multiplication can commute
     <AmberParm 1300 atoms; 100 residues; 1300 bonds; parametrized>
     >>> # phenol still hasn't changed
     ... phenol
@@ -375,16 +375,6 @@ like with combination, replication can be done both in-place and not::
     ... phenol *= 10
     >>> phenol
     <AmberParm 130 atoms; 10 residues; 130 bonds; parametrized>
-
-A word of caution here -- the multiplication operator for integers is not
-implemented for :class:`Structure <parmed.structure.Structure>` instances as
-the other operand, so multiplying an integer by the structure will result in a
-``TypeError``::
-
-    >>> 20 * phenol
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    TypeError: unsupported operand type(s) for *: 'int' and 'AmberParm'
 
 One comment about the parameter *type* arrays (e.g., ``bond_type``) -- unlike
 structure combination, all replicates have the *same* parameters, so there is no

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3317,6 +3317,8 @@ class Structure(object):
         cp = copy(self)
         return cp.__imul__(ncopies, self)
 
+    __rmul__ = __mul__
+
     def __imul__(self, ncopies, other=None):
         if not isinstance(ncopies, integer_types):
             return NotImplemented

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -593,6 +593,11 @@ class TestStructureAdd(unittest.TestCase):
         self.assertIsNot(s1, s2)
         self.assertEqual(len(s2.atoms), len(s1.atoms) * multfac)
         self._check_mult(s2, s1, multfac)
+        # Check commutativity
+        s3 = multfac * s1
+        self.assertIsNot(s1, s3)
+        self.assertEqual(len(s3.atoms), len(s1.atoms) * multfac)
+        self._check_mult(s3, s1, multfac)
 
     def testMultiplyNotParametrized(self):
         """ Tests replicating a non-parametrized Structure instance """
@@ -602,6 +607,11 @@ class TestStructureAdd(unittest.TestCase):
         self.assertIsNot(s1, s2)
         self.assertEqual(len(s2.atoms), len(s1.atoms) * multfac)
         self._check_mult(s2, s1, multfac)
+        # Check commutativity
+        s3 = multfac * s1
+        self.assertIsNot(s1, s3)
+        self.assertEqual(len(s3.atoms), len(s1.atoms) * multfac)
+        self._check_mult(s3, s1, multfac)
 
     def testMultNoValence(self):
         """ Tests addition of two minimal Structure instances """


### PR DESCRIPTION
It would be silly to make `struct * 10` behave different than `10 * struct` -- not to mention confusing.  So just go ahead and implement `Structure.__rmul__` as the same as `Structure.__mul__`.  Add a test for it and update docs.

Closes #286 