### PR TITLE
Fix misassignment of `defaults` section for GromacsTopologyFile

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -3,7 +3,7 @@ The parmed package manipulates molecular structures and provides a way to go
 between standard and amber file formats, manipulate structures, etc.
 """
 
-__version__ = '2.0.3'
+__version__ = '2.0.4'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.0.4-beta3'
+__version__ = '2.0.4'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',
@@ -102,6 +102,12 @@ class version(namedtuple('version', ['major', 'minor', 'patchlevel'])):
 
     def __ne__(self, other):
         return self < other or self > other
+
+    def __repr__(self):
+        ret = super(type(self), self).__repr__()
+        if self.beta is None:
+            return ret
+        return ret[:-1] + ', beta=%d)' % self.beta
 
 # Build the version
 _betare = re.compile(r'-beta*')

--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -103,6 +103,11 @@ class version(namedtuple('version', ['major', 'minor', 'patchlevel'])):
     def __ne__(self, other):
         return self < other or self > other
 
+    def __ge__(self, other):
+        return self > other or self == other
+    def __le__(self, other):
+        return self < other or self > other
+
     def __repr__(self):
         ret = super(type(self), self).__repr__()
         if self.beta is None:

--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -3,14 +3,17 @@ The parmed package manipulates molecular structures and provides a way to go
 between standard and amber file formats, manipulate structures, etc.
 """
 
-__version__ = '2.0.4'
+# Version format should be "major.minor.patch". For beta releases, attach
+# "-beta#" to the end. The beta number will be turned into another number in the
+# version tuple
+__version__ = '2.0.4-beta3'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',
            'Structure', 'StructureView', 'amber', 'charmm', 'namd', 'gromacs', 
            'tinker', 'openmm', 'rosetta', 'formats', 'Vec3', 'ParameterSet', 
            'load_file', 'read_PDB', 'read_CIF', 'write_PDB', 'write_CIF', 
-           'load_rosetta', 'download_PDB', 'download_CIF', 'tools']
+           'load_rosetta', 'download_PDB', 'download_CIF', 'tools', 'version']
 
 from parmed import exceptions, periodic_table, residue
 from parmed import unit, utils
@@ -36,3 +39,78 @@ from parmed import tools
 
 # Add all of the objects from parmed.topologyobjects to the top-level namespace
 __all__ += topologyobjects.__all__
+
+# Build a version tuple from __version__ for easy comparison
+import re
+from collections import namedtuple
+class version(namedtuple('version', ['major', 'minor', 'patchlevel'])):
+    # Make sure betas always compare *less* than non-betas, and beta levels
+    # compare greater than lower beta levels
+    def __lt__(self, other):
+        try:
+            other = tuple(other)
+        except TypeError:
+            return NotImplemented
+        other_is_beta = False
+        if len(other) >= 4:
+            other_is_beta = True
+        if other_is_beta and self.beta is None:
+            return tuple.__lt__(self, other[:3])
+        elif other_is_beta and self.beta is not None:
+            if tuple.__eq__(self, other[:3]):
+                return self.beta < other[3]
+            return tuple.__lt__(self, other)
+        elif not other_is_beta and self.beta is not None:
+            return tuple.__le__(self, other[:3])
+        else:
+            return tuple.__lt__(self, other)
+
+    def __gt__(self, other):
+        try:
+            other = tuple(other)
+        except TypeError:
+            return NotImplemented
+        other_is_beta = False
+        if len(other) >= 4:
+            other_is_beta = True
+        if other_is_beta and self.beta is None:
+            return tuple.__ge__(self, other[:3])
+        elif other_is_beta and self.beta is not None:
+            if tuple.__eq__(self, other[:3]):
+                return self.beta > other[3]
+            return tuple.__gt__(self, other)
+        elif not other_is_beta and self.beta is not None:
+            return tuple.__gt__(self, other)
+        else:
+            return tuple.__gt__(self, other)
+
+    def __eq__(self, other):
+        try:
+            other = tuple(other)
+        except TypeError:
+            return NotImplemented
+        other_is_beta = False
+        if len(other) >= 4:
+            other_is_beta = True
+        if other_is_beta and self.beta is None:
+            return False
+        elif not other_is_beta and self.beta is not None:
+            return False
+        if other_is_beta:
+            return tuple.__eq__(self, other[:3]) and self.beta == other[3]
+        return tuple.__eq__(self, other)
+
+    def __ne__(self, other):
+        return self < other or self > other
+
+# Build the version
+_betare = re.compile(r'-beta*')
+versionlist = list(int(x) for x in _betare.sub('.', __version__).split('.'))
+version = version(*versionlist[:3])
+if len(versionlist) > 3:
+    version.beta = versionlist[3]
+else:
+    version.beta = None
+
+# Clean up
+del namedtuple, re, _betare, versionlist

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1099,6 +1099,32 @@ class GromacsTopologyFile(Structure):
 
     #===================================================
 
+    def copy(self, cls, split_dihedrals=False):
+        """
+        Makes a copy of the current structure as an instance of a specified
+        subclass
+
+        Parameters
+        ----------
+        cls : Structure subclass
+            The returned object is a copy of this structure as a `cls` instance
+        split_dihedrals : ``bool``
+            If True, then the Dihedral entries will be split up so that each one
+            is paired with a single DihedralType (rather than a
+            DihedralTypeList)
+
+        Returns
+        -------
+        *cls* instance
+            The instance of the Structure subclass `cls` with a copy of the
+            current Structure's topology information
+        """
+        c = super(GromacsTopologyFile, self).copy(cls, split_dihedrals)
+        c.defaults = copy.copy(self.defaults)
+        return c
+
+    #===================================================
+
     @classmethod
     def from_structure(cls, struct, copy=False):
         """ Instantiates a GromacsTopologyFile instance from a Structure
@@ -1151,6 +1177,7 @@ class GromacsTopologyFile(Structure):
         # Now check what the 1-4 scaling factors should be
         if hasattr(struct, 'defaults') and isinstance(struct.defaults,
                                                       _Defaults):
+            print('Copying defaults: %r' % struct.defaults)
             gmxtop.defaults = struct.defaults
         else:
             scee_values = set()

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1188,7 +1188,6 @@ class GromacsTopologyFile(Structure):
         # Now check what the 1-4 scaling factors should be
         if hasattr(struct, 'defaults') and isinstance(struct.defaults,
                                                       _Defaults):
-            print('Copying defaults: %r' % struct.defaults)
             gmxtop.defaults = struct.defaults
         else:
             scee_values = set()

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1125,6 +1125,17 @@ class GromacsTopologyFile(Structure):
 
     #===================================================
 
+    def __getitem__(self, selection):
+        """ See Structure.__getitem__ for documentation """
+        # Make sure defaults is properly copied
+        struct = super(GromacsTopologyFile, self).__getitem__(selection)
+        if isinstance(struct, Atom):
+            return struct
+        struct.defaults = copy.copy(self.defaults)
+        return struct
+
+    #===================================================
+
     @classmethod
     def from_structure(cls, struct, copy=False):
         """ Instantiates a GromacsTopologyFile instance from a Structure

--- a/test/files/159.top
+++ b/test/files/159.top
@@ -1,0 +1,63 @@
+; 159_GMX.top created by acpype (Rev: 403) on Fri Aug  7 13:19:46 2015
+
+[ defaults ]
+; nbfunc        comb-rule       gen-pairs       fudgeLJ fudgeQQ
+1               2               yes             0.5     0.8333
+
+[ atomtypes ]
+;name   bond_type     mass     charge   ptype   sigma         epsilon       Amb
+ c3       c3          0.00000  0.00000   A     3.39967e-01   4.57730e-01 ; 1.91  0.1094
+ oh       oh          0.00000  0.00000   A     3.06647e-01   8.80314e-01 ; 1.72  0.2104
+ h1       h1          0.00000  0.00000   A     2.47135e-01   6.56888e-02 ; 1.39  0.0157
+ ho       ho          0.00000  0.00000   A     0.00000e+00   0.00000e+00 ; 0.00  0.0000
+
+[ moleculetype ]
+;name            nrexcl
+ 159 3
+
+[ atoms ]
+;   nr  type  resi  res  atom  cgnr     charge      mass       ; qtot   bond_type
+     1   c3     1   MOL    C1    1     0.116600     12.01000 ; qtot 0.117
+     2   oh     1   MOL    O1    2    -0.598601     16.00000 ; qtot -0.482
+     3   h1     1   MOL    H1    3     0.028500      1.00800 ; qtot -0.454
+     4   h1     1   MOL    H2    4     0.028500      1.00800 ; qtot -0.425
+     5   h1     1   MOL    H3    5     0.028500      1.00800 ; qtot -0.397
+     6   ho     1   MOL    H4    6     0.396500      1.00800 ; qtot 0.000
+
+[ bonds ]
+;   ai     aj funct   r             k
+     1      2   1    1.4260e-01    2.6284e+05 ;     C1 - O1    
+     1      3   1    1.0930e-01    2.8108e+05 ;     C1 - H1    
+     1      4   1    1.0930e-01    2.8108e+05 ;     C1 - H2    
+     1      5   1    1.0930e-01    2.8108e+05 ;     C1 - H3    
+     2      6   1    9.7400e-02    3.0928e+05 ;     O1 - H4    
+
+[ pairs ]
+;   ai     aj    funct
+     3      6      1 ;     H1 - H4    
+     4      6      1 ;     H2 - H4    
+     5      6      1 ;     H3 - H4    
+
+[ angles ]
+;   ai     aj     ak    funct   theta         cth
+     1      2      6      1    1.0816e+02    3.9405e+02 ;     C1 - O1     - H4    
+     2      1      3      1    1.0988e+02    4.2652e+02 ;     O1 - C1     - H1    
+     2      1      4      1    1.0988e+02    4.2652e+02 ;     O1 - C1     - H2    
+     2      1      5      1    1.0988e+02    4.2652e+02 ;     O1 - C1     - H3    
+     3      1      4      1    1.0955e+02    3.2786e+02 ;     H1 - C1     - H2    
+     3      1      5      1    1.0955e+02    3.2786e+02 ;     H1 - C1     - H3    
+     4      1      5      1    1.0955e+02    3.2786e+02 ;     H2 - C1     - H3    
+
+[ dihedrals ] ; propers
+; for gromacs 4.5 or higher, using funct 9
+;    i      j      k      l   func   phase     kd      pn
+     3      1      2      6      9     0.00   0.69733   3 ;     H1-    C1-    O1-    H4
+     4      1      2      6      9     0.00   0.69733   3 ;     H2-    C1-    O1-    H4
+     5      1      2      6      9     0.00   0.69733   3 ;     H3-    C1-    O1-    H4
+
+[ system ]
+ 159
+
+[ molecules ]
+; Compound        nmols
+ 159 1     

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -1,7 +1,7 @@
 """
 Tests the functionality in the parmed.gromacs package
 """
-import utils
+import copy
 from parmed import load_file, Structure, ExtraPoint, DihedralTypeList
 from parmed.exceptions import GromacsWarning
 from parmed.gromacs import GromacsTopologyFile, GromacsGroFile
@@ -245,6 +245,15 @@ class TestGromacsTop(FileIOTestCase):
             for a1, a2 in zip(r1.atoms, r2.atoms):
                 self.assertEqual(a1.name, a2.name)
                 self.assertEqual(a1.type, a2.type)
+
+    def testCopyingDefaults(self):
+        """ Tests that copying GromacsTopologyFile copies Defaults too """
+        parm = load_file(get_fn('159.top'))
+        newfile = StringIO()
+        copy.copy(parm).write(newfile)
+        newfile.seek(0)
+        newparm = GromacsTopologyFile(newfile)
+        self.assertEqual(parm.defaults, newparm.defaults)
 
     def testMoleculeCombine(self):
         """ Tests selective molecule combination in Gromacs topology files """

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -9,8 +9,8 @@ from parmed import gromacs as gmx
 from parmed.utils.six.moves import range, zip, StringIO
 import os
 import unittest
-import utils
 from utils import get_fn, diff_files, get_saved_fn, FileIOTestCase
+import utils
 import warnings
 
 @unittest.skipIf(not os.path.exists(gmx.GROMACS_TOPDIR), "Cannot run GROMACS tests without Gromacs")

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -9,7 +9,7 @@ from parmed import gromacs as gmx
 from parmed.utils.six.moves import range, zip, StringIO
 import os
 import unittest
-from utils import get_fn, diff_files, get_saved_fn, FileIOTestCase
+from utils import get_fn, diff_files, get_saved_fn, FileIOTestCase, HAS_GROMACS
 import utils
 import warnings
 

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -255,6 +255,15 @@ class TestGromacsTop(FileIOTestCase):
         newparm = GromacsTopologyFile(newfile)
         self.assertEqual(parm.defaults, newparm.defaults)
 
+    def testGetitemDefaults(self):
+        """ Tests that GromacsTopologyFile[] sets Defaults correctly """
+        parm = load_file(get_fn('159.top'))
+        newfile = StringIO()
+        parm[0,:].write(newfile)
+        newfile.seek(0)
+        newparm = GromacsTopologyFile(newfile)
+        self.assertEqual(parm.defaults, newparm.defaults)
+
     def testMoleculeCombine(self):
         """ Tests selective molecule combination in Gromacs topology files """
         warnings.filterwarnings('ignore', category=GromacsWarning)


### PR DESCRIPTION
Neither the `__copy__` nor the `__getitem__` functions for `GromacsTopologyFile` were implemented for that object (i.e., it was just calling the underlying function from the inherited `Structure`).  Since `Structure` stores the 1-4 scaling constants either in the dihedrals themselves (in the case of Amber), or in the explicit list of exceptions, ParmEd would never set the `defaults` attribute for the copy (meaning it would just get the default when copying a GromacsTopologyFile).

This broke the `GromacsTopologyFile` copy constructor when you just wanted to print out a new Gromacs topology file (and also broke the selector [], which is used by split under-the-hood).  The reason I didn't catch this before is that the underlying `Structure` still had the correct information -- just in the exclusion list.  So if you converted to another format (e.g., Amber), or tried to evaluate an energy with OpenMM, you would get the correct answer.  It was only when going *back* to `GromacsTopologyFile` that this didn't work.

Fixes #450 