### PR TITLE
Modified nu residue names

### DIFF
--- a/parmed/residue.py
+++ b/parmed/residue.py
@@ -268,13 +268,17 @@ DC = DNAResidue('Cytosine', 'DC', ['CYT', 'DC5', 'DC3', 'DCN', 'DCP'])
 DA = DNAResidue('Adenine', 'DA', ['ADE', 'DA5', 'DA3', 'DAN', 'DAP'])
 DT = DNAResidue('Thymine', 'DT', ['THY', 'DT5', 'DT3'])
 G = RNAResidue('Guanine', 'G', ['GUA', 'G5', 'G3', 'GN',
-                                'RG', 'RG3', 'RG5', 'RGN'])
+                                'RG', 'RG3', 'RG5', 'RGN',
+                                'GF2',])
 C = RNAResidue('Cytosine', 'C', ['CYT', 'CP', 'C5', 'C3', 'CN',
-                                 'RC', 'RC5', 'RC3', 'RCN'])
+                                 'RC', 'RC5', 'RC3', 'RCN',
+                                 'CFZ',])
 A = RNAResidue('Adenine', 'A', ['ADE', 'AP', 'A5', 'A3', 'AN',
-                                'RA', 'RA3', 'RA5'])
+                                'RA', 'RA3', 'RA5',
+                                'AF2',])
 U = RNAResidue('Uracil', 'U', ['URA', 'U3', 'U5', 'UN',
-                               'RU', 'RU3', 'RU5', 'RUN'])
+                               'RU', 'RU3', 'RU5', 'RUN',
+                               'UFT',])
 
 SOLVENT_NAMES = set(['WAT', 'HOH', 'TIP3', 'SOL',
                      'TIP4', 'TIP5', 'SPCE', 'SPC'])

--- a/parmed/residue.py
+++ b/parmed/residue.py
@@ -269,16 +269,17 @@ DA = DNAResidue('Adenine', 'DA', ['ADE', 'DA5', 'DA3', 'DAN', 'DAP'])
 DT = DNAResidue('Thymine', 'DT', ['THY', 'DT5', 'DT3'])
 G = RNAResidue('Guanine', 'G', ['GUA', 'G5', 'G3', 'GN',
                                 'RG', 'RG3', 'RG5', 'RGN',
-                                'GF2',])
+                                'GF2', 'M2G', 'YYG', '7MG', 'OMG',
+                                '2MG', 'MG',])
 C = RNAResidue('Cytosine', 'C', ['CYT', 'CP', 'C5', 'C3', 'CN',
                                  'RC', 'RC5', 'RC3', 'RCN',
-                                 'CFZ',])
+                                 'CFZ', '5MC', 'OMC',])
 A = RNAResidue('Adenine', 'A', ['ADE', 'AP', 'A5', 'A3', 'AN',
                                 'RA', 'RA3', 'RA5',
-                                'AF2',])
+                                'AF2', '1MA'])
 U = RNAResidue('Uracil', 'U', ['URA', 'U3', 'U5', 'UN',
                                'RU', 'RU3', 'RU5', 'RUN',
-                               'UFT',])
+                               'UFT', '5MU', 'H2U', 'PSU',])
 
 SOLVENT_NAMES = set(['WAT', 'HOH', 'TIP3', 'SOL',
                      'TIP4', 'TIP5', 'SPCE', 'SPC'])

--- a/parmed/residue.py
+++ b/parmed/residue.py
@@ -270,7 +270,7 @@ DT = DNAResidue('Thymine', 'DT', ['THY', 'DT5', 'DT3'])
 G = RNAResidue('Guanine', 'G', ['GUA', 'G5', 'G3', 'GN',
                                 'RG', 'RG3', 'RG5', 'RGN',
                                 'GF2', 'M2G', 'YYG', '7MG', 'OMG',
-                                '2MG', 'MG',])
+                                '2MG',])
 C = RNAResidue('Cytosine', 'C', ['CYT', 'CP', 'C5', 'C3', 'CN',
                                  'RC', 'RC5', 'RC3', 'RCN',
                                  'CFZ', '5MC', 'OMC',])

--- a/test/test_parmed_residue.py
+++ b/test/test_parmed_residue.py
@@ -139,11 +139,11 @@ class TestNucleicAcidResidues(unittest.TestCase):
                     nnuc += 1
             return nnuc
 
-        pdb_with_nnures = [('1EHZ', 76), ('3p4a', 8), ('3p4b', 8),
-                           ('3p4c', 8), ('3p4d', 8)]
-        for pdbid, nres in pdb_with_nnures:
+        pdb_with_nnures = [('1EHZ', 76), ]
+        for pdbid, correct_nres in pdb_with_nnures:
             pdb = pmd.download_PDB(pdbid)
-            self.assertTrue(count_nures(pdb), nres)
+            nres = count_nures(pdb)
+            self.assertTrue(correct_nres == nres)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_parmed_residue.py
+++ b/test/test_parmed_residue.py
@@ -3,7 +3,9 @@ Tests the functionality in parmed.residue
 """
 
 import utils
+import parmed as pmd
 from parmed import residue
+from parmed.residue import RNAResidue, DNAResidue
 import unittest
 
 class TestChemistryResidue(unittest.TestCase):
@@ -127,6 +129,21 @@ class TestNucleicAcidResidues(unittest.TestCase):
         self.assertTrue(residue.DNAResidue.has('DG5'))
         self.assertTrue(residue.DNAResidue.has('DG3'))
         self.assertFalse(residue.RNAResidue.has('G4'))
+
+    def testModifiedDNARNA(self):
+        """ Tests that modified DNA/RNA residue names are properly recognized"""
+        def count_nures(parm):
+            nnuc = 0
+            for res in parm.residues:
+                if RNAResidue.has(res.name) or DNAResidue.has(res.name):
+                    nnuc += 1
+            return nnuc
+
+        pdb_with_nnures = [('1EHZ', 76), ('3p4a', 8), ('3p4b', 8),
+                           ('3p4c', 8), ('3p4d', 8)]
+        for pdbid, nres in pdb_with_nnures:
+            pdb = pmd.download_PDB(pdbid)
+            self.assertTrue(count_nures(pdb), nres)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_parmed_residue.py
+++ b/test/test_parmed_residue.py
@@ -143,7 +143,7 @@ class TestNucleicAcidResidues(unittest.TestCase):
         for pdbid, correct_nres in pdb_with_nnures:
             pdb = pmd.download_PDB(pdbid)
             nres = count_nures(pdb)
-            self.assertTrue(correct_nres == nres)
+            self.assertEqual(correct_nres, nres)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
taken from 

3P4{A,B,C,D} and 1EHZ.

I will update if I see new ones (and the test is not very comprehensive)

scripts:
```python
import parmed as pmd

pdb_list = ['1EHZ',]

standard = set(('A', 'U', 'C', 'G', 'HOH'))

four_letters = ('A', 'U', 'C', 'G')

for pdbidb in pdb_list:
    t = pmd.download_PDB(pdbidb)
    resset = set(res.name.rstrip() for res in t.residues) - standard
    for c in four_letters:
        print (c, [x for x in resset if c in x])
```