### PR TITLE
Implement serialization for a wide array of ParmEd objects

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -2095,6 +2095,17 @@ class AmberParm(AmberFormat, Structure):
                      AmberWarning)
         return n13, n14
 
+    #===================================================
+
+    def __getstate__(self):
+        d = Structure.__getstate__(self)
+        d.update(AmberFormat.__getstate__(self))
+        return d
+
+    def __setstate__(self, d):
+        AmberFormat.__setstate__(self, d)
+        Structure.__setstate__(self, d)
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class Rst7(object):

--- a/parmed/amber/amberformat.py
+++ b/parmed/amber/amberformat.py
@@ -251,6 +251,25 @@ class FortranFormat(object):
     def _write_ffwriter(self, items, dest):
         dest.write('%s\n' % self._writer.write(items))
 
+    #===================================================
+
+    def __eq__(self, other):
+        return (self.format == other.format and
+                self.strip_strings == other.strip_strings)
+
+    #===================================================
+
+    def __hash__(self):
+        return hash((self.format, self.strip_strings))
+
+    #===================================================
+
+    def __getstate__(self):
+        return dict(format=self.format, strip_strings=self.strip_strings)
+
+    def __setstate__(self, d):
+        self.__init__(d['format'], d['strip_strings'])
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 @add_metaclass(FileFormatType)
@@ -906,6 +925,17 @@ class AmberFormat(object):
         del self.parm_comments[flag_name]
         del self.formats[flag_name]
         del self.parm_data[flag_name]
+
+    #===================================================
+
+    def __getstate__(self):
+        return dict(parm_data=self.parm_data, flag_list=self.flag_list,
+                    formats=self.formats, parm_comments=self.parm_comments,
+                    charge_flag=self.charge_flag, version=self.version,
+                    name=self.name)
+
+    def __setstate__(self, d):
+        self.__dict__ = d
 
     #===================================================
 

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -114,6 +114,13 @@ class _Defaults(object):
         if idx == 4: return self.fudgeQQ
         raise IndexError('Index %d out of range' % idx)
 
+    def __eq__(self, other):
+        return (self.nbfunc == other.nbfunc and
+                self.comb_rule == other.comb_rule and
+                self.gen_pairs == other.gen_pairs and
+                self.fudgeLJ == other.fudgeLJ and
+                self.fudgeQQ == other.fudgeQQ)
+
     def __setitem__(self, idx, value):
         if idx < 0: idx += 5
         if idx == 0:
@@ -1761,6 +1768,19 @@ class GromacsTopologyFile(Structure):
                     dest.write('  %d' % (a.idx+1))
                 dest.write('\n')
             dest.write('\n')
+
+    #===================================================
+
+    def __getstate__(self):
+        d = Structure.__getstate__(self)
+        d['parameterset'] = self.parameterset
+        d['defaults'] = self.defaults
+        return d
+
+    def __setstate__(self, d):
+        Structure.__setstate__(self, d)
+        self.parameterset = d['parameterset']
+        self.defaults = d['defaults']
 
 def _any_atoms_farther_than(structure, limit=3):
     """

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3385,6 +3385,7 @@ class Structure(object):
                        torsion_torsion_types=self.torsion_torsion_types,
                        adjust_types=self.adjust_types,
                        groups=self.groups,
+                       _coordinates=self._coordinates,
         )
         def idx(thing):
             if thing is None: return None
@@ -3458,7 +3459,7 @@ class Structure(object):
         # Assign the possible metadata
         for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
-                    'resolution', 'related_entries'):
+                    'resolution', 'related_entries', '_coordinates'):
             if key in d:
                 setattr(self, key, d[key])
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3409,7 +3409,7 @@ class Structure(object):
         retdict['urey_bradleys'] = [(u.atom1.idx, u.atom2.idx, idx(u.type))
                                     for u in self.urey_bradleys]
         retdict['cmaps'] = [(c.atom1.idx, c.atom2.idx, c.atom3.idx,
-                             c.atom4.idx, c.atom5.idx, c.type.idx)
+                             c.atom4.idx, c.atom5.idx, idx(c.type))
                             for c in self.cmaps]
         retdict['trigonal_angles'] = [(t.atom1.idx, t.atom2.idx, t.atom3.idx,
                                        t.atom4.idx, idx(t.type))

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3432,9 +3432,11 @@ class Structure(object):
         retdict['acceptors'] = [(a.atom1.idx, a.atom2.idx)
                                 for a in self.acceptors]
         retdict['donors'] = [(d.atom1.idx, d.atom2.idx) for d in self.donors]
+        retdict['exclusions'] = [tuple(e.idx for e in a._exclusion_partners)
+                                 for a in self.atoms]
 
         # Now the metadata stuff, if applicable
-        for key in ('experimental', 'journal authors', 'keywords', 'doi',
+        for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
                     'resolution', 'related_entries'):
             try:
@@ -3455,7 +3457,7 @@ class Structure(object):
             setattr(self, attr, d[attr])
             getattr(self, attr).claim()
         # Assign the possible metadata
-        for key in ('experimental', 'journal authors', 'keywords', 'doi',
+        for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
                     'resolution', 'related_entries'):
             if key in d:
@@ -3554,6 +3556,10 @@ class Structure(object):
                                    assign_type(self.adjust_types, it[2]))
                 for it in d['adjusts']
         )
+        # Transfer the exclusions
+        for atom, excl in zip(self.atoms, d['exclusions']):
+            for idx in excl:
+                atom.exclude(self.atoms[idx])
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3387,6 +3387,8 @@ class Structure(object):
                        groups=self.groups,
                        _coordinates=self._coordinates,
                        _box=self._box,
+                       nrexcl=self.nrexcl,
+                       _combining_rule=self._combining_rule,
         )
         def idx(thing):
             if thing is None: return None
@@ -3460,7 +3462,8 @@ class Structure(object):
         # Assign the possible metadata
         for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
-                    'resolution', 'related_entries', '_coordinates', '_box'):
+                    'resolution', 'related_entries', '_coordinates', '_box',
+                    'nrexcl', '_combining_rule'):
             if key in d:
                 setattr(self, key, d[key])
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -49,7 +49,6 @@ from parmed.utils.decorators import needs_openmm
 from parmed.utils.six import string_types, integer_types, iteritems
 from parmed.utils.six.moves import zip, range
 from parmed.vec3 import Vec3
-import pickle
 import re
 # Try to import the OpenMM modules
 try:

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -3386,6 +3386,7 @@ class Structure(object):
                        adjust_types=self.adjust_types,
                        groups=self.groups,
                        _coordinates=self._coordinates,
+                       _box=self._box,
         )
         def idx(thing):
             if thing is None: return None
@@ -3459,7 +3460,7 @@ class Structure(object):
         # Assign the possible metadata
         for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
-                    'resolution', 'related_entries', '_coordinates'):
+                    'resolution', 'related_entries', '_coordinates', '_box'):
             if key in d:
                 setattr(self, key, d[key])
 

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -4804,6 +4804,10 @@ class Group(object):
     def __copy__(self):
         return type(self)(self.bs, self.type, self.move)
 
+    def __eq__(self, other):
+        return (self.bs == other.bs and self.type == other.type and
+                self.move == other.move)
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 NoUreyBradley = BondType(0.0, 0.0) # singleton representing lack of a U-B term

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -627,7 +627,7 @@ class Atom(_ListItem):
     def rmin(self):
         """ Lennard-Jones Rmin/2 parameter (the to Lennard-Jones radius) """
         if self._rmin is None:
-            if (self.atom_type == UnassignedAtomType or
+            if (self.atom_type is UnassignedAtomType or
                     self.atom_type.rmin is None):
                 return 0.0
             return self.atom_type.rmin
@@ -655,7 +655,7 @@ class Atom(_ListItem):
     def epsilon(self):
         """ Lennard-Jones epsilon parameter (the Lennard-Jones well depth) """
         if self._epsilon is None:
-            if (self.atom_type == UnassignedAtomType or
+            if (self.atom_type is UnassignedAtomType or
                     self.atom_type.epsilon is None):
                 return 0.0
             return self.atom_type.epsilon
@@ -670,7 +670,7 @@ class Atom(_ListItem):
     def rmin_14(self):
         """ The 1-4 Lennard-Jones Rmin/2 parameter """
         if self._rmin14 is None:
-            if (self.atom_type == UnassignedAtomType or
+            if (self.atom_type is UnassignedAtomType or
                     self.atom_type.rmin_14 is None):
                 return self.rmin
             return self.atom_type.rmin_14
@@ -685,7 +685,7 @@ class Atom(_ListItem):
     def sigma_14(self):
         """ Lennard-Jones sigma parameter -- directly related to Rmin """
         if self._rmin14 is None:
-            if (self.atom_type == UnassignedAtomType or
+            if (self.atom_type is UnassignedAtomType or
                     self.atom_type.rmin_14 is None):
                 return self.sigma
             return self.atom_type.rmin_14 * 2**(-1/6) * 2
@@ -699,7 +699,7 @@ class Atom(_ListItem):
     def epsilon_14(self):
         """ The 1-4 Lennard-Jones epsilon parameter """
         if self._epsilon14 is None:
-            if (self.atom_type == UnassignedAtomType or
+            if (self.atom_type is UnassignedAtomType or
                     self.atom_type.epsilon_14 is None):
                 return self.epsilon
             return self.atom_type.epsilon_14
@@ -1802,6 +1802,15 @@ class BondType(_ListItem, _ParameterType):
         return BondType(self.k, self.req)
 
     __getstate__ = _getstate_with_exclusions()
+
+    def __reduce__(self):
+        """
+        Special-case NoUreyBradley, which should be a singleton. So if it's
+        NoUreyBradley, return the same object. Otherwise, create a new one
+        """
+        if self is NoUreyBradley:
+            return 'NoUreyBradley'
+        return super(BondType, self).__reduce__()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -4752,7 +4761,12 @@ class _UnassignedAtomType(object):
     def __eq__(self, other):
         return isinstance(other, _UnassignedAtomType) # Behave like a singleton
 
+    def __reduce__(self):
+        return 'UnassignedAtomType'
+
 UnassignedAtomType = _UnassignedAtomType()
+# Make sure it's a singleton
+assert UnassignedAtomType is _UnassignedAtomType(), "Not a singleton"
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -9,7 +9,7 @@ from __future__ import division, print_function, absolute_import
 from parmed.exceptions import MoleculeError, ParameterError
 from parmed.constants import TINY, DEG_TO_RAD, RAD_TO_DEG
 import parmed.unit as u
-from parmed.utils.six import string_types
+from parmed.utils.six import string_types, iteritems
 from parmed.utils.six.moves import zip, range
 from copy import copy
 import math
@@ -54,6 +54,27 @@ def _strip_units(value, unit=None):
         else:
             return value.value_in_unit(unit)
     return value
+
+def _getstate_with_exclusions(exclusions=None):
+    """ Serializes based on all attributes except requested exclusions
+
+    Parameters
+    ----------
+    exclusions : list of str, optional
+        List of all attributes to exclude from serialization (should be
+        descriptors and 'list'). Default is None
+
+    Notes
+    -----
+    If exclusions is None, it defaults to excluding 'list'. If this is not
+    desired, set exclusions to the empty list.
+    """
+    if exclusions is None:
+        exclusions = ['list']
+    def __getstate__(self):
+        return {key : val for (key, val) in iteritems(self.__dict__)
+                    if key not in exclusions}
+    return __getstate__
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -468,7 +489,7 @@ class Atom(_ListItem):
         self.urey_bradleys, self.impropers, self.cmaps = [], [], []
         self.tortors = []
         self.other_locations = {} # A dict of Atom instances
-        self.atom_type = _UnassignedAtomType
+        self.atom_type = UnassignedAtomType
         self.number = number
         self.anisou = None
         self._rmin = rmin
@@ -606,7 +627,7 @@ class Atom(_ListItem):
     def rmin(self):
         """ Lennard-Jones Rmin/2 parameter (the to Lennard-Jones radius) """
         if self._rmin is None:
-            if (self.atom_type is _UnassignedAtomType or
+            if (self.atom_type == UnassignedAtomType or
                     self.atom_type.rmin is None):
                 return 0.0
             return self.atom_type.rmin
@@ -634,7 +655,7 @@ class Atom(_ListItem):
     def epsilon(self):
         """ Lennard-Jones epsilon parameter (the Lennard-Jones well depth) """
         if self._epsilon is None:
-            if (self.atom_type is _UnassignedAtomType or
+            if (self.atom_type == UnassignedAtomType or
                     self.atom_type.epsilon is None):
                 return 0.0
             return self.atom_type.epsilon
@@ -649,7 +670,7 @@ class Atom(_ListItem):
     def rmin_14(self):
         """ The 1-4 Lennard-Jones Rmin/2 parameter """
         if self._rmin14 is None:
-            if (self.atom_type is _UnassignedAtomType or
+            if (self.atom_type == UnassignedAtomType or
                     self.atom_type.rmin_14 is None):
                 return self.rmin
             return self.atom_type.rmin_14
@@ -664,7 +685,7 @@ class Atom(_ListItem):
     def sigma_14(self):
         """ Lennard-Jones sigma parameter -- directly related to Rmin """
         if self._rmin14 is None:
-            if (self.atom_type is _UnassignedAtomType or
+            if (self.atom_type == UnassignedAtomType or
                     self.atom_type.rmin_14 is None):
                 return self.sigma
             return self.atom_type.rmin_14 * 2**(-1/6) * 2
@@ -678,7 +699,7 @@ class Atom(_ListItem):
     def epsilon_14(self):
         """ The 1-4 Lennard-Jones epsilon parameter """
         if self._epsilon14 is None:
-            if (self.atom_type is _UnassignedAtomType or
+            if (self.atom_type == UnassignedAtomType or
                     self.atom_type.epsilon_14 is None):
                 return self.epsilon
             return self.atom_type.epsilon_14
@@ -933,6 +954,45 @@ class Atom(_ListItem):
         elif self.residue is not None:
             return start + '; In %s>' % self.residue.name
         return start + '>'
+
+    #===================================================
+
+    # For pickleability
+
+    def __getstate__(self):
+        retval = dict(name=self.name, type=self.type, atom_type=self.atom_type,
+                      charge=self.charge, mass=self.mass, nb_idx=self.nb_idx,
+                      radii=self.radii, screen=self.screen, tree=self.tree,
+                      join=self.join, irotat=self.irotat, bfactor=self.bfactor,
+                      altloc=self.altloc, occupancy=self.occupancy,
+                      number=self.number, anisou=self.anisou, _rmin=self._rmin,
+                      _epsilon=self._epsilon, _rmin14=self._rmin14,
+                      _epsilon14=self._epsilon14, children=self.children,
+                      atomic_number=self.atomic_number,
+        )
+        for key in ('xx', 'xy', 'xz', 'vx', 'vy', 'vz', 'multipoles',
+                    'type_idx', 'class_idx', 'polarizability', 'vdw_weight',
+                    'segid', 'weights', '_frame_type'):
+            try:
+                retval[key] = getattr(self, key)
+            except AttributeError:
+                continue
+
+        return retval
+
+    def __setstate__(self, d):
+        self._bond_partners = []
+        self._angle_partners = []
+        self._dihedral_partners = []
+        self._tortor_partners = []
+        self._exclusion_partners = []
+        self.residue = None
+        self.marked = 0
+        self.bonds, self.angles, self.dihedrals = [], [], []
+        self.urey_bradleys, self.impropers, self.cmaps = [], [], []
+        self.tortors = []
+        self.other_locations = {}
+        self.__dict__.update(d)
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1741,6 +1801,8 @@ class BondType(_ListItem, _ParameterType):
             return self
         return BondType(self.k, self.req)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class Angle(object):
@@ -1891,6 +1953,8 @@ class AngleType(_ListItem, _ParameterType):
 
     def __copy__(self):
         return AngleType(self.k, self.theteq)
+
+    __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -2185,6 +2249,8 @@ class DihedralType(_ListItem, _ParameterType):
         return DihedralType(self.phi_k, self.per, self.phase, self.scee,
                             self.scnb)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class RBTorsionType(_ListItem, _ParameterType):
@@ -2277,6 +2343,8 @@ class RBTorsionType(_ListItem, _ParameterType):
                 (self.c0, self.c1, self.c2, self.c3, self.c4, self.c5,
                  self.scee, self.scnb))
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class DihedralTypeList(list, _ListItem):
@@ -2358,6 +2426,8 @@ class DihedralTypeList(list, _ListItem):
 
     def __copy__(self):
         return DihedralTypeList([copy(x) for x in self])
+
+    __getstate__ = _getstate_with_exclusions(['list', 'penalty'])
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -2637,6 +2707,8 @@ class ImproperType(_ListItem, _ParameterType):
     def __copy__(self):
         return ImproperType(self.psi_k, self.psi_eq)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class Cmap(object):
@@ -2886,6 +2958,8 @@ class CmapType(_ListItem, _ParameterType):
     def __copy__(self):
         return CmapType(self.resolution, copy(self.grid._data),
                         self.comments[:])
+
+    __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -3176,6 +3250,8 @@ class OutOfPlaneBendType(_ListItem, _ParameterType):
     def __copy__(self):
         return OutOfPlaneBendType(self.k)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class PiTorsion(object):
@@ -3381,6 +3457,8 @@ class StretchBendType(_ListItem, _ParameterType):
     def __copy__(self):
         return StretchBendType(self.k1, self.k2, self.req1, self.req2,
                                self.theteq)
+
+    __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -3664,6 +3742,8 @@ class TorsionTorsionType(_ListItem, _ParameterType):
         return TorsionTorsionType(self.dims, self.ang1, self.ang2, f, dfda1,
                                   dfda2, d2fda1da2)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class ChiralFrame(object):
@@ -3878,6 +3958,8 @@ class Residue(_ListItem):
         if self.insertion_code:
             rep += '; insertion_code=%s' % self.insertion_code
         return rep + '>'
+
+    __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -4388,6 +4470,8 @@ class NonbondedExceptionType(_ParameterType, _ListItem):
         return '<%s; rmin=%.4f, epsilon=%.4f, chgscale=%.4f>' % (
                 type(self).__name__, self.rmin, self.epsilon, self.chgscale)
 
+    __getstate__ = _getstate_with_exclusions()
+
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class AmoebaNonbondedExceptionType(NonbondedExceptionType):
@@ -4436,6 +4520,8 @@ class AmoebaNonbondedExceptionType(NonbondedExceptionType):
         return AmoebaNonbondedExceptionType(self.vdw_weight,
                 self.multipole_weight, self.direct_weight, self.polar_weight,
                 self.mutual_weight)
+
+    __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -4646,6 +4732,12 @@ class _UnassignedAtomType(object):
     This raises the appropriate exceptions (ParameterError) when you try to
     access its properties
     """
+    _OBJ = None
+
+    def __new__(cls):
+        if cls._OBJ is None:
+            cls._OBJ = super(_UnassignedAtomType, cls).__new__(cls)
+        return cls._OBJ
 
     def __int__(self):
         raise ParameterError('Atom type is not defined')
@@ -4653,7 +4745,10 @@ class _UnassignedAtomType(object):
     def __str__(self):
         raise ParameterError('Atom type is not defined')
 
-_UnassignedAtomType = _UnassignedAtomType() # Make it a singleton
+    def __eq__(self, other):
+        return isinstance(other, _UnassignedAtomType) # Behave like a singleton
+
+UnassignedAtomType = _UnassignedAtomType()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -4470,6 +4470,10 @@ class NonbondedExceptionType(_ParameterType, _ListItem):
         return '<%s; rmin=%.4f, epsilon=%.4f, chgscale=%.4f>' % (
                 type(self).__name__, self.rmin, self.epsilon, self.chgscale)
 
+    def __eq__(self, other):
+        return (self.rmin == other.rmin and self.epsilon == other.epsilon and
+                self.chgscale == other.chgscale)
+
     __getstate__ = _getstate_with_exclusions()
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -56,7 +56,7 @@ class TestParmedSerialization(unittest.TestCase):
                 self.assertFalse(hasattr(a1, key))
 
     def test_atom_serialization(self):
-        """ Tests serialization of Atom """
+        """ Tests the serialization of Atom """
         atom = pmd.Atom(atomic_number=random.randint(1, 100),
                         name=random.choice(uppercase)+random.choice(uppercase),
                         type=random.choice(uppercase)+random.choice(uppercase),
@@ -82,7 +82,7 @@ class TestParmedSerialization(unittest.TestCase):
         self._equal_atoms(unpickled, atom)
 
     def test_bond_serialization(self):
-        """ Tests serialization of Bond """
+        """ Tests the serialization of Bond """
         struct = utils.create_random_structure(True)
         bond = struct.bonds[0]
         fobj = BytesIO()
@@ -93,7 +93,7 @@ class TestParmedSerialization(unittest.TestCase):
         self.assertIsInstance(bond, pmd.Bond)
 
     def test_bondtype_serialization(self):
-        """ Tests serialization of BondType """
+        """ Tests the serialization of BondType """
         struct = utils.create_random_structure(True)
         bt = struct.bond_types[0]
 
@@ -107,7 +107,7 @@ class TestParmedSerialization(unittest.TestCase):
         self.assertIsNot(unpickled, bt)
 
     def test_residue_serialization(self):
-        """ Tests serialization of Residue """
+        """ Tests the serialization of Residue """
         struct = utils.create_random_structure(parametrized=True)
         res = struct.residues[0]
 
@@ -121,7 +121,7 @@ class TestParmedSerialization(unittest.TestCase):
             self._equal_atoms(a1, a2)
 
     def test_structure_serialization(self):
-        """ Tests serialization of Structure """
+        """ Tests the serialization of Structure """
         structure = utils.create_random_structure(parametrized=True)
         # Make sure we copy over exclusions
         structure.atoms[0].exclude(structure.atoms[10])
@@ -145,7 +145,7 @@ class TestParmedSerialization(unittest.TestCase):
         self.assertEqual(fmt.fmt, unpickled.fmt)
 
     def test_amberformat_serialization(self):
-        """ Tests serialization of AmberFormat """
+        """ Tests the serialization of AmberFormat """
         amber = pmd.load_file(utils.get_fn('cSPCE.mdl'))
         unpickled = pickle.loads(pickle.dumps(amber))
 
@@ -275,6 +275,15 @@ class TestParmedSerialization(unittest.TestCase):
         self._compare_parametersets(structure.parameterset,
                                     unpickled.parameterset)
 
+    def test_gromacscharmm_serialization(self):
+        """ Tests the serialization of a CHARMM FF Gromacs topology """
+        structure = pmd.load_file(utils.get_fn('1aki.charmm27.solv.top'))
+        unpickled = pickle.loads(pickle.dumps(structure))
+        self._compare_structures(unpickled, structure)
+        self.assertEqual(structure.defaults, unpickled.defaults)
+        self._compare_parametersets(structure.parameterset,
+                                    unpickled.parameterset)
+
     def test_charmmpsf_serialization(self):
         """ Tests the serialization of a CHARMM PSF file """
         structure = pmd.load_file(utils.get_fn('ala_ala_ala.psf'))
@@ -391,6 +400,10 @@ class TestParmedSerialization(unittest.TestCase):
             for k in l1:
                 self.assertEqual(l1[k], l2[k])
                 if reversible:
+                    if (pmd.NoUreyBradley is l1[k] or
+                            pmd.NoUreyBradley is l2[k]):
+                        self.assertIs(l1[k], pmd.NoUreyBradley)
+                        self.assertIs(l2[k], pmd.NoUreyBradley)
                     self.assertIs(l1[k], l1[tuple(reversed(k))])
                     self.assertIs(l2[k], l2[tuple(reversed(k))])
 

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -119,98 +119,6 @@ class TestParmedSerialization(unittest.TestCase):
         for a1, a2 in zip(res, unpickled):
             self._equal_atoms(a1, a2)
 
-    def _compare_structures(self, unpickled, structure):
-
-        self.assertEqual(len(unpickled.residues), len(structure.residues))
-        for r1, r2 in zip(unpickled.residues, structure.residues):
-            self.assertEqual(len(r1), len(r2))
-            self.assertEqual(r1.idx, r2.idx)
-            for a1, a2 in zip(r1, r2):
-                self._equal_atoms(a1, a2)
-
-        def cmp_alists(alist1, alist2):
-            self.assertEqual(len(alist1), len(alist2))
-            for a1, a2 in zip(alist1, alist2):
-                self._equal_atoms(a1, a2)
-
-        for a1, a2 in zip(unpickled, structure):
-            self._equal_atoms(a1, a2)
-            self.assertEqual(a1.idx, a2.idx)
-            self.assertEqual(len(a1.bonds), len(a2.bonds))
-            self.assertEqual(len(a1.angles), len(a2.angles))
-            self.assertEqual(len(a1.dihedrals), len(a2.dihedrals))
-            self.assertEqual(len(a1.impropers), len(a2.impropers))
-            cmp_alists(a1.bond_partners, a2.bond_partners)
-            cmp_alists(a1.angle_partners, a2.angle_partners)
-            cmp_alists(a1.dihedral_partners, a2.dihedral_partners)
-            cmp_alists(a1.tortor_partners, a2.tortor_partners)
-            cmp_alists(a1.exclusion_partners, a2.exclusion_partners)
-
-        # Check coordinates
-        if structure.get_coordinates() is None:
-            self.assertIs(unpickled.get_coordinates(), None)
-        else:
-            np.testing.assert_equal(structure.get_coordinates(),
-                                    unpickled.get_coordinates())
-        # Check unit cell
-        if structure.box is None:
-            self.assertIs(unpickled.box, None)
-            self.assertIs(unpickled.box_vectors, None)
-        else:
-            np.testing.assert_equal(structure.box, unpickled.box)
-            self.assertEqual(structure.box_vectors, unpickled.box_vectors)
-
-        # Make sure all of the type arrays are equivalent
-        def cmp_type_arrays(arr1, arr2):
-            self.assertEqual(len(arr1), len(arr2))
-            for x1, x2 in zip(arr1, arr2):
-                self.assertEqual(x1, x2)
-
-        cmp_type_arrays(structure.bond_types, unpickled.bond_types)
-        cmp_type_arrays(structure.angle_types, unpickled.angle_types)
-        cmp_type_arrays(structure.dihedral_types, unpickled.dihedral_types)
-        cmp_type_arrays(structure.improper_types, unpickled.improper_types)
-        cmp_type_arrays(structure.urey_bradley_types, unpickled.urey_bradley_types)
-        cmp_type_arrays(structure.rb_torsion_types, unpickled.rb_torsion_types)
-        cmp_type_arrays(structure.cmap_types, unpickled.cmap_types)
-        cmp_type_arrays(structure.trigonal_angle_types,
-                        unpickled.trigonal_angle_types)
-        cmp_type_arrays(structure.out_of_plane_bend_types,
-                        unpickled.out_of_plane_bend_types)
-        cmp_type_arrays(structure.stretch_bend_types, unpickled.stretch_bend_types)
-        cmp_type_arrays(structure.torsion_torsion_types,
-                        unpickled.torsion_torsion_types)
-        cmp_type_arrays(structure.pi_torsion_types, unpickled.pi_torsion_types)
-        cmp_type_arrays(structure.adjust_types, unpickled.adjust_types)
-        cmp_type_arrays(structure.groups, unpickled.groups)
-
-        # Make sure all of the connectivity arrays are equivalent
-        def cmp_top_arrays(arr1, arr2):
-            self.assertEqual(len(arr1), len(arr2))
-            for t1, t2 in zip(arr1, arr2):
-                self.assertIs(type(t1), type(t2))
-                atoms = [attr for attr in dir(t1) if attr.startswith('atom')]
-                for a in atoms:
-                    self._equal_atoms(getattr(t1, a), getattr(t2, a))
-                if hasattr(t1, 'type'):
-                    self.assertEqual(t1.type, t2.type)
-
-        cmp_top_arrays(structure.bonds, unpickled.bonds)
-        cmp_top_arrays(structure.angles, unpickled.angles)
-        cmp_top_arrays(structure.dihedrals, unpickled.dihedrals)
-        cmp_top_arrays(structure.impropers, unpickled.impropers)
-        cmp_top_arrays(structure.urey_bradleys, unpickled.urey_bradleys)
-        cmp_top_arrays(structure.rb_torsions, unpickled.rb_torsions)
-        cmp_top_arrays(structure.cmaps, unpickled.cmaps)
-        cmp_top_arrays(structure.trigonal_angles, unpickled.trigonal_angles)
-        cmp_top_arrays(structure.out_of_plane_bends, unpickled.out_of_plane_bends)
-        cmp_top_arrays(structure.pi_torsions, unpickled.pi_torsions)
-        cmp_top_arrays(structure.stretch_bends, unpickled.stretch_bends)
-        cmp_top_arrays(structure.torsion_torsions, unpickled.torsion_torsions)
-        cmp_top_arrays(structure.chiral_frames, unpickled.chiral_frames)
-        cmp_top_arrays(structure.multipole_frames, unpickled.multipole_frames)
-        cmp_top_arrays(structure.adjusts, unpickled.adjusts)
-
     def test_structure_serialization(self):
         """ Tests serialization/pickleability of Structure """
         structure = utils.create_random_structure(parametrized=True)
@@ -345,3 +253,112 @@ class TestParmedSerialization(unittest.TestCase):
             self.assertEqual(getattr(structure, key), getattr(unpickled, key))
 
         self.assertGreater(structure.get_coordinates().shape[0], 1)
+
+    def test_parm_velocities_serialization(self):
+        """ Tests the serialization/pickleability of a Structure w/ vels """
+        structure = pmd.load_file(utils.get_fn('tip4p.parm7'),
+                                  utils.get_fn('tip4p.rst7'))
+        unpickled = pickle.loads(pickle.dumps(structure))
+        self._compare_structures(unpickled, structure)
+
+    def _compare_structures(self, unpickled, structure):
+
+        self.assertEqual(len(unpickled.residues), len(structure.residues))
+        for r1, r2 in zip(unpickled.residues, structure.residues):
+            self.assertEqual(len(r1), len(r2))
+            self.assertEqual(r1.idx, r2.idx)
+            for a1, a2 in zip(r1, r2):
+                self._equal_atoms(a1, a2)
+
+        def cmp_alists(alist1, alist2):
+            self.assertEqual(len(alist1), len(alist2))
+            for a1, a2 in zip(alist1, alist2):
+                self._equal_atoms(a1, a2)
+
+        for a1, a2 in zip(unpickled, structure):
+            self._equal_atoms(a1, a2)
+            self.assertEqual(a1.idx, a2.idx)
+            self.assertEqual(len(a1.bonds), len(a2.bonds))
+            self.assertEqual(len(a1.angles), len(a2.angles))
+            self.assertEqual(len(a1.dihedrals), len(a2.dihedrals))
+            self.assertEqual(len(a1.impropers), len(a2.impropers))
+            cmp_alists(a1.bond_partners, a2.bond_partners)
+            cmp_alists(a1.angle_partners, a2.angle_partners)
+            cmp_alists(a1.dihedral_partners, a2.dihedral_partners)
+            cmp_alists(a1.tortor_partners, a2.tortor_partners)
+            cmp_alists(a1.exclusion_partners, a2.exclusion_partners)
+
+        # Check coordinates
+        if structure.get_coordinates() is None:
+            self.assertIs(unpickled.get_coordinates(), None)
+        else:
+            np.testing.assert_equal(structure.get_coordinates(),
+                                    unpickled.get_coordinates())
+        # Check unit cell
+        if structure.box is None:
+            self.assertIs(unpickled.box, None)
+            self.assertIs(unpickled.box_vectors, None)
+        else:
+            np.testing.assert_equal(structure.box, unpickled.box)
+            self.assertEqual(structure.box_vectors, unpickled.box_vectors)
+
+        # Check velocities
+        if structure.velocities is None:
+            self.assertIs(unpickled.velocities, None)
+        else:
+            np.testing.assert_equal(structure.velocities, unpickled.velocities)
+
+        # Check nrexcl and combining_rule
+        self.assertEqual(structure.nrexcl, unpickled.nrexcl)
+        self.assertEqual(structure.combining_rule, unpickled.combining_rule)
+
+        # Make sure all of the type arrays are equivalent
+        def cmp_type_arrays(arr1, arr2):
+            self.assertEqual(len(arr1), len(arr2))
+            for x1, x2 in zip(arr1, arr2):
+                self.assertEqual(x1, x2)
+
+        cmp_type_arrays(structure.bond_types, unpickled.bond_types)
+        cmp_type_arrays(structure.angle_types, unpickled.angle_types)
+        cmp_type_arrays(structure.dihedral_types, unpickled.dihedral_types)
+        cmp_type_arrays(structure.improper_types, unpickled.improper_types)
+        cmp_type_arrays(structure.urey_bradley_types, unpickled.urey_bradley_types)
+        cmp_type_arrays(structure.rb_torsion_types, unpickled.rb_torsion_types)
+        cmp_type_arrays(structure.cmap_types, unpickled.cmap_types)
+        cmp_type_arrays(structure.trigonal_angle_types,
+                        unpickled.trigonal_angle_types)
+        cmp_type_arrays(structure.out_of_plane_bend_types,
+                        unpickled.out_of_plane_bend_types)
+        cmp_type_arrays(structure.stretch_bend_types, unpickled.stretch_bend_types)
+        cmp_type_arrays(structure.torsion_torsion_types,
+                        unpickled.torsion_torsion_types)
+        cmp_type_arrays(structure.pi_torsion_types, unpickled.pi_torsion_types)
+        cmp_type_arrays(structure.adjust_types, unpickled.adjust_types)
+        cmp_type_arrays(structure.groups, unpickled.groups)
+
+        # Make sure all of the connectivity arrays are equivalent
+        def cmp_top_arrays(arr1, arr2):
+            self.assertEqual(len(arr1), len(arr2))
+            for t1, t2 in zip(arr1, arr2):
+                self.assertIs(type(t1), type(t2))
+                atoms = [attr for attr in dir(t1) if attr.startswith('atom')]
+                for a in atoms:
+                    self._equal_atoms(getattr(t1, a), getattr(t2, a))
+                if hasattr(t1, 'type'):
+                    self.assertEqual(t1.type, t2.type)
+
+        cmp_top_arrays(structure.bonds, unpickled.bonds)
+        cmp_top_arrays(structure.angles, unpickled.angles)
+        cmp_top_arrays(structure.dihedrals, unpickled.dihedrals)
+        cmp_top_arrays(structure.impropers, unpickled.impropers)
+        cmp_top_arrays(structure.urey_bradleys, unpickled.urey_bradleys)
+        cmp_top_arrays(structure.rb_torsions, unpickled.rb_torsions)
+        cmp_top_arrays(structure.cmaps, unpickled.cmaps)
+        cmp_top_arrays(structure.trigonal_angles, unpickled.trigonal_angles)
+        cmp_top_arrays(structure.out_of_plane_bends, unpickled.out_of_plane_bends)
+        cmp_top_arrays(structure.pi_torsions, unpickled.pi_torsions)
+        cmp_top_arrays(structure.stretch_bends, unpickled.stretch_bends)
+        cmp_top_arrays(structure.torsion_torsions, unpickled.torsion_torsions)
+        cmp_top_arrays(structure.chiral_frames, unpickled.chiral_frames)
+        cmp_top_arrays(structure.multipole_frames, unpickled.multipole_frames)
+        cmp_top_arrays(structure.adjusts, unpickled.adjusts)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -161,6 +161,7 @@ class TestParmedSerialization(unittest.TestCase):
                         unpickled.torsion_torsion_types)
         cmp_type_arrays(structure.pi_torsion_types, unpickled.pi_torsion_types)
         cmp_type_arrays(structure.adjust_types, unpickled.adjust_types)
+        cmp_type_arrays(structure.groups, unpickled.groups)
 
         # Make sure all of the connectivity arrays are equivalent
         def cmp_top_arrays(arr1, arr2):
@@ -175,3 +176,16 @@ class TestParmedSerialization(unittest.TestCase):
 
         cmp_top_arrays(structure.bonds, unpickled.bonds)
         cmp_top_arrays(structure.angles, unpickled.angles)
+        cmp_top_arrays(structure.dihedrals, unpickled.dihedrals)
+        cmp_top_arrays(structure.impropers, unpickled.impropers)
+        cmp_top_arrays(structure.urey_bradleys, unpickled.urey_bradleys)
+        cmp_top_arrays(structure.rb_torsions, unpickled.rb_torsions)
+        cmp_top_arrays(structure.cmaps, unpickled.cmaps)
+        cmp_top_arrays(structure.trigonal_angles, unpickled.trigonal_angles)
+        cmp_top_arrays(structure.out_of_plane_bends, unpickled.out_of_plane_bends)
+        cmp_top_arrays(structure.pi_torsions, unpickled.pi_torsions)
+        cmp_top_arrays(structure.stretch_bends, unpickled.stretch_bends)
+        cmp_top_arrays(structure.torsion_torsions, unpickled.torsion_torsions)
+        cmp_top_arrays(structure.chiral_frames, unpickled.chiral_frames)
+        cmp_top_arrays(structure.multipole_frames, unpickled.multipole_frames)
+        cmp_top_arrays(structure.adjusts, unpickled.adjusts)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -8,7 +8,6 @@ import numpy as np
 import parmed as pmd
 from parmed.utils.six.moves import range, zip
 try:
-    raise ImportError()
     import cPickle as pickle
 except ImportError:
     import pickle
@@ -264,3 +263,25 @@ class TestParmedSerialization(unittest.TestCase):
         self.assertEqual(structure.version, unpickled.version)
         self.assertEqual(structure.name, unpickled.name)
         self.assertIs(pmd.amber.ChamberParm, type(unpickled))
+
+    def test_amoebaparm_serialization(self):
+        """ Tests the serialization/pickleability of AmoebaParm """
+        structure = pmd.load_file(utils.get_fn('nma.parm7'),
+                                  utils.get_fn('nma.rst7'))
+        unpickled = pickle.loads(pickle.dumps(structure))
+
+        self._compare_structures(unpickled, structure)
+
+        self.assertEqual(set(structure.parm_data.keys()),
+                         set(unpickled.parm_data.keys()))
+        self.assertEqual(structure.flag_list, unpickled.flag_list)
+        self.assertEqual(set(structure.formats.keys()),
+                         set(unpickled.formats.keys()))
+        for k1 in structure.parm_data.keys():
+            self.assertEqual(structure.parm_data[k1], unpickled.parm_data[k1])
+            self.assertEqual(structure.formats[k1], unpickled.formats[k1])
+
+        self.assertEqual(structure.charge_flag, unpickled.charge_flag)
+        self.assertEqual(structure.version, unpickled.version)
+        self.assertEqual(structure.name, unpickled.name)
+        self.assertIs(pmd.amber.AmoebaParm, type(unpickled))

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -385,20 +385,23 @@ class TestParmedSerialization(unittest.TestCase):
 
     def _compare_parametersets(self, set1, set2):
 
-        def cmp_lists(l1, l2):
+        def cmp_lists(l1, l2, reversible=False):
             self.assertEqual(len(l1), len(l2))
             self.assertEqual(set(l1.keys()), set(l2.keys()))
             for k in l1:
                 self.assertEqual(l1[k], l2[k])
+                if reversible:
+                    self.assertIs(l1[k], l1[tuple(reversed(k))])
+                    self.assertIs(l2[k], l2[tuple(reversed(k))])
 
         # Now compare all of the parameter lists
-        cmp_lists(set1.bond_types, set2.bond_types)
-        cmp_lists(set1.angle_types, set2.angle_types)
-        cmp_lists(set1.dihedral_types, set2.dihedral_types)
+        cmp_lists(set1.bond_types, set2.bond_types, True)
+        cmp_lists(set1.angle_types, set2.angle_types, True)
+        cmp_lists(set1.dihedral_types, set2.dihedral_types, True)
         cmp_lists(set1.improper_types, set2.improper_types)
         cmp_lists(set1.improper_periodic_types, set2.improper_periodic_types)
-        cmp_lists(set1.cmap_types, set2.cmap_types)
+        cmp_lists(set1.cmap_types, set2.cmap_types, True)
         cmp_lists(set1.atom_types, set2.atom_types)
-        cmp_lists(set1.urey_bradley_types, set2.urey_bradley_types)
+        cmp_lists(set1.urey_bradley_types, set2.urey_bradley_types, True)
         cmp_lists(set1.nbfix_types, set2.nbfix_types)
         self.assertEqual(set1.combining_rule, set2.combining_rule)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -1,0 +1,177 @@
+"""
+Unittests for serializing various objects in ParmEd
+"""
+from __future__ import division
+
+from io import BytesIO
+import numpy as np
+import parmed as pmd
+from parmed.utils.six.moves import range, zip
+try:
+    raise ImportError()
+    import cPickle as pickle
+except ImportError:
+    import pickle
+import random
+try:
+    from string import uppercase
+except ImportError:
+    from string import ascii_uppercase as uppercase
+import unittest
+import utils
+
+class TestParmedSerialization(unittest.TestCase):
+    """ Tests ParmEd serialization """
+
+    def _equal_atoms(self, a1, a2):
+        self.assertEqual(a1.atomic_number, a2.atomic_number)
+        self.assertEqual(a1.screen, a2.screen)
+        self.assertEqual(a1.name, a2.name)
+        self.assertEqual(a1.type, a2.type)
+        self.assertEqual(a1.atom_type, a2.atom_type)
+        self.assertEqual(a1.charge, a2.charge)
+        self.assertEqual(a1.mass, a2.mass)
+        self.assertEqual(a1.nb_idx, a2.nb_idx)
+        self.assertEqual(a1.radii, a2.radii)
+        self.assertEqual(a1.tree, a2.tree)
+        self.assertEqual(a1.join, a2.join)
+        self.assertEqual(a1.irotat, a2.irotat)
+        self.assertEqual(a1.occupancy, a2.occupancy)
+        self.assertEqual(a1.bfactor, a2.bfactor)
+        self.assertEqual(a1.rmin, a2.rmin)
+        self.assertEqual(a1.epsilon, a2.epsilon)
+        self.assertEqual(a1.rmin_14, a2.rmin_14)
+        self.assertEqual(a1.epsilon_14, a2.epsilon_14)
+        for key in ('xx', 'xy', 'xz', 'vx', 'vy', 'vz', 'multipoles',
+                    'type_idx', 'class_idx', 'polarizability', 'vdw_weight',
+                    'segid'):
+            if hasattr(a2, key):
+                if isinstance(getattr(a2, key), np.ndarray):
+                    np.testing.assert_equal(
+                            getattr(a1, key), getattr(a2, key)
+                    )
+                else:
+                    self.assertEqual(getattr(a1, key), getattr(a2, key))
+            else:
+                self.assertFalse(hasattr(a1, key))
+
+    def test_atom_serialization(self):
+        """ Tests serialization/pickleability of Atom """
+        atom = pmd.Atom(atomic_number=random.randint(1, 100),
+                        name=random.choice(uppercase)+random.choice(uppercase),
+                        type=random.choice(uppercase)+random.choice(uppercase),
+                        charge=random.random()*2-1, mass=random.random()*30+1,
+                        nb_idx=random.randint(1, 20), radii=random.random()*2,
+                        screen=random.random()*2, tree='M',
+                        join=random.random()*2, irotat=random.random(),
+                        occupancy=random.random(), bfactor=random.random()*10,
+                        altloc=random.choice(uppercase), rmin=random.random()*2,
+                        epsilon=random.random()/2, rmin14=random.random()*2,
+                        epsilon14=random.random()/2)
+        atom.xx, atom.xy, atom.xz = (random.random()*100-50 for i in range(3))
+        atom.number = random.randint(1, 100)
+        atom.vx, atom.vy, atom.vz = (random.random()*100-50 for i in range(3))
+        atom.multipoles = np.random.rand(10) * 10
+
+        fobj = BytesIO()
+        pickle.dump(atom, fobj)
+        fobj.seek(0)
+        unpickled = pickle.load(fobj)
+        
+        self.assertIsInstance(unpickled, pmd.Atom)
+        self._equal_atoms(unpickled, atom)
+
+    def test_bond_serialization(self):
+        """ Tests serialization/pickleability of Bond """
+        struct = utils.create_random_structure(True)
+        bond = struct.bonds[0]
+        fobj = BytesIO()
+        pickle.dump(bond, fobj)
+        fobj.seek(0)
+        unpickled = pickle.load(fobj)
+
+        self.assertIsInstance(bond, pmd.Bond)
+
+    def test_bondtype_serialization(self):
+        """ Tests serialization/pickleability of BondType """
+        struct = utils.create_random_structure(True)
+        bt = struct.bond_types[0]
+
+        fobj = BytesIO()
+        pickle.dump(bt, fobj)
+        fobj.seek(0)
+
+        unpickled = pickle.load(fobj)
+
+        self.assertEqual(unpickled, bt)
+        self.assertIsNot(unpickled, bt)
+
+    def test_residue_serialization(self):
+        """ Tests serialization/pickleability of Residue """
+        struct = utils.create_random_structure(parametrized=True)
+        res = struct.residues[0]
+
+        fobj = BytesIO()
+        pickle.dump(res, fobj)
+        fobj.seek(0)
+        unpickled = pickle.load(fobj)
+
+        self.assertEqual(len(res.atoms), len(unpickled.atoms))
+        for a1, a2 in zip(res, unpickled):
+            self._equal_atoms(a1, a2)
+
+    def test_structure_serialization(self):
+        """ Tests serialization/pickleability of Structure """
+        structure = utils.create_random_structure(parametrized=True)
+        fobj = BytesIO()
+        pickle.dump(structure, fobj)
+        fobj.seek(0)
+        unpickled = pickle.load(fobj)
+
+        self.assertEqual(len(unpickled.residues), len(structure.residues))
+        for r1, r2 in zip(unpickled.residues, structure.residues):
+            self.assertEqual(len(r1), len(r2))
+            self.assertEqual(r1.idx, r2.idx)
+            for a1, a2 in zip(r1, r2):
+                self._equal_atoms(a1, a2)
+
+        for a1, a2 in zip(unpickled, structure):
+            self._equal_atoms(a1, a2)
+            self.assertEqual(a1.idx, a2.idx)
+
+        # Make sure all of the type arrays are equivalent
+        def cmp_type_arrays(arr1, arr2):
+            self.assertEqual(len(arr1), len(arr2))
+            for x1, x2 in zip(arr1, arr2):
+                self.assertEqual(x1, x2)
+
+        cmp_type_arrays(structure.bond_types, unpickled.bond_types)
+        cmp_type_arrays(structure.angle_types, unpickled.angle_types)
+        cmp_type_arrays(structure.dihedral_types, unpickled.dihedral_types)
+        cmp_type_arrays(structure.improper_types, unpickled.improper_types)
+        cmp_type_arrays(structure.urey_bradley_types, unpickled.urey_bradley_types)
+        cmp_type_arrays(structure.rb_torsion_types, unpickled.rb_torsion_types)
+        cmp_type_arrays(structure.cmap_types, unpickled.cmap_types)
+        cmp_type_arrays(structure.trigonal_angle_types,
+                        unpickled.trigonal_angle_types)
+        cmp_type_arrays(structure.out_of_plane_bend_types,
+                        unpickled.out_of_plane_bend_types)
+        cmp_type_arrays(structure.stretch_bend_types, unpickled.stretch_bend_types)
+        cmp_type_arrays(structure.torsion_torsion_types,
+                        unpickled.torsion_torsion_types)
+        cmp_type_arrays(structure.pi_torsion_types, unpickled.pi_torsion_types)
+        cmp_type_arrays(structure.adjust_types, unpickled.adjust_types)
+
+        # Make sure all of the connectivity arrays are equivalent
+        def cmp_top_arrays(arr1, arr2):
+            self.assertEqual(len(arr1), len(arr2))
+            for t1, t2 in zip(arr1, arr2):
+                self.assertIs(type(t1), type(t2))
+                atoms = [attr for attr in dir(t1) if attr.startswith('atom')]
+                for a in atoms:
+                    self._equal_atoms(getattr(t1, a), getattr(t2, a))
+                if hasattr(t1, 'type'):
+                    self.assertEqual(t1.type, t2.type)
+
+        cmp_top_arrays(structure.bonds, unpickled.bonds)
+        cmp_top_arrays(structure.angles, unpickled.angles)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -271,6 +271,9 @@ class TestParmedSerialization(unittest.TestCase):
         )
         unpickled = pickle.loads(pickle.dumps(structure))
         self._compare_structures(unpickled, structure)
+        self.assertEqual(structure.defaults, unpickled.defaults)
+        self._compare_parametersets(structure.parameterset,
+                                    unpickled.parameterset)
 
     def test_charmmpsf_serialization(self):
         """ Tests the serialization of a CHARMM PSF file """
@@ -379,3 +382,23 @@ class TestParmedSerialization(unittest.TestCase):
         cmp_top_arrays(structure.chiral_frames, unpickled.chiral_frames)
         cmp_top_arrays(structure.multipole_frames, unpickled.multipole_frames)
         cmp_top_arrays(structure.adjusts, unpickled.adjusts)
+
+    def _compare_parametersets(self, set1, set2):
+
+        def cmp_lists(l1, l2):
+            self.assertEqual(len(l1), len(l2))
+            self.assertEqual(set(l1.keys()), set(l2.keys()))
+            for k in l1:
+                self.assertEqual(l1[k], l2[k])
+
+        # Now compare all of the parameter lists
+        cmp_lists(set1.bond_types, set2.bond_types)
+        cmp_lists(set1.angle_types, set2.angle_types)
+        cmp_lists(set1.dihedral_types, set2.dihedral_types)
+        cmp_lists(set1.improper_types, set2.improper_types)
+        cmp_lists(set1.improper_periodic_types, set2.improper_periodic_types)
+        cmp_lists(set1.cmap_types, set2.cmap_types)
+        cmp_lists(set1.atom_types, set2.atom_types)
+        cmp_lists(set1.urey_bradley_types, set2.urey_bradley_types)
+        cmp_lists(set1.nbfix_types, set2.nbfix_types)
+        self.assertEqual(set1.combining_rule, set2.combining_rule)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -146,6 +146,12 @@ class TestParmedSerialization(unittest.TestCase):
             cmp_alists(a1.tortor_partners, a2.tortor_partners)
             cmp_alists(a1.exclusion_partners, a2.exclusion_partners)
 
+        # Check coordinates
+        if structure.get_coordinates() is None:
+            self.assertIs(unpickled.get_coordinates(), None)
+        else:
+            np.testing.assert_equal(structure.get_coordinates(),
+                                    unpickled.get_coordinates())
         # Make sure all of the type arrays are equivalent
         def cmp_type_arrays(arr1, arr2):
             self.assertEqual(len(arr1), len(arr2))
@@ -316,3 +322,18 @@ class TestParmedSerialization(unittest.TestCase):
                     'pmid', 'journal_authors', 'volume_page', 'title', 'year',
                     'resolution', 'related_entries'):
             self.assertEqual(getattr(structure, key), getattr(unpickled, key))
+
+    def test_pdbtraj_serialization(self):
+        """ Tests the serialization/pickleability of a Structure w/ traj """
+        structure = pmd.load_file(utils.get_fn('2koc.pdb'))
+        unpickled = pickle.loads(pickle.dumps(structure))
+
+        self._compare_structures(unpickled, structure)
+
+        # Check metadata
+        for key in ('experimental', 'journal', 'authors', 'keywords', 'doi',
+                    'pmid', 'journal_authors', 'volume_page', 'title', 'year',
+                    'resolution', 'related_entries'):
+            self.assertEqual(getattr(structure, key), getattr(unpickled, key))
+
+        self.assertGreater(structure.get_coordinates().shape[0], 1)

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -152,6 +152,14 @@ class TestParmedSerialization(unittest.TestCase):
         else:
             np.testing.assert_equal(structure.get_coordinates(),
                                     unpickled.get_coordinates())
+        # Check unit cell
+        if structure.box is None:
+            self.assertIs(unpickled.box, None)
+            self.assertIs(unpickled.box_vectors, None)
+        else:
+            np.testing.assert_equal(structure.box, unpickled.box)
+            self.assertEqual(structure.box_vectors, unpickled.box_vectors)
+
         # Make sure all of the type arrays are equivalent
         def cmp_type_arrays(arr1, arr2):
             self.assertEqual(len(arr1), len(arr2))

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -120,9 +120,26 @@ class TestParmedSerialization(unittest.TestCase):
             self._equal_atoms(a1, a2)
 
     def _compare_structures(self, unpickled, structure):
+
+        self.assertEqual(len(unpickled.residues), len(structure.residues))
+        for r1, r2 in zip(unpickled.residues, structure.residues):
+            self.assertEqual(len(r1), len(r2))
+            self.assertEqual(r1.idx, r2.idx)
+            for a1, a2 in zip(r1, r2):
+                self._equal_atoms(a1, a2)
+
         for a1, a2 in zip(unpickled, structure):
             self._equal_atoms(a1, a2)
             self.assertEqual(a1.idx, a2.idx)
+            self.assertEqual(len(a1.bonds), len(a2.bonds))
+            self.assertEqual(len(a1.angles), len(a2.angles))
+            self.assertEqual(len(a1.dihedrals), len(a2.dihedrals))
+            self.assertEqual(len(a1.impropers), len(a2.impropers))
+            self.assertEqual(len(a1.bond_partners), len(a2.bond_partners))
+            self.assertEqual(len(a1.angle_partners), len(a2.angle_partners))
+            self.assertEqual(len(a1.dihedral_partners), len(a2.dihedral_partners))
+            self.assertEqual(len(a1.tortor_partners), len(a2.tortor_partners))
+            self.assertEqual(len(a1.exclusion_partners), len(a2.exclusion_partners))
 
         # Make sure all of the type arrays are equivalent
         def cmp_type_arrays(arr1, arr2):
@@ -178,17 +195,12 @@ class TestParmedSerialization(unittest.TestCase):
     def test_structure_serialization(self):
         """ Tests serialization/pickleability of Structure """
         structure = utils.create_random_structure(parametrized=True)
+        structure.atoms[0].exclude(structure.atoms[10])
         fobj = BytesIO()
         pickle.dump(structure, fobj)
         fobj.seek(0)
         unpickled = pickle.load(fobj)
 
-        self.assertEqual(len(unpickled.residues), len(structure.residues))
-        for r1, r2 in zip(unpickled.residues, structure.residues):
-            self.assertEqual(len(r1), len(r2))
-            self.assertEqual(r1.idx, r2.idx)
-            for a1, a2 in zip(r1, r2):
-                self._equal_atoms(a1, a2)
         self._compare_structures(unpickled, structure)
 
     def test_fortran_format_serialization(self):


### PR DESCRIPTION
Can now pickle Structure, AmberFormat, and AmberParm and its subclasses.

Still need to check on some others:

- [x] Structure containing trajectory information
- [x] Structure containing velocity information
- [x] GromacsTopologyFile subclass
- [x] CharmmPsfFile subclass
- [x] ParameterSet and friends

This closes #328 