### PR TITLE
Revert to using AMBER atom types in generating OpenMM ffxml atom types

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -166,14 +166,12 @@ class OpenMMParameterSet(ParameterSet):
 
     def _write_omm_atom_types(self, dest):
         dest.write(' <AtomTypes>\n')
-        for name, residue in iteritems(self.residues):
-            if not isinstance(residue, ResidueTemplate):
-                continue
-            for atom in residue.atoms:
-                element = Element[atom.atom_type.atomic_number]
-                dest.write('  <Type name="%s-%s" class="%s" element="%s" '
-                           'mass="%f"/>\n' % (name, atom.name, atom.type,
-                           element, atom.atom_type.mass))
+        for name, atom_type in iteritems(self.atom_types):
+            assert atom_type.atomic_number >= 0, 'Atomic number not set!'
+            element = Element[atom_type.atomic_number]
+            dest.write('  <Type name="%s" element="%s" mass="%f"/>\n'
+                       % (name, element, atom_type.mass or Mass[element])
+                       )
         dest.write(' </AtomTypes>\n')
 
     def _write_omm_residues(self, dest):
@@ -183,8 +181,8 @@ class OpenMMParameterSet(ParameterSet):
                 continue
             dest.write('  <Residue name="%s">\n' % residue.name)
             for atom in residue.atoms:
-                dest.write('   <Atom name="%s" type="%s-%s" charge="%f"/>\n' %
-                           (atom.name, name, atom.name, atom.charge))
+                dest.write('   <Atom name="%s" type="%s" charge="%f"/>\n' %
+                           (atom.name, atom.type, atom.charge))
             for bond in residue.bonds:
                 dest.write('   <Bond atomName1="%s" atomName2="%s" />\n' %
                            (bond.atom1.name, bond.atom2.name))
@@ -207,7 +205,7 @@ class OpenMMParameterSet(ParameterSet):
             if (a1, a2) in bonds_done: continue
             bonds_done.add((a1, a2))
             bonds_done.add((a2, a1))
-            dest.write('  <Bond class1="%s" class2="%s", length="%f", k="%f"/>\n'
+            dest.write('  <Bond type1="%s" type2="%s", length="%f", k="%f"/>\n'
                        % (a1, a2, bond.req*lconv, bond.k*kconv))
         dest.write(' </HarmonicBondForce>\n')
 
@@ -221,7 +219,7 @@ class OpenMMParameterSet(ParameterSet):
             if (a1, a2, a3) in angles_done: continue
             angles_done.add((a1, a2, a3))
             angles_done.add((a3, a2, a1))
-            dest.write('  <Angle class1="%s" class2="%s" class3="%s" '
+            dest.write('  <Angle type1="%s" type2="%s" type3="%s" '
                        'angle="%s" k="%s"/>\n' %
                        (a1, a2, a3, angle.theteq*tconv, angle.k*kconv))
         dest.write(' </HarmonicAngleForce>\n')
@@ -241,8 +239,8 @@ class OpenMMParameterSet(ParameterSet):
             if (a1, a2, a3, a4) in diheds_done: continue
             diheds_done.add((a1, a2, a3, a4))
             diheds_done.add((a4, a3, a2, a1))
-            dest.write('  <Proper class1="%s" class2="%s" class3="%s" '
-                       'class4="%s"' % (nowild(a1), a2, a3, nowild(a4)))
+            dest.write('  <Proper type1="%s" type2="%s" type3="%s" '
+                       'type4="%s"' % (nowild(a1), a2, a3, nowild(a4)))
             for i, term in enumerate(dihed):
                 i += 1
                 dest.write(' periodicity%d="%d" phase%d="%f" k%d="%f"' %
@@ -264,8 +262,8 @@ class OpenMMParameterSet(ParameterSet):
             if a2 != 'X' and a3 == 'X':
                 # Single wild-card entries put the wild-card in position 2
                 a2, a3 = a3, a2
-            dest.write('  <Improper class1="%s" class2="%s" class3="%s" '
-                       'class4="%s" periodicity1="%d" phase1="%f" k1="%f"/>\n' %
+            dest.write('  <Improper type1="%s" type2="%s" type3="%s" '
+                       'type4="%s" periodicity1="%d" phase1="%f" k1="%f"/>\n' %
                        (a1, nowild(a2), nowild(a3), nowild(a4), improp.per,
                         improp.phase*pconv, improp.phi_k*kconv)
             )
@@ -281,8 +279,8 @@ class OpenMMParameterSet(ParameterSet):
         def nowild(name):
             return name if name != 'X' else ''
         for (a1, a2, a3, a4), improp in iteritems(self.improper_types):
-            dest.write('  <Improper class1="%s" class2="%s" class3="%s" '
-                       'class4="%s" k="%f" theta0="%f"/>\n' %
+            dest.write('  <Improper type1="%s" type2="%s" type3="%s" '
+                       'type4="%s" k="%f" theta0="%f"/>\n' %
                        (nowild(a1), nowild(a2), nowild(a3), nowild(a4),
                        improp.psi_k*kconv, improp.psi_eq*tconv)
             )
@@ -312,8 +310,8 @@ class OpenMMParameterSet(ParameterSet):
             if (a1, a2, a3, a4, a5) in used_torsions: continue
             used_torsions.add((a1, a2, a3, a4, a5))
             used_torsions.add((a5, a4, a3, a2, a1))
-            dest.write('   <Torsion map="%d" class1="%s" class=2"%s" '
-                       'class3="%s" class4="%s" class5="%s"/>\n' %
+            dest.write('   <Torsion map="%d" type1="%s" type=2"%s" '
+                       'type3="%s" type4="%s" type5="%s"/>\n' %
                        (maps[id(cmap)], a1, a2, a3, a4, a5)
             )
         dest.write(' </CmapTorsionForce>\n')

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -324,7 +324,7 @@ class OpenMMParameterSet(ParameterSet):
                 raise NotImplementedError("Nonbonded forces with geometric combining rules have not been implemented yet.")
 
         if len(self.nbfix_types) > 0:
-            raise NotImplementedError("Nonbonded forces with geometric combining rules have not been implemented yet.")
+            raise NotImplementedError("Nonbonded forces with NBFIX have not been implemented yet.")
 
         # Compute conversion factors for writing in natrual OpenMM units.
         length_conv = u.angstrom.conversion_factor_to(u.nanometer)
@@ -336,6 +336,7 @@ class OpenMMParameterSet(ParameterSet):
 
         # Write NonbondedForce records.
         dest.write(' <NonbondedForce coulomb14scale="%f" lj14scale="%f">\n' % (coulomb14scale, lj14scale))
+        dest.write('  <UseAttributeFromResidue name="charge">\n')
         for name, atom_type in iteritems(self.atom_types):
             if (atom_type.rmin != None) and (atom_type.epsilon != None):
                 sigma = (2.0**(-1./6.) * atom_type.rmin) * length_conv # in md_unit_system

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -344,6 +344,14 @@ class OpenMMParameterSet(ParameterSet):
                 # Dummy atom
                 sigma = 1.0
                 epsilon = 0.0
+
+            # Ensure we don't have sigma = 0
+            if (sigma == 0.0):
+                if (epsilon == 0.0):
+                    sigma = 1.0 # reset sigma = 1
+                else:
+                    raise Exception("For atom type '%s', sigma = 0 but epsilon != 0." % name)
+
             dest.write('  <Atom type="%s" sigma="%f" epsilon="%f"/>\n' % (name, sigma, epsilon))
         dest.write(' </NonbondedForce>\n')
 

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -287,6 +287,25 @@ CHIS = CHIE
                      Reference='Maier & Simmerling')
         )
 
+
+    @unittest.skipIf(os.getenv('AMBERHOME') is None, 'Cannot test w/out Amber')
+    def testWriteXMLParametersGAFF(self):
+        """ Test writing XML parameters loaded from Amber GAFF parameter files """
+        leaprc = StringIO("""\
+parm10 = loadamberparams gaff.dat
+""")
+        params = openmm.OpenMMParameterSet.from_parameterset(
+                amber.AmberParameterSet.from_leaprc(leaprc)
+        )
+        citations = """\
+Wang, J., Wang, W., Kollman P. A.; Case, D. A. "Automatic atom type and bond type perception in molecular mechanical calculations". Journal of Molecular Graphics and Modelling , 25, 2006, 247260.
+Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development and testing of a general AMBER force field". Journal of Computational Chemistry, 25, 2004, 1157-1174.
+"""
+        params.write(get_fn('gaff.xml', written=True),
+                     provenance=dict(OriginalFile='gaff.dat',
+                     Reference=citations)
+        )
+
     def testWriteXMLParametersCharmm(self):
         """ Test writing XML parameter files from Charmm parameter files"""
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -65,7 +65,6 @@ class FileIOTestCase(unittest.TestCase):
             pass
 
     def tearDown(self):
-        return # DEBUG
         self._empty_writes()
         try:
             os.rmdir(get_fn('writes'))

--- a/test/utils.py
+++ b/test/utils.py
@@ -65,6 +65,7 @@ class FileIOTestCase(unittest.TestCase):
             pass
 
     def tearDown(self):
+        return # DEBUG
         self._empty_writes()
         try:
             os.rmdir(get_fn('writes'))


### PR DESCRIPTION
Following the discussion in https://github.com/pandegroup/openmm/issues/1298, there is no way for us to break `ffxml` files into separate files for parameters, amino acids, and nucleic acids (and possibly other components) if atom types are based on `resname-atomname` due to the requirement that parameters can only refer to atomtypes that have been defined in the files that have already been read.  Even if the atom classes were set to be AMBER atom types, atom classes are simply expanded into the set of matching atom types that have been defined at the time the parameters are read, so this would not work without major changes to `ForceField`.

See [the OpenMM User Guide](http://docs.openmm.org/6.3.0/userguide/application.html#using-multiple-files), which states:
> If multiple XML files are specified when a ForceField is created, their definitions are combined as follows.
> A file may refer to atom types and classes that it defines, as well as those defined in previous files. It may not refer to ones defined in later files. This means that the order in which files are listed when calling the ForceField constructor is potentially significant.

Instead, if we define OpenMM atom types to be identical to AMBER atom types, we can define atom types and parameters in one file and leave residue definitions (amino acids, nucleic acids) for separate files.  This will also allow us to generate a `gaff.xml` that include GAFF atom types and parameters that can be used with the [residue template generator registration scheme](https://github.com/pandegroup/openmm/pull/1312) for incorporating Antechamber- or other parameterization schemes (which I can implement very soon after this).