### PR TITLE
Special-case natom and hasbox keywords in load_file

### DIFF
--- a/parmed/formats/registry.py
+++ b/parmed/formats/registry.py
@@ -72,6 +72,12 @@ def load_file(filename, *args, **kwargs):
         easy code, the ``structure`` keyword is always processed and only passed
         on to the correct file parser if that parser accepts the structure
         keyword. There is no default, as each parser has its own default.
+    natom : int, optional
+        This is needed for some coordinate file classes, but not others. This is
+        treated the same as ``structure``, above. It is the # of atoms expected
+    hasbox : bool, optional
+        Same as ``natom``, but indicates whether the coordinate file has unit
+        cell dimensions
     *args : other positional arguments
         Some formats accept positional arguments. These will be passed along
     **kwargs : other options
@@ -138,19 +144,27 @@ def load_file(filename, *args, **kwargs):
     # Pass on the "structure" keyword IFF the target function accepts a target
     # keyword. Otherwise, get rid of it.
     if hasattr(cls, 'parse'):
-        _prune_structure(cls.parse, kwargs)
+        _prune_argument(cls.parse, kwargs, 'structure')
+        _prune_argument(cls.parse, kwargs, 'natom')
+        _prune_argument(cls.parse, kwargs, 'hasbox')
         return cls.parse(filename, *args, **kwargs)
     elif hasattr(cls, 'open_old'):
-        _prune_structure(cls.open_old, kwargs)
+        _prune_argument(cls.open_old, kwargs, 'structure')
+        _prune_argument(cls.open_old, kwargs, 'natom')
+        _prune_argument(cls.open_old, kwargs, 'hasbox')
         return cls.open_old(filename, *args, **kwargs)
     elif hasattr(cls, 'open'):
-        _prune_structure(cls.open, kwargs)
+        _prune_argument(cls.open, kwargs, 'structure')
+        _prune_argument(cls.open, kwargs, 'natom')
+        _prune_argument(cls.open, kwargs, 'hasbox')
         return cls.open(filename, *args, **kwargs)
-    _prune_structure(cls.__init__, kwargs)
+    _prune_argument(cls.__init__, kwargs, 'structure')
+    _prune_argument(cls.__init__, kwargs, 'natom')
+    _prune_argument(cls.__init__, kwargs, 'hasbox')
     return cls(filename, *args, **kwargs)
 
-def _prune_structure(func, kwargs):
-    if 'structure' in kwargs:
-        if ('structure' not in
+def _prune_argument(func, kwargs, keyword):
+    if keyword in kwargs:
+        if (keyword not in
                 func.__code__.co_varnames[:func.__code__.co_argcount]):
-            kwargs.pop('structure')
+            kwargs.pop(keyword)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -149,6 +149,15 @@ class TestFileLoader(unittest.TestCase):
         self.assertIsInstance(mol2, Structure)
         pdb = formats.load_file(get_fn('4lzt.pdb'), structure=True)
 
+    def testNatomHasboxKeyword(self):
+        """ Tests that the hasbox/natom arguments are special-cased in load_file """
+        crd = formats.load_file(get_fn('tz2.truncoct.crd'), natom=5827,
+                                hasbox=True)
+        self.assertIsInstance(crd, amber.AmberMdcrd)
+        crd = formats.load_file(get_fn('tz2.truncoct.nc'), natom=5827,
+                                hasbox=True)
+        self.assertIsInstance(crd, amber.NetCDFTraj)
+
 class TestChemistryPDBStructure(FileIOTestCase):
     
     def setUp(self):

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -154,9 +154,14 @@ class TestFileLoader(unittest.TestCase):
         crd = formats.load_file(get_fn('tz2.truncoct.crd'), natom=5827,
                                 hasbox=True)
         self.assertIsInstance(crd, amber.AmberMdcrd)
-        crd = formats.load_file(get_fn('tz2.truncoct.nc'), natom=5827,
-                                hasbox=True)
-        self.assertIsInstance(crd, amber.NetCDFTraj)
+        if amber.HAS_NETCDF:
+            crd = formats.load_file(get_fn('tz2.truncoct.nc'), natom=5827,
+                                    hasbox=True)
+            self.assertIsInstance(crd, amber.NetCDFTraj)
+        else:
+            crd = formats.load_file(get_fn('trx.prmtop'), natom=5827,
+                                    hasbox=True)
+            self.assertIsInstance(crd, amber.AmberParm)
 
 class TestChemistryPDBStructure(FileIOTestCase):
     


### PR DESCRIPTION
Some coordinate file types (e.g., Amber ASCII trajectories) require natom and
hasbox to know whether or not that information is present in the file. Just like
the ``structure`` keyword, these keywords are not required for all coordinate
file types, so let them pass silently if they're not needed, but given.