### PR TITLE
Implements moleculetype combining semantics for GromacsTopologyFile

### DIFF
--- a/devtools/travis-ci/pyflakes_check.sh
+++ b/devtools/travis-ci/pyflakes_check.sh
@@ -17,7 +17,7 @@ notfound() {
 
 test -d parmed || notfound
 
-pyflakes parmed | \
+pyflakes parmed 2>&1 | \
     grep -v -e "from parmed.topologyobjects import \*" \
             -e "from parmed.modeller.residue import \*" \
             -e "from parmed.tools.actions import \*" \

--- a/doc/gromacs.rst
+++ b/doc/gromacs.rst
@@ -81,9 +81,117 @@ is shown below::
     >>> top
     <GromacsTopologyFile 1960 atoms; 129 residues; 1984 bonds; parametrized>
     
-
 You can manipulate the ``top`` instance any way you can a :class:`Structure
 <parmed.structure.Structure>` instance.
+
+Writing GROMACS Topology Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Molecule type definitions**
+
+The GROMACS topology is constructed by piecing together *fragments* of a system,
+where each fragment is, by standard convention, an individual *molecule*
+(meaning that you can "reach" every atom in a molecule from every other atom in
+that molecule by traversing some number of bonds -- i.e., it is a connected
+graph).
+
+These "molecules" are defined in separate ``[ moleculetype ]`` sections of the
+topology file, and then the ``[ molecules ]`` section gives the order, and
+number, of each molecule *type* in the system.
+
+GROMACS can make use of the definitions of a molecule *type*, and this
+distinction is particularly important for free energy calculations. For this
+reason, the ``combine`` keyword in :meth:`GromacsTopologyFile.write` allows
+fine-grained control over how ``[ moleculetype ]`` sections are defined. By
+default, (when ``combine`` is assigned ``None``), the structure is split into
+molecules and written as separate ``[ moleculetype ]`` sections. When
+``combine`` is assigned the string ``all``, the entire structure is considered
+to be a single molecule and is stored as a single ``[ moleculetype ]`` section.
+
+The last allowable mode is to assign lists of lists of molecule indices for
+``combine``, telling :class:`GromacsTopologyFile` exactly which molecules to
+"combine" into larger ``[ moleculetype ]`` sections. There is one major
+restriction here: combined molecules *must* be contiguously ordered in the
+original atom sequence of the structure! The reason for this is that if the
+original order of the atoms is changed, then the topology atom order will no
+longer match that from the coordinate file! An annotated example may help
+demonstrate this. Consider the following topology file (it is actually the
+``topol3.top`` file from the ``12.DPPC/`` directory in the test suite):
+
+    #include "DPPC_2.itp"
+    
+    ; System specifications
+    [ system ]
+    DPPC Bilayer
+    
+    [ molecules ]
+    ; molecule name nr.
+    DPPC 4
+    SOL	122
+    DPPC 4
+    SOL 122
+    
+The DPPC and SOL molecule types are defined in the ``DPPC_2.itp`` include
+topology file. When this topology is read in, there will be 252 residues -- 8
+DPPC residues and 244 SOL residues::
+
+    >>> import parmed as pmd
+    >>> # You can safely ignore the warning printed here
+    ... system = pmd.load_file('topol3.top')
+    >>> system
+    <GromacsTopologyFile 1132 atoms; 252 residues; 880 bonds; parametrized>
+
+Now suppose that we want to do something special with a DPPC-solvent pair, and
+then something special with all of the DPPC residues in the second set (possibly
+a second "leaflet" in a bilayer system) again with a single solvent.  So what we
+want to do is combine the 4th and 5th molecules (since indices start from 0,
+this would be molecules 3 and 4), as well as the five residues 127 through 131
+(indices 126, 127, 128, 129, and 130). Our ``combine`` would then look like
+``[[3,4],[126,127,128,129,130]]``::
+
+    >>> system.write('test.top', combine=[[3, 4], [126, 127, 128, 129, 130]])
+
+If we look at the bottom of the ``test.top`` file we generated, we should see
+this:
+
+    [ molecules ]
+    ; Compound       #mols
+    DPPC                 3
+    system1              1
+    SOL                121
+    system2              1
+    SOL                121
+    
+If we think about it, this is exactly what we want.  We left our first 3 DPPC
+residues alone, then combined DPPC and SOL into a single molecule (since the
+molecule is defined by more than 1 residue, it is given a generic name
+``system#``, where ``#`` increments for each multi-residue molecule that is
+encountered. We left the last 121 of 122 SOL residues alone, then combined all 4
+DPPC residues and the first of the second set of 122 SOL residues into a single
+molecule type. Leaving us with ``system2`` and 121 ``SOL`` left to define our
+original system.
+
+Note, if you read a GROMACS topology file that combines multiple molecules into
+individual molecule types, writing a copy back to a different topology file will
+*not* preserve the original ``[ moleculetype ]`` definitions (since the ParmEd
+``Structure`` object carries no memory of such decompositions and always
+flattens the list of atoms and residues).  For the most part, you should not
+bother with this added complication unless you *know* it is necessary.
+
+**Parameters**
+
+There are 3 ways that parameters can be specified in GROMACS topologies --
+either through include topology files, as separate ``[ <parameter>type ]``
+sections in the main topology file, or in-line with the actual topologies
+themselves.
+
+You can specify where the parameters are placed using the ``parameters`` keyword
+in :meth:`GromacsTopologyFile.write`. The allowed values are ``inline``, a
+string representing the name of a file, or an open file object. If the file name
+is the same as the file name of the topology file itself, then the parameter
+sections will be written to the beginning of the topology file. If it is a
+different file, the name of the file will be included in the generated topology
+file. The default value is ``inline``.
 
 The GRO coordinate
 ------------------

--- a/doc/gromacs.rst
+++ b/doc/gromacs.rst
@@ -118,6 +118,8 @@ longer match that from the coordinate file! An annotated example may help
 demonstrate this. Consider the following topology file (it is actually the
 ``topol3.top`` file from the ``12.DPPC/`` directory in the test suite):
 
+::
+
     #include "DPPC_2.itp"
     
     ; System specifications
@@ -153,6 +155,8 @@ this would be molecules 3 and 4), as well as the five residues 127 through 131
 
 If we look at the bottom of the ``test.top`` file we generated, we should see
 this:
+
+::
 
     [ molecules ]
     ; Compound       #mols

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -4,6 +4,12 @@ and building a Structure from it
 """
 from __future__ import print_function, division, absolute_import
 
+from collections import OrderedDict, defaultdict
+from contextlib import closing
+import copy
+from datetime import datetime
+import math
+import os
 from parmed.constants import TINY, DEG_TO_RAD
 from parmed.exceptions import GromacsError, GromacsWarning, ParameterWarning
 from parmed.formats.registry import FileFormatType
@@ -21,12 +27,6 @@ from parmed import unit as u
 from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
-from collections import OrderedDict
-from contextlib import closing
-import copy
-from datetime import datetime
-import math
-import os
 import re
 try:
     from string import letters
@@ -1246,6 +1246,28 @@ class GromacsTopologyFile(Structure):
             raise ValueError('parameters must be "inline", a file name, or '
                              'a file-like object')
 
+        # Error-checking for combine
+        if combine is not None:
+            if isinstance(combine, string_types):
+                if combine.lower() != 'all':
+                    raise ValueError('combine must be None, list of indices, '
+                                     'or "all"')
+            else:
+                try:
+                    it = iter(combine)
+                except TypeError:
+                    raise TypeError('combine must be a list of molecule index '
+                                    'lists')
+                combine_lists = []
+                for indices in it:
+                    try:
+                        indices = sorted(set(indices))
+                    except TypeError:
+                        raise ValueError('combine must be a list of iterables')
+                    if any((indices[i+1] - indices[i]) != 1
+                                for i in range(len(indices)-1)):
+                        raise ValueError('Can only combine adjacent molecules')
+                    combine_lists.append(indices)
         try:
             # Write the header
             now = datetime.now()
@@ -1476,8 +1498,105 @@ class GromacsTopologyFile(Structure):
                 dest.write('[ molecules ]\n; Compound       #mols\n')
                 dest.write('%-15s %6d\n' % ('system', 1))
             else:
-                raise NotImplementedError('Specialized molecule splitting is '
-                                          'not yet supported')
+                molecules = self.split()
+                nmols = sum(len(m[1]) for m in molecules)
+                moleculedict = dict()
+                # Hash our molecules by indices
+                for m, num in molecules:
+                    for i in num:
+                        moleculedict[i] = m
+                combined_molecules = []
+                for cl in combine_lists:
+                    counts = defaultdict(int)
+                    mols_in_mol = []
+                    for molid in cl:
+                        try:
+                            mol = moleculedict[molid]
+                        except KeyError:
+                            raise IndexError('Molecule ID out of range')
+                        counts[id(moleculedict[molid])] += 1
+                        if counts[id(moleculedict[molid])] == 1:
+                            mols_in_mol.append(mol)
+                    if counts[id(mols_in_mol[0])] > 1:
+                        combmol = mols_in_mol[0] * counts[id(mols_in_mol[0])]
+                    else:
+                        combmol = copy.copy(mols_in_mol[0])
+                    for i, mol in enumerate(mols_in_mol):
+                        if i == 0: continue
+                        assert id(mol) in counts and counts[id(mol)] > 0
+                        if counts[id(mol)] > 1:
+                            combmol += mol * counts[id(mol)]
+                        else:
+                            combmol += mol
+                    combined_molecules.append((combmol, cl[0], len(cl)))
+                    nmols -= len(cl)
+                # combined_molecules now contains a list of tuples, and that
+                # tuple stores the combined molecule, first molecule index of
+                # the pre-combined molecule, and how many molecules were
+                # combined
+
+                # Sort combined molecules by starting location
+                combined_molecules.sort(key=lambda x: x[1])
+                new_molecules = []
+                counts = defaultdict(set)
+                cmc = 0 # Combined Molecule Counter
+                add = 0 # How many molecules to "skip" due to combining
+                for i in range(nmols):
+                    ii = i + add
+                    if (cmc < len(combined_molecules) and
+                            combined_molecules[cmc][1] == ii):
+                        new_molecules.append([combined_molecules[cmc][0],
+                                              set([i])])
+                        add += combined_molecules[cmc][2] - 1
+                        cmc += 1
+                    elif len(counts[id(moleculedict[ii])]) == 0:
+                        counts[id(moleculedict[ii])].add(i)
+                        new_molecules.append([moleculedict[ii],
+                                              counts[id(moleculedict[ii])]])
+                    else:
+                        counts[id(moleculedict[ii])].add(i)
+                sysnum = 1
+                names = []
+                nameset = set()
+                for molecule, num in new_molecules:
+                    if len(molecule.residues) == 1:
+                        title = molecule.residues[0].name
+                        if title in nameset:
+                            orig = title
+                            sfx = 2
+                            while title in nameset:
+                                title = '%s%d' % (orig, sfx)
+                                sfx += 1
+                    else:
+                        title = 'system%d' % sysnum
+                        sysnum += 1
+                    names.append(title)
+                    nameset.add(title)
+                    GromacsTopologyFile._write_molecule(molecule, dest, title,
+                                        params, parameters == 'inline')
+                # System
+                dest.write('[ system ]\n; Name\n')
+                if self.title:
+                    dest.write(self.title)
+                else:
+                    dest.write('Generic title')
+                dest.write('\n\n')
+                # Molecules
+                dest.write('[ molecules ]\n; Compound       #mols\n')
+                total_mols = sum(len(m[1]) for m in molecules)
+                i = 0
+                while i < total_mols:
+                    for j, (molecule, lst) in enumerate(molecules):
+                        if i in lst:
+                            break
+                    else:
+                        raise RuntimeError('Could not find molecule %d in list'
+                                           % i)
+                    ii = i
+                    while ii < total_mols and ii in lst:
+                        ii += 1
+                    dest.write('%-15s %6d\n' % (names[j], ii-i))
+                    i = ii
         finally:
             if own_handle:
                 dest.close()

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1499,7 +1499,7 @@ class GromacsTopologyFile(Structure):
                 dest.write('%-15s %6d\n' % ('system', 1))
             else:
                 molecules = self.split()
-                nmols = nmols_orig = sum(len(m[1]) for m in molecules)
+                nmols = sum(len(m[1]) for m in molecules)
                 moleculedict = dict()
                 # Hash our molecules by indices
                 for m, num in molecules:

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1499,7 +1499,7 @@ class GromacsTopologyFile(Structure):
                 dest.write('%-15s %6d\n' % ('system', 1))
             else:
                 molecules = self.split()
-                nmols = sum(len(m[1]) for m in molecules)
+                nmols = nmols_orig = sum(len(m[1]) for m in molecules)
                 moleculedict = dict()
                 # Hash our molecules by indices
                 for m, num in molecules:
@@ -1529,7 +1529,7 @@ class GromacsTopologyFile(Structure):
                         else:
                             combmol += mol
                     combined_molecules.append((combmol, cl[0], len(cl)))
-                    nmols -= len(cl)
+                    nmols -= (len(cl) - 1)
                 # combined_molecules now contains a list of tuples, and that
                 # tuple stores the combined molecule, first molecule index of
                 # the pre-combined molecule, and how many molecules were
@@ -1583,10 +1583,10 @@ class GromacsTopologyFile(Structure):
                 dest.write('\n\n')
                 # Molecules
                 dest.write('[ molecules ]\n; Compound       #mols\n')
-                total_mols = sum(len(m[1]) for m in molecules)
+                total_mols = sum(len(m[1]) for m in new_molecules)
                 i = 0
                 while i < total_mols:
-                    for j, (molecule, lst) in enumerate(molecules):
+                    for j, (molecule, lst) in enumerate(new_molecules):
                         if i in lst:
                             break
                     else:

--- a/test/test_parmed_genopen.py
+++ b/test/test_parmed_genopen.py
@@ -56,7 +56,7 @@ class TestGenopen(FileIOTestCase):
 
     def testReadNormalURL(self):
         """ Tests genopen reading a remote file """
-        url = 'http://q4md-forcefieldtools.org/REDDB/projects/W-73/tripos1.mol2'
+        url = 'https://github.com/ParmEd/ParmEd/raw/master/test/files/tripos1.mol2'
         with closing(genopen(url, 'r')) as f:
             self.assertEqual(f.read(), open(get_fn('tripos1.mol2')).read())
 

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -251,6 +251,15 @@ class TestGromacsTop(FileIOTestCase):
         warnings.filterwarnings('ignore', category=GromacsWarning)
         parm = load_file(os.path.join(get_fn('12.DPPC'), 'topol3.top'))
         fname = get_fn('combined.top', written=True)
+        # Make sure that combining non-adjacent molecules fails
+        self.assertRaises(ValueError, lambda:
+                parm.write(fname, combine=[[1, 3]]))
+        self.assertRaises(ValueError, lambda:
+                parm.write(fname, combine='joey'))
+        self.assertRaises(ValueError, lambda:
+                parm.write(fname, combine=[1, 2, 3]))
+        self.assertRaises(TypeError, lambda:
+                parm.write(fname, combine=1))
         parm.write(fname, combine=[[3, 4], [126, 127, 128, 129, 130]])
         with open(fname, 'r') as f:
             for line in f:

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -270,8 +270,17 @@ class TestGromacsTop(FileIOTestCase):
                 if line[0] == ';': continue
                 words = line.split()
                 molecule_list.append((words[0], int(words[1])))
+        parm2 = load_file(fname)
         self.assertEqual(molecule_list, [('DPPC', 3), ('system1', 1),
                          ('SOL', 121), ('system2', 1), ('SOL', 121)])
+        self.assertEqual(len(parm2.atoms), len(parm.atoms))
+        self.assertEqual(len(parm2.residues), len(parm2.residues))
+        for a1, a2 in zip(parm.atoms, parm2.atoms):
+            self._equal_atoms(a1, a2)
+        for r1, r2 in zip(parm.residues, parm2.residues):
+            self.assertEqual(len(r1), len(r2))
+            for a1, a2 in zip(r1, r2):
+                self._equal_atoms(a1, a2)
 
     _equal_atoms = utils.equal_atoms
 

--- a/test/test_parmed_serialization.py
+++ b/test/test_parmed_serialization.py
@@ -23,36 +23,7 @@ import utils
 class TestParmedSerialization(unittest.TestCase):
     """ Tests ParmEd serialization """
 
-    def _equal_atoms(self, a1, a2):
-        self.assertEqual(a1.atomic_number, a2.atomic_number)
-        self.assertEqual(a1.screen, a2.screen)
-        self.assertEqual(a1.name, a2.name)
-        self.assertEqual(a1.type, a2.type)
-        self.assertEqual(a1.atom_type, a2.atom_type)
-        self.assertEqual(a1.charge, a2.charge)
-        self.assertEqual(a1.mass, a2.mass)
-        self.assertEqual(a1.nb_idx, a2.nb_idx)
-        self.assertEqual(a1.radii, a2.radii)
-        self.assertEqual(a1.tree, a2.tree)
-        self.assertEqual(a1.join, a2.join)
-        self.assertEqual(a1.irotat, a2.irotat)
-        self.assertEqual(a1.occupancy, a2.occupancy)
-        self.assertEqual(a1.bfactor, a2.bfactor)
-        self.assertEqual(a1.rmin, a2.rmin)
-        self.assertEqual(a1.epsilon, a2.epsilon)
-        self.assertEqual(a1.rmin_14, a2.rmin_14)
-        self.assertEqual(a1.epsilon_14, a2.epsilon_14)
-        for key in ('xx', 'xy', 'xz', 'vx', 'vy', 'vz', 'multipoles',
-                    'type_idx', 'class_idx', 'polarizability', 'vdw_weight'):
-            if hasattr(a2, key):
-                if isinstance(getattr(a2, key), np.ndarray):
-                    np.testing.assert_equal(
-                            getattr(a1, key), getattr(a2, key)
-                    )
-                else:
-                    self.assertEqual(getattr(a1, key), getattr(a2, key))
-            else:
-                self.assertFalse(hasattr(a1, key))
+    _equal_atoms = utils.equal_atoms
 
     def test_atom_serialization(self):
         """ Tests the serialization of Atom """

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,10 +1,11 @@
 """
 Useful functions for the test cases
 """
-from parmed.utils.six import string_types
-from parmed.utils.six.moves import zip
+import numpy as np
 import os
 from os.path import join, split, abspath
+from parmed.utils.six import string_types
+from parmed.utils.six.moves import zip
 import random
 import unittest
 import warnings
@@ -490,3 +491,45 @@ def create_random_structure(parametrized, novalence=False):
     struct.unchange()
     struct.update_dihedral_exclusions()
     return struct
+
+def equal_atoms(tester, a1, a2):
+    """ Tests equality of two atoms based on properties
+
+    Parameters
+    ----------
+    tester : unittest.TestCase
+        TestCase instance
+    a1 : Atom
+        First atom to compare
+    a2 : Atom
+        Second atom to compare
+    """
+    tester.assertEqual(a1.atomic_number, a2.atomic_number)
+    tester.assertEqual(a1.screen, a2.screen)
+    tester.assertEqual(a1.name, a2.name)
+    tester.assertEqual(a1.type, a2.type)
+    tester.assertEqual(a1.atom_type, a2.atom_type)
+    tester.assertEqual(a1.charge, a2.charge)
+    tester.assertEqual(a1.mass, a2.mass)
+    tester.assertEqual(a1.nb_idx, a2.nb_idx)
+    tester.assertEqual(a1.radii, a2.radii)
+    tester.assertEqual(a1.tree, a2.tree)
+    tester.assertEqual(a1.join, a2.join)
+    tester.assertEqual(a1.irotat, a2.irotat)
+    tester.assertEqual(a1.occupancy, a2.occupancy)
+    tester.assertEqual(a1.bfactor, a2.bfactor)
+    tester.assertEqual(a1.rmin, a2.rmin)
+    tester.assertEqual(a1.epsilon, a2.epsilon)
+    tester.assertEqual(a1.rmin_14, a2.rmin_14)
+    tester.assertEqual(a1.epsilon_14, a2.epsilon_14)
+    for key in ('xx', 'xy', 'xz', 'vx', 'vy', 'vz', 'multipoles',
+                'type_idx', 'class_idx', 'polarizability', 'vdw_weight'):
+        if hasattr(a2, key):
+            if isinstance(getattr(a2, key), np.ndarray):
+                np.testing.assert_equal(
+                        getattr(a1, key), getattr(a2, key)
+                )
+            else:
+                tester.assertEqual(getattr(a1, key), getattr(a2, key))
+        else:
+            tester.assertFalse(hasattr(a1, key))


### PR DESCRIPTION
`GromacsTopologyFile.write(combine)` now accepts a list of lists, where the second level of list specifies molecule indices to combine into a single moleculetype.  These indices *must* be consecutive, since otherwise it will desynchronize from the coordinate file.

Closes #435 