### PR TITLE
Fix printout of masses in generated GROMACS top files

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -3,7 +3,7 @@ The parmed package manipulates molecular structures and provides a way to go
 between standard and amber file formats, manipulate structures, etc.
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1326,7 +1326,7 @@ class GromacsTopologyFile(Structure):
                 if print_atnum:
                     parfile.write('%8d ' % atom_type.atomic_number)
                 parfile.write('%10.5f  %10.6f  A %13.6g %13.6g\n' % (
-                              0, atom_type.mass, atom_type.sigma/10,
+                              atom_type.mass, 0, atom_type.sigma/10,
                               atom_type.epsilon*econv))
             parfile.write('\n')
             # Print all parameter types unless we asked for inline

--- a/test/files/saved/benzene_cyclohexane_10_500.top
+++ b/test/files/saved/benzene_cyclohexane_10_500.top
@@ -1,17 +1,17 @@
 ;
-;   File saved/benzene_cyclohexane_10_500.top was generated
-;   By user: swails (501)
-;   On host: Jasons-MBP
-;   At date: Mon. June  1 10:32:34 2015
+;   File /scratch2/swails/src/ParmEd/test/files/writes/benzene_cyclohexane_10_500.top was generated
+;   By user: swails (44411)
+;   On host: batman
+;   At date: Tue. October  2 12:54:43 2015
 ;
 ;   This is a standalone topology file
 ;
 ;   Created by:
-;   ParmEd:       , VERSION 15.1
-;   Executable:   
-;   Library dir:  /usr/local/share/gromacs/top
+;   ParmEd:       nosetests, VERSION 2.0.2
+;   Executable:   nosetests
+;   Library dir:  /usr/share/gromacs/top
 ;   Command line:
-;
+;     /scratch2/miniconda/envs/py27/bin/nosetests -vs test/test_format_conversions.py --pdb
 ;
 
 [ defaults ]
@@ -20,10 +20,10 @@
 
 [ atomtypes ]
 ; name    at.num    mass    charge ptype  sigma      epsilon
-ca             6    0.00000   12.010000  A      0.339967      0.359824
-ha             1    0.00000    1.008000  A      0.259964       0.06276
-c3             6    0.00000   12.010000  A      0.339967       0.45773
-hc             1    0.00000    1.008000  A      0.264953     0.0656888
+ca             6   12.01000    0.000000  A      0.339967      0.359824
+ha             1    1.00800    0.000000  A      0.259964       0.06276
+c3             6   12.01000    0.000000  A      0.339967       0.45773
+hc             1    1.00800    0.000000  A      0.264953     0.0656888
 
 
 [ moleculetype ]


### PR DESCRIPTION
Accidentally swapped charge and mass. It was mainly cosmetic, as these masses
were not used by anything that I'm aware of, but it's still better to print out
compatible topologies.