### PR TITLE
Ensure that cmap_types key is *always* an 8-type tuple in `ParameterSet`

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -183,11 +183,8 @@ class CharmmParameterSet(ParameterSet):
         for key, typ in iteritems(params.improper_types):
             copy_paramtype(key, typ, new_params.improper_types)
         for key, typ in iteritems(params.cmap_types):
-            if len(key) == 8:
-                key = (key[0], key[1], key[2], key[3], key[7])
-                copy_paramtype(key, typ, new_params.cmap_types)
-            elif len(key) == 5:
-                copy_paramtype(key, typ, new_params.cmap_types)
+            assert len(key) == 8, '%d-key cmap type detected!' % len(key)
+            copy_paramtype(key, typ, new_params.cmap_types)
         for key, typ in iteritems(params.nbfix_types):
             copy_paramtype(key, typ, new_params.nbfix_types)
 

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -831,8 +831,8 @@ class GromacsTopologyFile(Structure):
                     if res1 != res2:
                         raise GromacsError('Only square CMAPs are supported')
                     cmaptype = CmapType(res1, grid)
-                    params.cmap_types[(a1, a2, a3, a4, a5)] = cmaptype
-                    params.cmap_types[(a5, a4, a3, a2, a1)] = cmaptype
+                    params.cmap_types[(a1,a2,a3,a4,a2,a3,a4,a5)] = cmaptype
+                    params.cmap_types[(a5,a4,a3,a2,a4,a3,a2,a1)] = cmaptype
                 elif current_section == 'pairtypes':
                     words = line.split()
                     a1, a2 = words[:2]
@@ -1090,6 +1090,7 @@ class GromacsTopologyFile(Structure):
             if c.type is not None: continue
             key = (_gettype(c.atom1), _gettype(c.atom2), _gettype(c.atom3),
                     _gettype(c.atom4), _gettype(c.atom5))
+            key = (key[0],key[1],key[2],key[3],key[1],key[2],key[3],key[4])
             if key in params.cmap_types:
                 c.type = params.cmap_types[key]
                 c.type.used = True
@@ -1469,7 +1470,7 @@ class GromacsTopologyFile(Structure):
                         used_keys.add(tuple(reversed(key)))
                         parfile.write('%-6s %-6s %-6s %-6s %-6s   1   '
                                       '%4d %4d' % (key[0], key[1], key[2],
-                                      key[3], key[4], param.resolution,
+                                      key[3], key[7], param.resolution,
                                       param.resolution))
                         res2 = param.resolution * param.resolution
                         for i in range(0, res2, 10):

--- a/parmed/parameters.py
+++ b/parmed/parameters.py
@@ -59,7 +59,7 @@ class ParameterSet(object):
         Dictionary mapping the 4-element tuple of the names of the four atom
         types involved in the Ryckaert-Bellemans torsion to the RBTorsionType
         instances
-    cmap_types : dict((str,str,str,str,str):CmapType)
+    cmap_types : dict((str,str,str,str,str,str,str,str):CmapType)
         Dictionary mapping the 5-element tuple of the names of the five atom
         types involved in the correction map to the CmapType instances
     nbfix_types : dict((str,str):(float,float))
@@ -337,12 +337,14 @@ class ParameterSet(object):
         for cmap in struct.cmaps:
             if cmap.type is None: continue
             key = (cmap.atom1.type, cmap.atom2.type, cmap.atom3.type,
+                    cmap.atom4.type, cmap.atom2.type, cmap.atom3.type,
                     cmap.atom4.type, cmap.atom5.type)
             if key in params.cmap_types:
                 if (not allow_unequal_duplicates and
                         cmap.type != params.cmap_types[key]):
                     raise ParameterError('Unequal CMAP types defined between '
-                            '%s, %s, %s, %s, and %s' % key)
+                            '%s, %s, %s, %s, and %s' % (key[0], key[1], key[2],
+                                key[3], key[7]))
                 continue
             typ = copy(cmap.type)
             params.cmap_types[key] = typ

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -546,6 +546,9 @@ class TestCharmmParameters(utils.FileIOTestCase):
         self.assertEqual(uniques(params.dihedral_types), 81)
         self.assertEqual(uniques(params.improper_types), 20)
         self.assertEqual(uniques(params.urey_bradley_types), 42)
+        # Make sure all cmaps have 8 atom type keys
+        for key in params.cmap_types:
+            self.assertEqual(len(key), 8)
 
     def testParamFileOnly(self):
         """ Test reading only a parameter file with no RTF (CHARMM36) """
@@ -580,6 +583,8 @@ class TestCharmmParameters(utils.FileIOTestCase):
         self.assertEqual(uniques(p.improper_types), 15)
         self.assertEqual(uniques(p.nbfix_types), 6)
         self.assertEqual(uniques(p.urey_bradley_types), 45)
+        for key in p.cmap_types:
+            self.assertEqual(len(key), 8)
 
     def testWriteParams(self):
         """ Tests writing CHARMM RTF/PAR/STR files from parameter sets """
@@ -735,13 +740,6 @@ class TestCharmmParameters(utils.FileIOTestCase):
                 os.path.join(pmd.gromacs.GROMACS_TOPDIR,
                              'charmm27.ff', 'forcefield.itp')
         )
-        # Make sure it can handle 8-key CMAPs
-        types = OrderedDict()
-        for key, typ in iteritems(gmx.parameterset.cmap_types):
-            assert len(key) == 5, 'Unexpected cmap key length'
-            types[(key[0], key[1], key[2], key[3],
-                   key[1], key[2], key[3], key[4])] = typ
-        gmx.parameterset.cmap_types = types
         gmx.parameterset.nbfix_types[('X', 'Y')] = (2.0, 3.0)
         from_gmx2 = parameters.CharmmParameterSet.from_parameterset(gmx.parameterset)
         for (key1, typ1), (key2, typ2) in zip(iteritems(from_gmx.cmap_types),
@@ -836,6 +834,7 @@ class TestCharmmParameters(utils.FileIOTestCase):
         else:
             self.assertEqual(d1, d2)
         for key, item2 in iteritems(set2.cmap_types):
+            self.assertEqual(len(key), 8)
             self.assertEqual(set1.cmap_types[typenames(key)], item2)
         # Atom types
         a1, a2 = get_typeset(set1.atom_types, set2.atom_types)


### PR DESCRIPTION
This was not always the case, and could cause problems.  Now ParmEd is fully consistent everywhere with respect to storing CMAP types in `ParameterSet` dictionaries.

This also means that the recent fix in #505 will now always be correct.