### PR TITLE
PARMED: add charge as a property for Structure and its view

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1485,6 +1485,18 @@ class Structure(object):
                 for atom in self.atoms:
                     atom.type = int(atom.atom_type)
 
+    @property
+    def charge(self):
+        '''return charge as 1D numpy array'''
+        return np.array([atom.charge for atom in self.atoms])
+
+    @charge.setter
+    def charge(self, values):
+        if len(values) != len(self.atoms):
+            raise ValueError('length of values must be equal to natom')
+        for input_charge, atom in zip(values, self.atoms):
+            atom.charge = input_charge
+
     #===================================================
 
     @property
@@ -3689,6 +3701,18 @@ class StructureView(object):
             return [Vec3(a.xx,a.xy,a.xz) for a in self.atoms] * u.angstroms
         except AttributeError:
             return None
+
+    @property
+    def charge(self):
+        '''return charge as 1D numpy array'''
+        return np.array([atom.charge for atom in self.atoms])
+
+    @charge.setter
+    def charge(self, values):
+        if len(values) != len(self.atoms):
+            raise ValueError('length of values must be equal to natom')
+        for input_charge, atom in zip(values, self.atoms):
+            atom.charge = input_charge
 
     def __bool__(self):
         return bool(self.atoms or self.residues or self.bonds or self.angles or

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -945,5 +945,11 @@ class TestStructureSave(FileIOTestCase):
         pdb = pmd.load_file(get_fn('test.pdb', written=True))
         self.assertEqual(len(pdb.atoms), len(self.sys1.atoms))
 
+    def testChargeAssignment(self):
+        parm = pmd.load_file(get_fn('tripos1.mol2'), structure=True)
+        charges = [1., 2., 0.2]
+        parm.view[[0, 2, 3]].charge = charges
+        np.testing.assert_allclose(parm[[0, 2, 3]].charge, charges)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_parmed_structure.py
+++ b/test/test_parmed_structure.py
@@ -950,6 +950,11 @@ class TestStructureSave(FileIOTestCase):
         charges = [1., 2., 0.2]
         parm.view[[0, 2, 3]].charge = charges
         np.testing.assert_allclose(parm[[0, 2, 3]].charge, charges)
+        # raise ValueError if len of input charges is not equal natom
+
+        def wrong_shape():
+            parm.view[[0, 2, 3]].charge = [0., 1.5]
+        self.assertRaises(ValueError, lambda: wrong_shape())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Motivation: charge is important. Should treat it differently.

I knew we had discussion about adding more property and you did not want to make the api complicated. But charge is important (that why people make R.E.D server). So we need to make it access as easy as possible in parmed.

Look at below code to see how easy we can assign charge without writing `for ...` loop?

```python
charges = [1., 2., 0.2]
parm.view[[0, 2, 3]].charge = charges

# get charge info?
parm.charge.sum()
parm[[0, 3, 7]].charge.sum()

(p0 + p1).charge

p3.charge = (p1['@CA'] +  p['@H=']).charge
```