### PR TITLE
Do not delete box when solvent removed by strip in AmberParm

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.0.9'
+__version__ = '2.0.10'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -625,7 +625,7 @@ class Structure(object):
             )
         for g in self.groups:
             c.groups.append(Group(g.bs, g.type, g.move))
-        c.box = copy(self.box)
+        c._box = copy(self.box)
         c._coordinates = copy(self._coordinates)
         c.combining_rule = self.combining_rule
         return c

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -1399,19 +1399,27 @@ class netCharge(Action):
 class strip(Action):
     """
     Deletes the atoms specified by <mask> from the topology file and rebuilds
-    the topology file according to the parameters that remain.
+    the topology file according to the parameters that remain. If nobox is
+    provided, the unit cell information is discarded (useful when stripping
+    solvent to run an aperiodic implicit solvent calculation).
     """
-    usage = '<mask>'
+    usage = '<mask> [nobox]'
     def init(self, arg_list):
         self.mask = AmberMask(self.parm, arg_list.get_next_mask())
+        self.nobox = arg_list.has_key('nobox')
         self.num_atms = sum(self.mask.Selection())
 
     def __str__(self):
-        return "Removing mask '%s' (%d atoms) from the topology file." % (
-                                    self.mask, self.num_atms)
+        retstr = ["Removing mask '%s' (%d atoms) from the topology file." %
+                    (self.mask, self.num_atoms)]
+        if self.nobox:
+            retstr.append('Deleting box info.')
+        return ' '.join(retstr)
 
     def execute(self):
         self.parm.strip(self.mask)
+        if self.nobox:
+            self.parm.box = None
 
 #+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/test/test_format_conversions.py
+++ b/test/test_format_conversions.py
@@ -104,6 +104,7 @@ class TestGromacsToAmber(FileIOTestCase, TestCaseRelative):
         self.assertEqual(top.combining_rule, 'geometric')
         del top.rb_torsions[:]
         parm = amber.AmberParm.from_structure(top)
+        parm.box = None # Get rid of the unit cell
         self.assertEqual(parm.combining_rule, 'geometric')
         parm.write_parm(get_fn('opls.parm7', written=True))
         self.assertTrue(diff_files(get_fn('opls.parm7', written=True),

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -218,6 +218,22 @@ class TestReadParm(unittest.TestCase):
         self.assertFalse(parm.chamber)
         self.assertFalse(parm.amoeba)
         self.assertEqual(parm.ptr('ifbox'), 1)
+        orig_box = parm.box
+        orig_boxdims = parm.parm_data['BOX_DIMENSIONS'][:]
+        # Strip the solvent and make sure that the box info sticks around
+        parm.strip(':WAT,Cl-')
+        self.assertEqual(parm.ptr('ifbox'), 1)
+        np.testing.assert_equal(orig_box, parm.box)
+        self.assertEqual(parm.parm_data['BOX_DIMENSIONS'], orig_boxdims)
+        self.assertEqual(parm.parm_data['SOLVENT_POINTERS'], [163, 2, 3])
+        self.assertEqual(parm.parm_data['ATOMS_PER_MOLECULE'], [2603, 12])
+        # Make sure that setting box to None gets rid of all boxy stuff
+        parm.box = None
+        self.assertEqual(parm.ptr('ifbox'), 0)
+        self.assertIs(parm.box, None)
+        self.assertNotIn('BOX_DIMENSIONS', parm.parm_data)
+        self.assertNotIn('SOLVENT_POINTERS', parm.parm_data)
+        self.assertNotIn('ATOMS_PER_MOLECULE', parm.parm_data)
 
     def testChamberGasParm(self):
         """Test the ChamberParm class with a non-periodic (gas phase) prmtop"""

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -179,6 +179,7 @@ class TestNonParmActions(unittest.TestCase):
                        os.path.join(get_fn('03.AlaGlu'), 'conf.gro'))
         a.execute()
         parm = a.parm
+        parm.box = None
         self._standard_parm_tests(parm)
         self._extensive_checks(parm)
         self.assertIs(parm.box, None) # AmberParm deletes the box without solvent
@@ -198,6 +199,7 @@ class TestNonParmActions(unittest.TestCase):
         self.assertIn('SOMEDEF2', stra)
         a.execute()
         parm = a.parm
+        parm.box = None
         self._standard_parm_tests(parm)
         self._extensive_checks(parm)
         self.assertIs(parm.box, None)
@@ -1641,7 +1643,7 @@ class TestChamberParmActions(utils.TestCaseRelative, utils.FileIOTestCase):
         parm = copy(solvchamber)
         atoms = [atom for atom in parm.atoms] # shallow copy!
         self.assertTrue(all([x is y for x,y in zip(parm.atoms,atoms)]))
-        self.assertEqual(parm.ptr('IPTRES'), 160)
+        self.assertEqual(parm.ptr('IPTRES'), 159)
         self.assertEqual(parm.ptr('NSPM'), 17857)
         self.assertEqual(parm.ptr('NSPSOL'), 2)
         # To keep the output clean


### PR DESCRIPTION
This causes problems now that the parm is always rebuilt before writing.
Sometimes we want unit cell vectors even if we don't have solvent...