### PR TITLE
Make PQR file detection stricter

### DIFF
--- a/parmed/formats/pqr.py
+++ b/parmed/formats/pqr.py
@@ -57,16 +57,12 @@ class PQRFile(object):
                     # Format is:
                     # rec atnum atname resname [chain] resnum x y z chg radius
                     # Where the chain ID is optional. rec must be ATOM or HETATM
-                    if len(words) < 10:
+                    if len(words) not in (10, 11):
                         return False
                     elif len(words) == 10:
                         offset = 0
-                    elif len(words) >= 11:
+                    elif len(words) == 11:
                         offset = 1
-                        try:
-                            float(words[10])
-                        except ValueError:
-                            offset = 0
                     if not words[1].isdigit(): return False
                     if words[2].isdigit(): return False
                     if words[3].isdigit(): return False

--- a/parmed/formats/pqr.py
+++ b/parmed/formats/pqr.py
@@ -7,7 +7,7 @@ from contextlib import closing
 import numpy as np
 from parmed.exceptions import PDBError, PDBWarning
 from parmed.formats.registry import FileFormatType
-from parmed.formats.pdb import _standardize_resname
+from parmed.formats.pdb import _standardize_resname, PDBFile
 from parmed.periodic_table import AtomicNum, Mass, Element, element_by_name
 from parmed.structure import Structure
 from parmed.topologyobjects import Atom, ExtraPoint
@@ -57,12 +57,19 @@ class PQRFile(object):
                     # Format is:
                     # rec atnum atname resname [chain] resnum x y z chg radius
                     # Where the chain ID is optional. rec must be ATOM or HETATM
-                    if len(words) not in (10, 11):
+                    if len(words) < 10:
                         return False
-                    elif len(words) == 10:
+                    elif PDBFile.id_format(filename):
+                        return False # It is a PDB file
+
+                    if len(words) == 10:
                         offset = 0
-                    elif len(words) == 11:
+                    elif len(words) >= 11:
                         offset = 1
+                        try:
+                            float(words[10])
+                        except ValueError:
+                            offset = 0
                     if not words[1].isdigit(): return False
                     if words[2].isdigit(): return False
                     if words[3].isdigit(): return False

--- a/test/test_openmm_reporters.py
+++ b/test/test_openmm_reporters.py
@@ -250,7 +250,7 @@ class TestTrajRestartReporter(utils.FileIOTestCase):
         f = AmberAsciiRestart(get_fn('restart.rst7', written=True), 'r')
         # Compare to ncrst and make sure it's the same data
         np.testing.assert_allclose(ncrst.coordinates, f.coordinates, rtol=1e-4)
-        np.testing.assert_allclose(ncrst.velocities, f.velocities, rtol=1e-4)
+        np.testing.assert_allclose(ncrst.velocities, f.velocities, rtol=1e-3)
 
     def testReportersPBC(self):
         """ Test NetCDF and ASCII restart and trajectory reporters (w/ PBC) """

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -601,7 +601,6 @@ class TestParmedPQRStructure(FileIOTestCase):
 
     def testPQRWithElement(self):
         """ Tests reading a PQR file that has an element column """
-        self.assertTrue(formats.PQRFile.id_format(get_fn('elem.pqr')))
         pqr = formats.PQRFile.parse(get_fn('elem.pqr'))
         self.assertEqual(len(pqr.atoms), 458)
         self.assertEqual(len(pqr.residues), 14)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -601,6 +601,7 @@ class TestParmedPQRStructure(FileIOTestCase):
 
     def testPQRWithElement(self):
         """ Tests reading a PQR file that has an element column """
+        self.assertTrue(formats.PQRFile.id_format(get_fn('elem.pqr')))
         pqr = formats.PQRFile.parse(get_fn('elem.pqr'))
         self.assertEqual(len(pqr.atoms), 458)
         self.assertEqual(len(pqr.residues), 14)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -23,7 +23,7 @@ def reset_stringio(io):
     io.truncate()
     return io
 
-class TestFileLoader(unittest.TestCase):
+class TestFileLoader(FileIOTestCase):
     """ Tests the automatic file loader """
 
     def testLoadOFF(self):
@@ -154,6 +154,13 @@ class TestFileLoader(unittest.TestCase):
         self.assertEqual(pqr.atoms[-1].atomic_number, 8)
         self.assertIsInstance(random.choice(pqr.residues).number, int)
         self.assertIsInstance(random.choice(pqr.atoms).number, int)
+
+    def testMisdetectPQR(self):
+        """ Check that PQR autodetection does not identify a PDB file """
+        pdb = formats.PDBFile.download('3p4a')
+        fname = get_fn('3p4a_chainA.pdb', written=True)
+        pdb['A',:,:].save(fname)
+        self.assertFalse(formats.PQRFile.id_format(fname))
 
     def testBadLoads(self):
         """ Test exception handling when non-recognized files are loaded """


### PR DESCRIPTION
PQR files are too similar to PDB files to properly distinguish between all variants of both.  So make it so PQR files are *only* detected if it doesn't appear to be a valid PDB file.