### PR TITLE
Open scipy NetCDF files with mmap=False

### DIFF
--- a/parmed/amber/netcdffiles.py
+++ b/parmed/amber/netcdffiles.py
@@ -63,7 +63,8 @@ except ImportError:
 
 try:
     from scipy.io.netcdf import netcdf_file as spNetCDFFile
-    spopen_netcdf = lambda name, mode: spNetCDFFile(name, mode)
+    spopen_netcdf = lambda name, mode: \
+            spNetCDFFile(name, mode, mmap=False, version=2)
     spget_int_dimension = lambda obj, name: obj.dimensions[name]
     spget_float = lambda obj, name: obj.variables[name].getValue()
     _HAS_SCIPY_NETCDF = True


### PR DESCRIPTION
We don't make much use of the mmap feature here (ParmEd is not particularly
concerned about memory usage in trajectory processing -- other libraries are
optimized for that).

Also make sure that scipy-generated files are opened in 64-bit offset mode.

Fixes #358 