### PR TITLE
Add `Structure.view`

### DIFF
--- a/doc/structure.rst
+++ b/doc/structure.rst
@@ -347,15 +347,31 @@ There are three many ways to select from a :class:`Structure
    atoms.
 
 When selecting from a :class:`Structure <parmed.structure.Structure>`
-instance, the return value can be one of three things:
+instance, the return value can be one of two things:
 
-1. ``None`` if no atoms match the selection criteria
-2. :class:`Atom <parmed.topologyobjects.Atom>` instance if the selection
-   matches only a single atom. This instance is a reference to the original
-   atom, it is *not* a copy.
-3. :class:`Structure <parmed.structure.Structure>` with all of the selected
+1. :class:`Atom <parmed.topologyobjects.Atom>` instance if the selection
+   specified only a single atom either by atom index, atom index *within* a
+   residue index, or an atom index *within* a residue index *within* a single
+   chain.
+2. :class:`Structure <parmed.structure.Structure>` with all of the selected
    atoms and all parameters that were present between the selected atoms. In
-   this case, a copy is made of all selected atoms.
+   this case, a copy is made of all selected atoms. If no atoms were selected,
+   the resulting structure is empty, and will evaluate to boolean ``False``.
+   Note that selections return the same type as the original object being
+   selected, so the resulting object may be a subclass of :class:`Structure
+   <parmed.structure.Structure>`.
+
+**NOTE**
+
+The return value of a selection---unless it is selecting a single atom---is a
+*copy* of the original structure, meaning that changes to the result of the
+slice will *not* change the structure from which you sliced.
+
+This is not always desirable. In cases where you want the resulting structure to
+contain the *same* atoms, residues, bonds, etc. as the original Structure so
+that you can simplify the process of modifying a subset of the structure, you
+want to use the ``view`` descriptor of :class:`Structure
+<parmed.structure.Structure>` instead.  This is described in more detail below.
 
 **Let's look at the simplest form of the selection syntax -- by atom index**::
 
@@ -484,6 +500,31 @@ we defined above::
 
 There is so much flexiblity in the Atom selection here that we can't possibly
 cover everything. You are encouraged to try things out!
+
+Structure views
+~~~~~~~~~~~~~~~
+
+In the previous section, we alluded to a way of applying the selection syntax to
+obtain a *view* of a structure, rather than a full copy of the subset of
+selected atoms. You still need to familiarize yourself with the selection
+syntax, as it is the same when you are trying to take a view.
+
+However, instead of selecting directly from the :class:`Structure
+<parmed.structure.Structure>` instance, you instead select from
+``Structure.view``, as demonstrated below on a downloaded PDB::
+
+    >>> import parmed as pmd
+    >>> pdb = pmd.download_PDB('4lzt')
+    >>> pdb.residues[0]
+    <Residue LYS[1]; chain=A>
+    >>> # Changing a slice does NOT change the original
+    ... pdb[:1,:].residues[0].name = 'MOL'
+    >>> pdb.residues[0]
+    <Residue LYS[1]; chain=A>
+    >>> # However, changing a view DOES change the original
+    ... pdb.view[:1,:].residues[0].name = 'MOL'
+    >>> pdb.residues[0]
+    <Residue MOL[1]; chain=A>
 
 Structure Combining
 ~~~~~~~~~~~~~~~~~~~

--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -9,7 +9,7 @@ __author__ = 'Jason Swails'
 from parmed import exceptions, periodic_table, residue
 from parmed import unit, utils
 from parmed.topologyobjects import *
-from parmed.structure import Structure
+from parmed.structure import Structure, StructureView
 from parmed import amber, charmm, gromacs, tinker, openmm, rosetta
 from parmed import formats
 from parmed.vec3 import Vec3

--- a/parmed/amber/amberformat.py
+++ b/parmed/amber/amberformat.py
@@ -388,7 +388,7 @@ class AmberFormat(object):
 
     #===================================================
 
-    def view(self, cls):
+    def view_as(self, cls):
         """
         Returns a view of the current object as another object.
 

--- a/parmed/amber/readparm.py
+++ b/parmed/amber/readparm.py
@@ -61,11 +61,11 @@ def LoadParm(parmname, xyz=None, box=None, rst7_name=None):
     from parmed.constants import IFBOX
     parm = AmberFormat(parmname)
     if 'CTITLE' in parm.flag_list:
-        parm = parm.view(ChamberParm)
+        parm = parm.view_as(ChamberParm)
     elif 'AMOEBA_FORCEFIELD' in parm.flag_list:
-        parm = parm.view(AmoebaParm)
+        parm = parm.view_as(AmoebaParm)
     else:
-        parm = parm.view(AmberParm)
+        parm = parm.view_as(AmberParm)
 
     # Now read the coordinate file if applicable
     if xyz is None and rst7_name is not None:

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3673,6 +3673,18 @@ class StructureView(object):
                     self.donors)
         # Ignore types here because it's just a view
 
+    def __repr__(self):
+        natom = len(self.atoms)
+        nres = len(self.residues)
+        nextra = sum([isinstance(a, ExtraPoint) for a in self.atoms])
+        retstr = ['<%s %d atoms' % (type(self).__name__, natom)]
+        if nextra > 0:
+            retstr.append(' [%d EPs]' % nextra)
+        retstr.append('; %d residues' % nres)
+        nbond = len(self.bonds)
+        retstr.append('; %d bonds>' % nbond)
+        return ''.join(retstr)
+
     def __nonzero__(self):
         # For Python 2
         return self.__bool__()

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -183,9 +183,9 @@ class Structure(object):
     angles : :class:`TrackedList` (:class:`Angle`)
         List of all angles in the structure
     dihedrals : :class:`TrackedList` (:class:`Dihedral`)
-        List of all dihedrals in the structure -- only one term per dihedral, so
-        multi-term dihedral parameters will have the same 4 atoms appear
-        multiple times in the list
+        List of all dihedrals in the structure
+    rb_torsions : :class:`TrackedList` (:class:`RBTorsion`)
+        List of all Ryckaert-Bellemans torsions in the structure
     urey_bradleys : :class:`TrackedList` (:class:`UreyBradley`)
         List of all Urey-Bradley angle bends in the structure
     impropers : :class:`TrackedList` (:class:`Improper`)
@@ -1017,129 +1017,17 @@ class Structure(object):
         ``ValueError`` : if the selection is a boolean-like list and its length
                          is not the same as the number of atoms in the system
         """
-        from parmed.amber import AmberMask
         if isinstance(selection, integer_types):
             return self.atoms[selection]
 
-        # Now we select a subset of atoms. Convert "selection" into a natom list
-        # with 0s and 1s, depending on what the input selection is
-        if isinstance(selection, string_types):
-            mask = AmberMask(self, selection)
-            selection = mask.Selection()
-        elif isinstance(selection, slice):
-            sel = [0 for a in self.atoms]
-            for idx in list(range(len(self.atoms)))[selection]:
-                sel[idx] = 1
-            selection = sel
-        elif isinstance(selection, tuple) and len(selection) in (2, 3):
-            # This is a selection of chains, and/or residues, and/or atoms
-            if len(selection) == 2:
-                # Select just residues and atoms. Special-case a single-atom
-                # selection for speed -- orders of magnitude improvement in
-                # efficiency
-                ressel, atomsel = selection
-                if (isinstance(ressel, integer_types) and
-                        isinstance(atomsel, integer_types)):
-                    return self.residues[ressel][atomsel]
-                has_chain = False
-            elif len(selection) == 3:
-                chainsel, ressel, atomsel = selection
-                chainmap = defaultdict(TrackedList)
-                for r in self.residues:
-                    chainmap[r.chain].append(r)
-                if (isinstance(chainsel, string_types) and
-                        isinstance(ressel, integer_types) and
-                        isinstance(atomsel, integer_types)):
-                    # Special-case single-atom selection for efficiency
-                    try:
-                        return chainmap[chainsel][ressel][atomsel]
-                    except KeyError:
-                        raise IndexError('No chain %s in Structure' % chainsel)
-                if isinstance(chainsel, string_types):
-                    if chainsel in chainmap:
-                        chainset = set([chainsel])
-                    else:
-                        # The selected chain is not in the system. Cannot
-                        # possibly select *any* atoms. Bail now for speed
-                        return type(self)()
-                elif isinstance(chainsel, slice):
-                    # Build an ordered set of chains
-                    chains = [self.residues[0].chain]
-                    for res in self.residues:
-                        if res.chain != chains[-1]:
-                            chains.append(res.chain)
-                    chainset = set(chains[chainsel])
-                else:
-                    chainset = set(chainsel)
-                for chain in chainset:
-                    if chain in chainmap:
-                        break
-                else:
-                    # No requested chain is present. Bail now for speed
-                    return type(self)()
-                has_chain = True
-            # Residue selection can either be by name or index
-            if isinstance(ressel, slice):
-                resset = set(list(range(len(self.residues)))[ressel])
-            elif isinstance(ressel, string_types) or isinstance(ressel,
-                    integer_types):
-                resset = set([ressel])
-            else:
-                resset = set(ressel)
-            if isinstance(atomsel, slice):
-                atomset = set(list(range(len(self.atoms)))[atomsel])
-            elif isinstance(atomsel, string_types) or isinstance(atomsel,
-                    integer_types):
-                atomset = set([atomsel])
-            else:
-                atomset = set(atomsel)
-            if has_chain:
-                try:
-                    # To allow us to index the atoms residues from their list of
-                    # chains, temporarily have the chainmap lists claim the
-                    # residues. This must be reversed or the Structure will be
-                    # broken
-                    for chain_name, chain in iteritems(chainmap):
-                        chain.claim()
-                    selection = [
-                            (a.residue.chain in chainset) and
-                            (a.residue.name in resset or
-                                a.residue.idx in resset) and
-                            (a.name in atomset or
-                                a.idx-a.residue[0].idx in atomset)
-
-                            for a in self.atoms
-                    ]
-                finally:
-                    # Make sure that the residues list *always* reclaims its
-                    # contents
-                    self.residues.claim()
-            else:
-                selection = [
-                    (a.name in atomset or a.idx-a.residue[0].idx in atomset)
-                    and (a.residue.name in resset or a.residue.idx in resset)
-                            for a in self.atoms
-                ]
-        else:
-            # Assume it is an iterable. If it is the same length as the atoms,
-            # it is a boolean mask array. Otherwise, it is a list of atom
-            # indices to select
-            sel = [0 for atom in self.atoms]
-            selection = list(selection)
-            if len(selection) == len(self.atoms):
-                for i, val in enumerate(selection):
-                    if val: sel[i] = 1
-            elif len(selection) > len(self.atoms):
-                raise ValueError('Selection iterable is too long')
-            else:
-                try:
-                    for val in selection:
-                        sel[val] = 1
-                except IndexError:
-                    raise ValueError('Selected atom out of range')
-            selection = sel
-        # Make sure we have an integer array of 0s and 1s
-        selection = [int(bool(x)) for x in selection]
+        selection = self._get_selection_array(selection)
+        # _get_selection_array might have returned either an Atom or None if
+        # there is no selection. Handle those and return, or continue if we got
+        # a list of atoms
+        if selection is None:
+            return type(self)()
+        elif isinstance(selection, Atom):
+            return selection
         sumsel = sum(selection)
         if sumsel == 0:
             # No atoms selected. Return None
@@ -1244,6 +1132,151 @@ class Structure(object):
         copy_valence_terms(struct.groups, [], self.groups, [],
                            ['bs', 'type', 'move'])
         return struct
+
+    def _get_selection_array(self, selection):
+        """
+        Private method to convert a selection into an array -- common use for
+        viewing and regular selection
+
+        Parameters
+        ----------
+        selection : selector (slice, tuple, ... etc.)
+            The selection given to the [] operator
+        """
+        from parmed.amber import AmberMask
+        # Now we select a subset of atoms. Convert "selection" into a natom list
+        # with 0s and 1s, depending on what the input selection is
+        if isinstance(selection, string_types):
+            mask = AmberMask(self, selection)
+            selection = mask.Selection()
+        elif isinstance(selection, slice):
+            sel = [0 for a in self.atoms]
+            for idx in list(range(len(self.atoms)))[selection]:
+                sel[idx] = 1
+            selection = sel
+        elif isinstance(selection, tuple) and len(selection) in (2, 3):
+            # This is a selection of chains, and/or residues, and/or atoms
+            if len(selection) == 2:
+                # Select just residues and atoms. Special-case a single-atom
+                # selection for speed -- orders of magnitude improvement in
+                # efficiency
+                ressel, atomsel = selection
+                if (isinstance(ressel, integer_types) and
+                        isinstance(atomsel, integer_types)):
+                    return self.residues[ressel][atomsel]
+                has_chain = False
+            elif len(selection) == 3:
+                chainsel, ressel, atomsel = selection
+                chainmap = defaultdict(TrackedList)
+                for r in self.residues:
+                    chainmap[r.chain].append(r)
+                if (isinstance(chainsel, string_types) and
+                        isinstance(ressel, integer_types) and
+                        isinstance(atomsel, integer_types)):
+                    # Special-case single-atom selection for efficiency
+                    try:
+                        return chainmap[chainsel][ressel][atomsel]
+                    except KeyError:
+                        raise IndexError('No chain %s in Structure' % chainsel)
+                if isinstance(chainsel, string_types):
+                    if chainsel in chainmap:
+                        chainset = set([chainsel])
+                    else:
+                        # The selected chain is not in the system. Cannot
+                        # possibly select *any* atoms. Bail now for speed
+                        return None
+                elif isinstance(chainsel, slice):
+                    # Build an ordered set of chains
+                    chains = [self.residues[0].chain]
+                    for res in self.residues:
+                        if res.chain != chains[-1]:
+                            chains.append(res.chain)
+                    chainset = set(chains[chainsel])
+                else:
+                    chainset = set(chainsel)
+                for chain in chainset:
+                    if chain in chainmap:
+                        break
+                else:
+                    # No requested chain is present. Bail now for speed
+                    return None
+                has_chain = True
+            # Residue selection can either be by name or index
+            if isinstance(ressel, slice):
+                resset = set(list(range(len(self.residues)))[ressel])
+            elif isinstance(ressel, string_types) or isinstance(ressel,
+                    integer_types):
+                resset = set([ressel])
+            else:
+                resset = set(ressel)
+            if isinstance(atomsel, slice):
+                atomset = set(list(range(len(self.atoms)))[atomsel])
+            elif isinstance(atomsel, string_types) or isinstance(atomsel,
+                    integer_types):
+                atomset = set([atomsel])
+            else:
+                atomset = set(atomsel)
+            if has_chain:
+                try:
+                    # To allow us to index the atoms residues from their list of
+                    # chains, temporarily have the chainmap lists claim the
+                    # residues. This must be reversed or the Structure will be
+                    # broken
+                    for chain_name, chain in iteritems(chainmap):
+                        chain.claim()
+                    selection = [
+                            (a.residue.chain in chainset) and
+                            (a.residue.name in resset or
+                                a.residue.idx in resset) and
+                            (a.name in atomset or
+                                a.idx-a.residue[0].idx in atomset)
+
+                            for a in self.atoms
+                    ]
+                finally:
+                    # Make sure that the residues list *always* reclaims its
+                    # contents
+                    self.residues.claim()
+            else:
+                selection = [
+                    (a.name in atomset or a.idx-a.residue[0].idx in atomset)
+                    and (a.residue.name in resset or a.residue.idx in resset)
+                            for a in self.atoms
+                ]
+        else:
+            # Assume it is an iterable. If it is the same length as the atoms,
+            # it is a boolean mask array. Otherwise, it is a list of atom
+            # indices to select
+            sel = [0 for atom in self.atoms]
+            selection = list(selection)
+            if len(selection) == len(self.atoms):
+                for i, val in enumerate(selection):
+                    if val: sel[i] = 1
+            elif len(selection) > len(self.atoms):
+                raise ValueError('Selection iterable is too long')
+            else:
+                try:
+                    for val in selection:
+                        sel[val] = 1
+                except IndexError:
+                    raise ValueError('Selected atom out of range')
+            selection = sel
+        # Make sure we have an integer array of 0s and 1s
+        return [int(bool(x)) for x in selection]
+
+    #===================================================
+
+    @property
+    def view(self):
+        """
+        Returns an indexable object that can be indexed like a standard
+        Structure, but returns a *view* rather than a copy
+
+        See Also
+        --------
+        Structure.__getitem__
+        """
+        return _StructureViewerCreator(self)
 
     #===================================================
 
@@ -3445,5 +3478,204 @@ class Structure(object):
                 system.addForce(f)
             return
         system.addForce(force)
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+class _StructureViewerCreator(object):
+    """ Class responsible for creating a StructureView when indexed """
+
+    def __init__(self, struct):
+        self.struct = struct
+
+    def __getitem__(self, selection):
+        struct = self.struct
+        if isinstance(selection, integer_types):
+            return struct.atoms[selection]
+
+        view = StructureView()
+        selection = struct._get_selection_array(selection)
+        # _get_selection_array might have returned either an Atom or None if
+        # there is no selection. Handle those and return, or continue if we got
+        # a list of atoms
+        if selection is None:
+            return view
+        elif isinstance(selection, Atom):
+            return selection
+        sumsel = sum(selection)
+        if sumsel == 0:
+            # No atoms selected. Return None
+            return view
+        # The cumulative sum of selection will give our index + 1 of each
+        # selected atom into the new structure
+        scan = [selection[0]]
+        for i in range(1, len(selection)):
+            scan.append(scan[i-1] + selection[i])
+        # Zero-out the unselected atoms
+        scan = [x * y for x, y in zip(scan, selection)]
+        # Copy all parameters
+        sel_res = set()
+        for i, atom in enumerate(struct.atoms):
+            if not selection[i]: continue
+            view.atoms.append(atom)
+            if atom.residue in sel_res: continue
+            view.residues.append(atom.residue)
+            sel_res.add(atom.residue)
+        def add_valence_terms(oval, sval, attrlist):
+            """ Adds the valence terms from one list to another;
+            oval=Other VALence; otyp=Other TYPe; sval=Self VALence;
+            styp=Self TYPe; attrlist=ATTRibute LIST (atom1, atom2, ...)
+            """
+            for val in sval:
+                ats = [getattr(val, attr) for attr in attrlist]
+                # Make sure all of our atoms in this valence term is "selected"
+                indices = [scan[at.idx] for at in ats if isinstance(at, Atom)]
+                if not all(indices):
+                    continue
+                # Add the type if applicable
+                oval.append(val)
+        add_valence_terms(view.bonds, struct.bonds, ['atom1', 'atom2'])
+        add_valence_terms(view.angles, struct.angles,
+                          ['atom1', 'atom2', 'atom3'])
+        add_valence_terms(view.dihedrals, struct.dihedrals,
+                          ['atom1', 'atom2', 'atom3', 'atom4'])
+        add_valence_terms(view.rb_torsions, struct.rb_torsions,
+                          ['atom1', 'atom2', 'atom3', 'atom4'])
+        add_valence_terms(view.urey_bradleys, struct.urey_bradleys,
+                          ['atom1', 'atom2'])
+        add_valence_terms(view.impropers, struct.impropers,
+                          ['atom1', 'atom2', 'atom3', 'atom4'])
+        add_valence_terms(view.cmaps, struct.cmaps,
+                          ['atom1', 'atom2', 'atom3', 'atom4', 'atom5'])
+        add_valence_terms(view.trigonal_angles, struct.trigonal_angles,
+                          ['atom1', 'atom2', 'atom3', 'atom4'])
+        add_valence_terms(view.out_of_plane_bends, struct.out_of_plane_bends,
+                          ['atom1', 'atom2', 'atom3', 'atom4'])
+        add_valence_terms(view.pi_torsions, struct.pi_torsions,
+                          ['atom1', 'atom2', 'atom3', 'atom4', 'atom5',
+                           'atom6'])
+        add_valence_terms(view.stretch_bends, struct.stretch_bends,
+                          ['atom1', 'atom2', 'atom3'])
+        add_valence_terms(view.torsion_torsions, struct.torsion_torsions,
+                          ['atom1', 'atom2', 'atom3', 'atom4', 'atom5'])
+        add_valence_terms(view.chiral_frames, struct.chiral_frames,
+                          ['atom1', 'atom2'])
+        add_valence_terms(view.multipole_frames, struct.multipole_frames,
+                          ['atom'])
+        add_valence_terms(view.adjusts, struct.adjusts, ['atom1', 'atom2'])
+        add_valence_terms(view.donors, struct.donors, ['atom1', 'atom2'])
+        add_valence_terms(view.acceptors, struct.acceptors, ['atom1', 'atom2'])
+        return view
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+class StructureView(object):
+    """
+    A view of a Structure. In many cases, this can serve as a duck-typed
+    Structure and it has many of the same attributes. However, none of its lists
+    *own* their objects, and the lists of atoms, residues, and
+    parameters/topologies are regular lists, rather than TrackedList instances.
+    Therefore, the indexes correspond to the indexes from the *original*
+    Structure from which this view was taken. Furthermore, there are no "type"
+    lists, as they would be exactly equivalent to the type lists of the parent
+    Structure instance.
+
+    Attributes
+    ----------
+    atoms : :class:`AtomList`
+        List of all atoms in the structure
+    residues : :class:`ResidueList`
+        List of all residues in the structure
+    bonds : :class:`TrackedList` (:class:`Bond`)
+        List of all bonds in the structure
+    angles : :class:`TrackedList` (:class:`Angle`)
+        List of all angles in the structure
+    dihedrals : :class:`TrackedList` (:class:`Dihedral`)
+        List of all dihedrals in the structure
+    rb_torsions : :class:`TrackedList` (:class:`RBTorsion`)
+        List of all Ryckaert-Bellemans torsions in the structure
+    urey_bradleys : :class:`TrackedList` (:class:`UreyBradley`)
+        List of all Urey-Bradley angle bends in the structure
+    impropers : :class:`TrackedList` (:class:`Improper`)
+        List of all CHARMM-style improper torsions in the structure
+    cmaps : :class:`TrackedList` (:class:`Cmap`)
+        List of all CMAP objects in the structure
+    trigonal_angles : :class:`TrackedList` (:class:`TrigonalAngle`)
+        List of all AMOEBA-style trigonal angles in the structure
+    out_of_plane_bends : :class:`TrackedList` (:class:`OutOfPlaneBends`)
+        List of all AMOEBA-style out-of-plane bending angles
+    pi_torsions : :class:`TrackedList` (:class:`PiTorsion`)
+        List of all AMOEBA-style pi-torsion angles
+    stretch_bends : :class:`TrackedList` (:class:`StretchBend`)
+        List of all AMOEBA-style stretch-bend compound bond/angle terms
+    torsion_torsions : :class:`TrackedList` (:class:`TorsionTorsion`)
+        List of all AMOEBA-style coupled torsion-torsion terms
+    chiral_frames : :class:`TrackedList` (:class:`ChiralFrame`)
+        List of all AMOEBA-style chiral frames defined in the structure
+    multipole_frames : :class:`TrackedList` (:class:`MultipoleFrame`)
+        List of all AMOEBA-style multipole frames defined in the structure
+    adjusts : :class:`TrackedList` (:class:`NonbondedException`)
+        List of all nonbonded pair-exception rules
+    acceptors : :class:`TrackedList` (:class:`AcceptorDonor`)
+        List of all H-bond acceptors, if that information is present
+    donors : :class:`TrackedList` (:class:`AcceptorDonor`)
+        List of all H-bond donors, if that information is present
+    positions : u.Quantity(list(Vec3), u.angstroms)
+        Unit-bearing atomic coordinates. If not all atoms have coordinates, this
+        property is None
+    coordinates : np.ndarray of shape (nframes, natom, 3)
+        If no coordinates are set, this is set to None. The first frame will
+        match the coordinates present on the atoms.
+    """
+
+    def __init__(self):
+        self.atoms = []
+        self.residues = []
+        self.bonds = []
+        self.angles = []
+        self.dihedrals = []
+        self.rb_torsions = []
+        self.urey_bradleys = []
+        self.impropers = []
+        self.cmaps = []
+        self.trigonal_angles = []
+        self.out_of_plane_bends = []
+        self.pi_torsions = []
+        self.stretch_bends = []
+        self.torsion_torsions = []
+        self.chiral_frames = []
+        self.multipole_frames = []
+        self.adjusts = []
+        self.acceptors = []
+        self.donors = []
+
+    @property
+    def coordinates(self):
+        try:
+            return np.array([[a.xx, a.xy, a.xz] for a in self.atoms])
+        except AttributeError:
+            return None
+
+    @property
+    def positions(self):
+        try:
+            return [Vec3(a.xx,a.xy,a.xz) for a in self.atoms] * u.angstroms
+        except AttributeError:
+            return None
+
+    def __bool__(self):
+        return bool(self.atoms or self.residues or self.bonds or self.angles or
+                    self.dihedrals or self.impropers or self.rb_torsions or
+                    self.cmaps or self.torsion_torsions or self.stretch_bends or
+                    self.out_of_plane_bends or self.trigonal_angles or
+                    self.torsion_torsions or self.pi_torsions or
+                    self.urey_bradleys or self.chiral_frames or
+                    self.multipole_frames or self.adjusts or self.acceptors or
+                    self.donors)
+        # Ignore types here because it's just a view
+
+    def __nonzero__(self):
+        # For Python 2
+        return self.__bool__()
+
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -689,7 +689,7 @@ class TestFileWriting(utils.FileIOTestCase):
             if attr.startswith('_'): continue
             # Skip descriptors
             if attr in ('topology', 'positions', 'box_vectors',
-                        'velocities', 'name'):
+                        'velocities', 'name', 'view'):
                 continue
             if callable(getattr(cpsf, attr)): continue
             if hasattr(getattr(cpsf, attr), '__len__'):
@@ -717,7 +717,7 @@ class TestFileWriting(utils.FileIOTestCase):
         for attr in dir(cpsf):
             if attr.startswith('_'): continue
             if attr in ('topology', 'positions', 'box_vectors',
-                        'velocities', 'name'):
+                        'velocities', 'name', 'view'):
                 continue
             if callable(getattr(cpsf, attr)): continue
             if hasattr(getattr(cpsf, attr), '__len__'):

--- a/test/test_parmed_structure_slicing.py
+++ b/test/test_parmed_structure_slicing.py
@@ -308,16 +308,28 @@ class TestStructureViewSlicing(unittest.TestCase):
         # Check that the atoms sliced out are correct
         for atom in sl11.atoms:
             self.assertIs(atom, parm.atoms[atom.idx])
+        for atom in sl12.atoms:
+            self.assertIs(atom, parm.atoms[atom.idx])
+        for atom in sl13.atoms:
+            self.assertIs(atom, parm.atoms[atom.idx])
+        for atom in sl21.atoms:
+            self.assertIs(atom, pdb1.atoms[atom.idx])
         for atom in sl22.atoms:
-            self.assertIs(atom, parm.atoms[atom.idx])
+            self.assertIs(atom, pdb1.atoms[atom.idx])
+        for atom in sl23.atoms:
+            self.assertIs(atom, pdb1.atoms[atom.idx])
+        for atom in sl31.atoms:
+            self.assertIs(atom, pdb2.atoms[atom.idx])
+        for atom in sl32.atoms:
+            self.assertIs(atom, pdb2.atoms[atom.idx])
         for atom in sl33.atoms:
-            self.assertIs(atom, parm.atoms[atom.idx])
+            self.assertIs(atom, pdb2.atoms[atom.idx])
 
     def testMaskArray(self):
         """ Tests Structure selection using a mask array (view) """
         mask = [a.name in ('CA', 'CB') for a in parm.atoms]
         sel = parm.view[mask]
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         self.assertEqual(len(sel.atoms), 207)
         for atom in sel.atoms:
             self.assertIn(atom.name, ('CA', 'CB'))
@@ -334,7 +346,7 @@ class TestStructureViewSlicing(unittest.TestCase):
     def testResidueAtomSelection(self):
         """ Tests combined residue,atom slicing/selections (view) """
         sel = pdb1.view[10:20,:5] # First five atoms of residues 10-19
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         self.assertEqual(len(sel.atoms), 49) # 1 residue has only 4 atoms
         c = 0
         for res in pdb1.residues[10:20]:
@@ -343,7 +355,7 @@ class TestStructureViewSlicing(unittest.TestCase):
                 c += 1
 
         sel = pdb1.view[[0,2,3,5], :2] # First 2 atoms of residues 0, 2, 3, and 5
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         self.assertEqual(len(sel.atoms), 8)
         c = 0
         for i, res in enumerate([0, 2, 3, 5]):
@@ -354,7 +366,7 @@ class TestStructureViewSlicing(unittest.TestCase):
             c += 1
 
         sel = pdb1.view[8,:]
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         self.assertEqual(len(sel.atoms), len(pdb1.residues[8]))
         for a1, a2 in zip(sel.atoms, pdb1.residues[8]):
             self.assertIs(a1, a2)
@@ -362,7 +374,7 @@ class TestStructureViewSlicing(unittest.TestCase):
         self.assertIs(pdb1[8,4], pdb1.residues[8][4])
 
         sel = pdb1.view[['ALA', 'GLY'], :]
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         for atom in sel.atoms:
             self.assertIn(atom.residue.name, ('ALA', 'GLY'))
             self.assertIs(atom.list, pdb1.atoms)
@@ -375,7 +387,7 @@ class TestStructureViewSlicing(unittest.TestCase):
     def testChainResidueAtomSelection(self):
         """ Tests combined chain,residue,atom slicing/selections (view) """
         sel = pdb2.view['A',:,:] # All of chain A
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         for a in sel.atoms:
             self.assertEqual(a.residue.chain, 'A')
             self.assertIs(a.list, pdb2.atoms)
@@ -387,5 +399,5 @@ class TestStructureViewSlicing(unittest.TestCase):
         sel = pdb2.view['B',0,0]
         self.assertIs(sel, pdb2.atoms[826])
         sel = pdb2.view[['A','B'], :10:2, 0]
-        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertIsInstance(sel, pmd.structure.StructureView)
         self.assertEqual(len(sel.atoms), 2*5*1)

--- a/test/test_parmed_structure_slicing.py
+++ b/test/test_parmed_structure_slicing.py
@@ -57,6 +57,7 @@ class TestStructureSlicing(unittest.TestCase):
         self.assertEqual(len(sel2.atoms), 1)
 
     def testEmptyStructure(self):
+        """ Tests empty selection of a Structure (view) """
         sel1 = parm[10000000:]
         sel2 = pdb1['@NOTHING']
         sel3 = pdb2['G',:,:]
@@ -209,4 +210,182 @@ class TestStructureSlicing(unittest.TestCase):
         sel = pdb2['B',0,0]
         self.assertIs(sel, pdb2.atoms[826])
         sel = pdb2[['A','B'], :10:2, 0]
+        self.assertEqual(len(sel.atoms), 2*5*1)
+
+class TestStructureViewSlicing(unittest.TestCase):
+    """ Tests the fancy slicing/indexing of Structure """
+
+    def testIntIndex(self):
+        """ Tests simple Structure indexing (integer) (view) """
+        for i, atom in enumerate(parm.atoms):
+            self.assertIs(atom, parm.view[i])
+        for i, atom in enumerate(pdb1.atoms):
+            self.assertIs(atom, pdb1.view[i])
+        for i, atom in enumerate(pdb2.atoms):
+            self.assertIs(atom, pdb2.view[i])
+
+    def testTwoIntIndex(self):
+        """ Tests simple Structure view w/ residue and atom (int, int) """
+        for i, res in enumerate(parm.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], parm.view[i,j])
+        for i, res in enumerate(pdb1.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], pdb1.view[i,j])
+        for i, res in enumerate(pdb2.residues):
+            for j, atom in enumerate(res):
+                self.assertIs(res[j], pdb2.view[i,j])
+
+    def testThreeSimpleIndex(self):
+        """ Tests simple indexing with chain, residue, and atom ID (view) """
+        chains = defaultdict(pmd.TrackedList)
+        for res in pdb2.residues:
+            chains[res.chain].append(res)
+        for chain_name, chain in iteritems(chains):
+            for i, res in enumerate(chain):
+                for j, atom in enumerate(res):
+                    self.assertIs(atom, pdb2.view[chain_name, i, j])
+
+    def testSingleAtomSlice(self):
+        """ Test that non-trivial, single-atom selections give StructureView """
+        sel1 = parm.view['@1']
+        sel2 = parm.view[:1]
+        self.assertIsInstance(sel1, pmd.structure.StructureView)
+        self.assertIsInstance(sel2, pmd.structure.StructureView)
+        self.assertEqual(len(sel1.atoms), 1)
+        self.assertEqual(len(sel2.atoms), 1)
+        self.assertIs(sel1.atoms[0], parm.atoms[0])
+        self.assertIs(sel2.atoms[0], parm.atoms[0])
+
+    def testEmptyStructure(self):
+        """ Tests empty selection of a Structure (view) """
+        sel1 = parm.view[10000000:]
+        sel2 = pdb1.view['@NOTHING']
+        sel3 = pdb2.view['G',:,:]
+        sel4 = parm.view['NOTHING',:]
+        self.assertFalse(sel1)
+        self.assertFalse(sel2)
+        self.assertFalse(sel3)
+        self.assertFalse(sel4)
+        self.assertIsInstance(sel1, pmd.structure.StructureView)
+        self.assertIsInstance(sel2, pmd.structure.StructureView)
+        self.assertIsInstance(sel3, pmd.structure.StructureView)
+        self.assertIsInstance(sel4, pmd.structure.StructureView)
+
+    def testSimpleSlice(self):
+        """ Tests simple atom slicing (view) """
+        sl11 = parm.view[:10]
+        sl21 = pdb1.view[:10]
+        sl31 = pdb2.view[:10]
+        sl12 = parm.view[10:20]
+        sl22 = pdb1.view[10:20]
+        sl32 = pdb2.view[10:20]
+        sl13 = parm.view[5:100:5] # 19 selections -- 100 not inclusive
+        sl23 = pdb1.view[5:100:5]
+        sl33 = pdb2.view[5:100:5]
+        # Check that the slices are all the correct # of atoms
+        self.assertEqual(len(sl11.atoms), 10)
+        self.assertEqual(len(sl21.atoms), 10)
+        self.assertEqual(len(sl31.atoms), 10)
+        self.assertEqual(len(sl12.atoms), 10)
+        self.assertEqual(len(sl22.atoms), 10)
+        self.assertEqual(len(sl32.atoms), 10)
+        self.assertEqual(len(sl13.atoms), 19)
+        self.assertEqual(len(sl23.atoms), 19)
+        self.assertEqual(len(sl33.atoms), 19)
+
+        # Check that the resulting types of the slices are correct
+        self.assertIsInstance(sl11, pmd.structure.StructureView)
+        self.assertIsInstance(sl21, pmd.structure.StructureView)
+        self.assertIsInstance(sl31, pmd.structure.StructureView)
+        self.assertIsInstance(sl12, pmd.structure.StructureView)
+        self.assertIsInstance(sl22, pmd.structure.StructureView)
+        self.assertIsInstance(sl32, pmd.structure.StructureView)
+        self.assertIsInstance(sl13, pmd.structure.StructureView)
+        self.assertIsInstance(sl23, pmd.structure.StructureView)
+        self.assertIsInstance(sl33, pmd.structure.StructureView)
+
+        # Check that the atoms sliced out are correct
+        for atom in sl11.atoms:
+            self.assertIs(atom, parm.atoms[atom.idx])
+        for atom in sl22.atoms:
+            self.assertIs(atom, parm.atoms[atom.idx])
+        for atom in sl33.atoms:
+            self.assertIs(atom, parm.atoms[atom.idx])
+
+    def testMaskArray(self):
+        """ Tests Structure selection using a mask array (view) """
+        mask = [a.name in ('CA', 'CB') for a in parm.atoms]
+        sel = parm.view[mask]
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertEqual(len(sel.atoms), 207)
+        for atom in sel.atoms:
+            self.assertIn(atom.name, ('CA', 'CB'))
+
+    def testSelectionArray(self):
+        """ Tests Structure selection using indices array (view) """
+        indices = [random.randint(0, len(pdb1.atoms)-1) for i in range(100)]
+        sel = pdb1.view[indices]
+        self.assertEqual(len(sel.atoms), len(set(indices)))
+        self.assertGreater(len(sel.atoms), 0)
+        for i, val in enumerate(sorted(set(indices))):
+            self.assertIs(sel.atoms[i], pdb1.atoms[sel.atoms[i].idx])
+
+    def testResidueAtomSelection(self):
+        """ Tests combined residue,atom slicing/selections (view) """
+        sel = pdb1.view[10:20,:5] # First five atoms of residues 10-19
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertEqual(len(sel.atoms), 49) # 1 residue has only 4 atoms
+        c = 0
+        for res in pdb1.residues[10:20]:
+            for i in range(min(len(res), 5)):
+                self.assertIs(sel.atoms[c], res[i])
+                c += 1
+
+        sel = pdb1.view[[0,2,3,5], :2] # First 2 atoms of residues 0, 2, 3, and 5
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertEqual(len(sel.atoms), 8)
+        c = 0
+        for i, res in enumerate([0, 2, 3, 5]):
+            res = pdb1.residues[res]
+            self.assertIs(sel.atoms[c], res[0])
+            c += 1
+            self.assertIs(sel.atoms[c], res[1])
+            c += 1
+
+        sel = pdb1.view[8,:]
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        self.assertEqual(len(sel.atoms), len(pdb1.residues[8]))
+        for a1, a2 in zip(sel.atoms, pdb1.residues[8]):
+            self.assertIs(a1, a2)
+
+        self.assertIs(pdb1[8,4], pdb1.residues[8][4])
+
+        sel = pdb1.view[['ALA', 'GLY'], :]
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        for atom in sel.atoms:
+            self.assertIn(atom.residue.name, ('ALA', 'GLY'))
+            self.assertIs(atom.list, pdb1.atoms)
+
+        nalagly = sum(r.name in ('ALA', 'GLY') for r in pdb1.residues)
+        natom = sum(len(r) for r in pdb1.residues if r.name in ('ALA', 'GLY'))
+        self.assertEqual(nalagly, len(sel.residues))
+        self.assertEqual(natom, len(sel.atoms))
+
+    def testChainResidueAtomSelection(self):
+        """ Tests combined chain,residue,atom slicing/selections (view) """
+        sel = pdb2.view['A',:,:] # All of chain A
+        self.assertIsInstance(sel, parmed.structure.StructureView)
+        for a in sel.atoms:
+            self.assertEqual(a.residue.chain, 'A')
+            self.assertIs(a.list, pdb2.atoms)
+        # Get all chains
+        chainA = pdb2.view['A',:,:]
+        chainB = pdb2.view['B',:,:]
+        chainC = pdb2.view['C',:,:]
+        # Now try some different kinds of indexing
+        sel = pdb2.view['B',0,0]
+        self.assertIs(sel, pdb2.atoms[826])
+        sel = pdb2.view[['A','B'], :10:2, 0]
+        self.assertIsInstance(sel, parmed.structure.StructureView)
         self.assertEqual(len(sel.atoms), 2*5*1)


### PR DESCRIPTION
This makes it so you can use the selection/slicing syntax to obtain a view of the Structure data rather than a copy.  It will let you do something like this:

```Python
struct = pmd.load_file('something.prmtop')

# The following changes all of the charges in all atoms in residues 100 to 200
# of struct to 0, since this is a view and not a copy
for atom in struct.view[100:200,:]:
    atom.charge = 0
```

Closes #278 
cc #272 -- this would work for that code snippet as well