### PR TITLE
Fix GB support for newer versions of OpenMM

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -2685,8 +2685,12 @@ class Structure(object):
             The dielectric constant of the water used in GB
         """
         from simtk.openmm.app.internal.customgbforces import (GBSAHCTForce,
-                GBSAOBC1Force, GBSAOBC2Force, GBSAGBnForce, GBSAGBn2Force,
-                convertParameters)
+                GBSAOBC1Force, GBSAOBC2Force, GBSAGBnForce, GBSAGBn2Force)
+        try:
+            from simtk.openmm.app.internal.customgbforces import convertParameters
+        except ImportError:
+            # Unnecessary in newer versions of OpenMM
+            convertParameters = lambda params, choice: params
         if implicitSolvent is None: return None
         if useSASA:
             sasa = 'ACE'


### PR DESCRIPTION
Support OpenMM versions that require GB parameter conversions and that don't
(because they now do it inside the CustomGBForce subclasses directly).