### PR TITLE
Protect against bad "source" commands

### DIFF
--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -210,8 +210,6 @@ class Action(lawsuit):
             except AttributeError:
                 usage = cmdname
             Action.stderr.write("Bad command %s:\n\t%s\n" % (cmdname, usage))
-            self.__str__ = Action.__str__
-            self.execute = Action.execute
             return
 
         # Check any unmarked commands

--- a/parmed/tools/parmed_cmd.py
+++ b/parmed/tools/parmed_cmd.py
@@ -186,6 +186,7 @@ class ParmedCmd(cmd.Cmd):
 
     def do_source(self, line):
         action = COMMANDMAP['source'](self.parm, line)
+        if not action.valid: return
         self.stdout.write('%s\n' % action)
         _cmd = ParmedCmd(self.parm, stdin=open(action.filename, 'r'),
                          stdout=self.stdout)


### PR DESCRIPTION
Prevent interpreter from shutting down.

Fixes #462