### PR TITLE
Fix writing PDB and PQR files with multiple models

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -722,7 +722,7 @@ class PDBFile(object):
                 else:
                     atoms = sorted(res.atoms, key=lambda atom: atom.number)
                 for atom in atoms:
-                    pa, others, (x, y, z) = print_atoms(atom, coords[0])
+                    pa, others, (x, y, z) = print_atoms(atom, coord)
                     # Figure out the serial numbers we want to print
                     if renumber:
                         anum = (atom.idx + 1 + nmore)

--- a/parmed/formats/pqr.py
+++ b/parmed/formats/pqr.py
@@ -296,9 +296,10 @@ class PQRFile(object):
                         aname = ' %-3s' % atom.name
                     else:
                         aname = atom.name
+                    xyz = coord[atom.idx]
                     dest.write(atomrec % (anum, aname, standardize(res.name),
-                                          res.chain, rnum, atom.xx, atom.xy,
-                                          atom.xz, atom.charge, atom.radii))
+                                          res.chain, rnum, xyz[0], xyz[1],
+                                          xyz[2], atom.charge, atom.radii))
             if coords.shape[0] > 1:
                 dest.write('ENDMDL\n')
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -2689,8 +2689,8 @@ class Structure(object):
         else:
             raise ValueError('Unexpected implicit solvent model... '
                              'should not be here')
-        for i, atom in enumerate(self.atoms):
-            force.addParticle([atom.charge] + list(gb_parms[i]))
+        for atom, parms in zip(self.atoms, gb_parms):
+            force.addParticle([atom.charge] + list(parms))
         # Set cutoff method
         if nonbondedMethod is app.NoCutoff:
             force.setNonbondedMethod(mm.CustomGBForce.NoCutoff)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1023,85 +1023,100 @@ class TestFileDownloader(unittest.TestCase):
 
     def testDownloadOFF(self):
         """ Tests automatic loading of downloaded OFF files """
-        off = formats.load_file(self.url + 'amino12.lib')
+        self.assertTrue(amber.AmberOFFLibrary.id_format(self.url + 'amino12.lib'))
+        off = amber.AmberOFFLibrary.parse(self.url + 'amino12.lib')
         self.assertIsInstance(off, dict)
         for key, item in iteritems(off):
             self.assertIsInstance(item, ResidueTemplate)
 
     def testDownloadAmberParm(self):
         """ Tests automatic loading of downloaded AmberParm object """
-        parm = formats.load_file(self.url + 'tip4p.parm7')
+        self.assertTrue(amber.AmberFormat.id_format(self.url + 'tip4p.parm7'))
+        parm = amber.AmberFormat.parse(self.url + 'tip4p.parm7')
         self.assertIsInstance(parm, amber.AmberParm)
 
     def testDownloadAmoebaParm(self):
         """ Tests automatic loading of downloaded AmoebaParm object """
-        parm = formats.load_file(self.url + 'nma.parm7')
+        self.assertTrue(amber.AmberFormat.id_format(self.url + 'nma.parm7'))
+        parm = amber.AmberFormat.parse(self.url + 'nma.parm7')
         self.assertIsInstance(parm, amber.AmoebaParm)
 
     def testDownloadChamberParm(self):
         """ Tests automatic loading of downloaded ChamberParm object """
-        parm = formats.load_file(self.url + 'ala_ala_ala.parm7')
+        self.assertTrue(amber.AmberFormat.id_format(self.url + 'ala_ala_ala.parm7'))
+        parm = amber.AmberFormat.parse(self.url + 'ala_ala_ala.parm7')
         self.assertIsInstance(parm, amber.ChamberParm)
 
     def testDownloadAmberFormat(self):
         """ Tests automatic loading of downloaded AmberFormat object """
-        parm = formats.load_file(self.url + 'cSPCE.mdl')
+        self.assertTrue(amber.AmberFormat.id_format(self.url + 'cSPCE.mdl'))
+        parm = amber.AmberFormat.parse(self.url + 'cSPCE.mdl')
         self.assertIsInstance(parm, amber.AmberFormat)
         self.assertNotIsInstance(parm, amber.AmberParm)
 
     def testDownloadAmberRestart(self):
         """ Tests automatic loading of downloaded Amber ASCII restart file """
-        parm = formats.load_file(self.url + 'trx.inpcrd')
+        self.assertTrue(amber.AmberAsciiRestart.id_format(self.url + 'trx.inpcrd'))
+        parm = amber.AmberAsciiRestart(self.url + 'trx.inpcrd')
         self.assertIsInstance(parm, amber.AmberAsciiRestart)
 
     def testDownloadAmberMdcrd(self):
         """ Tests automatic loading of downloaded Amber mdcrd file """
-        crd = formats.load_file(self.url + 'tz2.truncoct.crd', natom=5827,
-                                hasbox=True)
+        self.assertTrue(amber.AmberMdcrd.id_format(self.url + 'tz2.truncoct.crd'))
+        crd = amber.AmberMdcrd(self.url + 'tz2.truncoct.crd', natom=5827, hasbox=True)
         self.assertIsInstance(crd, amber.AmberMdcrd)
 
     def testDownloadCharmmPsfFile(self):
         """ Tests automatic loading of downloaded CHARMM PSF file """
-        parm = formats.load_file(self.url + 'ala_ala_ala.psf')
+        self.assertTrue(formats.PSFFile.id_format(self.url + 'ala_ala_ala.psf'))
+        parm = formats.PSFFile.parse(self.url + 'ala_ala_ala.psf')
         self.assertIsInstance(parm, charmm.CharmmPsfFile)
 
     def testDownloadCharmmCrdFile(self):
         """ Tests automatic loading of downloaded CHARMM crd file """
-        crd = formats.load_file(self.url + 'dhfr_min_charmm.crd')
+        self.assertTrue(charmm.CharmmCrdFile.id_format(self.url + 'dhfr_min_charmm.crd'))
+        crd = charmm.CharmmCrdFile(self.url + 'dhfr_min_charmm.crd')
         self.assertIsInstance(crd, charmm.CharmmCrdFile)
 
     def testDownloadCharmmRestart(self):
         """ Tests automatic loading of downloaded CHARMM restart file """
-        crd = formats.load_file(self.url + 'sample-charmm.rst')
+        self.assertTrue(charmm.CharmmRstFile.id_format(self.url + 'sample-charmm.rst'))
+        crd = charmm.CharmmRstFile(self.url + 'sample-charmm.rst')
         self.assertIsInstance(crd, charmm.CharmmRstFile)
 
     def testDownloadPDB(self):
         """ Tests automatic loading of downloaded PDB files """
-        pdb = formats.load_file(self.url + '4lzt.pdb')
+        self.assertTrue(formats.PDBFile.id_format(self.url + '4lzt.pdb'))
+        pdb = formats.PDBFile.parse(self.url + '4lzt.pdb')
         self.assertIsInstance(pdb, Structure)
         self.assertEqual(len(pdb.atoms), 1164)
 
     def testDownloadCIF(self):
         """ Tests automatic loading of downloaded PDBx/mmCIF files """
-        cif = formats.load_file(self.url + '4LZT.cif')
+        self.assertTrue(formats.CIFFile.id_format(self.url + '4LZT.cif'))
+        cif = formats.CIFFile.parse(self.url + '4LZT.cif')
         self.assertIsInstance(cif, Structure)
         self.assertEqual(len(cif.atoms), 1164)
 
     def testDownloadMol2(self):
         """ Tests automatic loading of downloaded mol2 and mol3 files """
-        mol2 = formats.load_file(self.url + 'test_multi.mol2')
+        self.assertTrue(formats.Mol2File.id_format(self.url + 'test_multi.mol2'))
+        self.assertTrue(formats.Mol2File.id_format(self.url + 'tripos9.mol2'))
+        mol2 = formats.Mol2File.parse(self.url + 'test_multi.mol2')
         self.assertIsInstance(mol2, ResidueTemplateContainer)
-        mol3 = formats.load_file(self.url + 'tripos9.mol2')
+        mol3 = formats.Mol2File.parse(self.url + 'tripos9.mol2')
         self.assertIsInstance(mol3, ResidueTemplate)
 
     def testDownloadGromacsTop(self):
         """ Tests automatic loading of downloaded Gromacs topology file """
-        top = formats.load_file(self.url + '1aki.charmm27.top')
+        self.assertTrue(gromacs.GromacsTopologyFile.id_format(self.url + '1aki.charmm27.top'))
+        top = gromacs.GromacsTopologyFile(self.url + '1aki.charmm27.top')
         self.assertIsInstance(top, gromacs.GromacsTopologyFile)
 
     def testDownloadGromacsGro(self):
         """ Tests automatic loading of downloaded Gromacs GRO file """
-        gro = formats.load_file(self.url + '1aki.ff99sbildn.gro')
+        self.assertTrue(gromacs.GromacsGroFile.id_format(self.url + '1aki.ff99sbildn.gro'))
+        gro = gromacs.GromacsGroFile.parse(self.url + '1aki.ff99sbildn.gro')
         self.assertIsInstance(gro, Structure)
 
 del skip_big_tests # Avoid fake testing this method :)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -279,6 +279,8 @@ class TestChemistryPDBStructure(FileIOTestCase):
         pdbfile2 = read_PDB(output)
         self.assertEqual(len(pdbfile2.atoms), 451)
         self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
+        np.testing.assert_allclose(pdbfile2.get_coordinates('all'),
+                                   pdbfile.get_coordinates('all'))
         self._compareInputOutputPDBs(pdbfile, pdbfile2)
 
     def testPdbBigCoordinates(self):

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -607,8 +607,8 @@ class TestParmedPQRStructure(FileIOTestCase):
             self.assertAlmostEqual(a1.charge, a2.charge)
             self.assertAlmostEqual(a1.radii, a2.radii)
         self.assertEqual(pqr.get_coordinates().shape[0], 3)
-        np.testing.assert_allclose(pqr.get_coordinates(),
-                                   parm.get_coordinates(), atol=2e-3)
+        np.testing.assert_allclose(pqr.get_coordinates(0),
+                                   parm.get_coordinates(0), atol=2e-3)
 
     def testPQRWithElement(self):
         """ Tests reading a PQR file that has an element column """

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -590,6 +590,12 @@ class TestParmedPQRStructure(FileIOTestCase):
     def testPQRWriter(self):
         """ Tests writing a PQR file with charges and radii """
         parm = formats.load_file(get_fn('trx.prmtop'), get_fn('trx.inpcrd'))
+        # Create multiple models
+        coords = []
+        coords.append(parm.coordinates)
+        coords.append(parm.coordinates + 1)
+        coords.append(parm.coordinates + 2)
+        parm.coordinates = np.vstack(coords)
         formats.PQRFile.write(parm, get_fn('test.pqr', written=True),
                               renumber=True)
         pqr = formats.PQRFile.parse(get_fn('test.pqr', written=True))
@@ -600,6 +606,9 @@ class TestParmedPQRStructure(FileIOTestCase):
             self.assertEqual(a1.residue.idx, a2.residue.idx)
             self.assertAlmostEqual(a1.charge, a2.charge)
             self.assertAlmostEqual(a1.radii, a2.radii)
+        self.assertEqual(pqr.get_coordinates().shape[0], 3)
+        np.testing.assert_allclose(pqr.get_coordinates(),
+                                   parm.get_coordinates(), atol=2e-3)
 
     def testPQRWithElement(self):
         """ Tests reading a PQR file that has an element column """
@@ -714,6 +723,8 @@ class TestChemistryCIFStructure(FileIOTestCase):
         pdbfile2 = read_CIF(output)
         self.assertEqual(len(pdbfile2.atoms), 451)
         self.assertEqual(pdbfile2.get_coordinates('all').shape, (20, 451, 3))
+        np.testing.assert_allclose(pdbfile2.get_coordinates('all'),
+                                   cif.get_coordinates('all'))
 
     def testCIFWriteStandardNames(self):
         """ Test PDBx/mmCIF file writing converting to standard names """


### PR DESCRIPTION
Old (bad) behavior was to write all models with the same coordinates. 