### PR TITLE
Add tests to improve coverage of topologyobjects

### DIFF
--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -324,7 +324,7 @@ class ChamberParm(AmberParm):
 
     @property
     def has_cmap(self):
-        return len(self.cmaps) > 0
+        return len(self.cmaps) > 0 or 'CHARMM_CMAP_COUNT' in self.parm_data
 
     #===========  PRIVATE INSTANCE METHODS  ============
 

--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -324,7 +324,7 @@ class ChamberParm(AmberParm):
 
     @property
     def has_cmap(self):
-        return len(self.cmaps) > 0 or 'CHARMM_CMAP_COUNT' in self.parm_data
+        return len(self.cmaps) > 0
 
     #===========  PRIVATE INSTANCE METHODS  ============
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -917,7 +917,7 @@ class Structure(object):
             return selection
         sumsel = sum(selection)
         if sumsel == 0:
-            # No atoms selected. Return None
+            # No atoms selected. Return empty type
             return type(self)()
         # The cumulative sum of selection will give our index + 1 of each
         # selected atom into the new structure

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3539,17 +3539,19 @@ class deleteBond(Action):
         self.verbose = arg_list.has_key('verbose')
         # Go through each atom in mask1 and see if it forms a bond with any atom
         # in mask2.
-        self.del_bonds = set()
-        self.del_angles = set()
-        self.del_dihedrals = set()
-        self.del_urey_bradleys = set()
-        self.del_impropers = set()
-        self.del_cmaps = set()
-        self.del_trigonal_angles = set()
-        self.del_oopbends = set()
-        self.del_pi_torsions = set()
-        self.del_strbnds = set()
-        self.del_tortors = set()
+        bonds_to_delete = set()
+        self.del_bonds = []
+        self.del_angles = []
+        self.del_dihedrals = []
+        self.del_rbtorsions = []
+        self.del_urey_bradleys = []
+        self.del_impropers = []
+        self.del_cmaps = []
+        self.del_trigonal_angles = []
+        self.del_oopbends = []
+        self.del_pi_torsions = []
+        self.del_strbnds = []
+        self.del_tortors = []
         for i in self.mask1.Selected():
             ai = self.parm.atoms[i]
             for j in self.mask2.Selected():
@@ -3558,42 +3560,48 @@ class deleteBond(Action):
                 if ai is aj: continue
                 for bond in ai.bonds:
                     if aj not in bond: continue
-                    self.del_bonds.add(bond)
+                    bonds_to_delete.add(bond)
         # Find other valence terms we need to delete
-        for bond in self.del_bonds:
-            for angle in self.parm.angles:
+        for i, bond in enumerate(self.parm.bonds):
+            if bond in bonds_to_delete:
+                self.del_bonds.append(i)
+        for bond in bonds_to_delete:
+            for i, angle in enumerate(self.parm.angles):
                 if bond in angle:
-                    self.del_angles.add(angle)
-            for dihed in self.parm.dihedrals:
+                    self.del_angles.append(i)
+            for i, dihed in enumerate(self.parm.dihedrals):
                 if bond in dihed:
-                    self.del_dihedrals.add(dihed)
-            for urey in self.parm.urey_bradleys:
+                    self.del_dihedrals.append(i)
+            for i, dihed in enumerate(self.parm.rb_torsions):
+                if bond in dihed:
+                    self.del_rbtorsions.append(i)
+            for i, urey in enumerate(self.parm.urey_bradleys):
                 if bond in urey:
-                    self.del_urey_bradleys.add(urey)
-            for improper in self.parm.impropers:
+                    self.del_urey_bradleys.append(i)
+            for i, improper in enumerate(self.parm.impropers):
                 if bond in improper:
-                    self.del_impropers.add(improper)
-            for cmap in self.parm.cmaps:
+                    self.del_impropers.append(i)
+            for i, cmap in enumerate(self.parm.cmaps):
                 if bond in cmap:
-                    self.del_cmaps.add(cmap)
-            for trigonal_angle in self.parm.trigonal_angles:
+                    self.del_cmaps.append(i)
+            for i, trigonal_angle in enumerate(self.parm.trigonal_angles):
                 if bond in trigonal_angle:
-                    self.del_trigonal_angles.add(trigonal_angle)
-            for oopbend in self.parm.out_of_plane_bends:
+                    self.del_trigonal_angles.append(i)
+            for i, oopbend in enumerate(self.parm.out_of_plane_bends):
                 if bond in oopbend:
-                    self.del_oopbends.add(oopbend)
-            for pitor in self.parm.pi_torsions:
+                    self.del_oopbends.append(i)
+            for i, pitor in enumerate(self.parm.pi_torsions):
                 if bond in pitor:
-                    self.del_pi_torsions.add(pitor)
-            for strbnd in self.parm.stretch_bends:
+                    self.del_pi_torsions.append(i)
+            for i, strbnd in enumerate(self.parm.stretch_bends):
                 if bond in strbnd:
-                    self.del_strbnds.add(strbnd)
-            for tortor in self.parm.torsion_torsions:
+                    self.del_strbnds.append(i)
+            for i, tortor in enumerate(self.parm.torsion_torsions):
                 if bond in tortor:
-                    self.del_tortors.add(tortor)
+                    self.del_tortors.append(i)
 
     def __str__(self):
-        if not self.del_h_bonds and not self.del_noh_bonds:
+        if not self.del_bonds:
             return 'No bonds to delete'
         if not self.verbose:
             return 'Deleting the %d bonds found between %s and %s' % (
@@ -3607,13 +3615,14 @@ class deleteBond(Action):
                     a1.residue.name, a1.residue.idx+1, a1.name, a2.idx+1,
                     a2.residue.name, a2.residue.idx+1, a2.name)
         retstr += 'Deleting %d angles, ' % (len(self.del_angles))
-        if self.parm.chamber:
+        if self.parm.urey_bradleys or self.parm.impropers or self.parm.cmaps:
             retstr += ('%d Urey-Bradleys, %d impropers,\n         %d dihedrals '
                         'and %d CMAPs' % (
                         len(self.del_urey_bradleys), len(self.del_impropers),
                         len(self.del_dihedrals), len(self.del_cmap))
             )
-        elif self.parm.amoeba:
+        elif self.parm.trigonal_angles or self.parm.out_of_plane_bends or \
+                self.parm.stretch_bends or self.parm.torsion_torsions:
             retstr += ('%d Urey-Bradleys, %d trigonal angles,\n         '
                        '%d dihedrals, %d out-of-plane bends, %d stretch-bends\n'
                        '         and %d torsion-torsions' % (
@@ -3622,24 +3631,46 @@ class deleteBond(Action):
                         len(self.del_dihedrals), len(self.del_oopbends),
                         len(self.del_strbnds), len(self.del_tortors))
             )
+        elif self.parm.rb_torsions:
+            retstr += ('%d R-B torsions and %d dihedrals' %
+                    (len(self.del_rbtorsions), len(self.del_dihedrals)))
         else:
             retstr += 'and %d dihedrals' % (len(self.del_dihedrals))
         return retstr
 
     def execute(self):
         if not self.del_bonds: return
-        for bond in self.del_bonds: bond.delete()
-        for angle in self.del_angles: angle.delete()
-        for dihedral in self.del_dihedrals: dihedral.delete()
-        for urey in self.del_urey_bradleys: urey.delete()
-        for imp in self.del_impropers: imp.delete()
-        for cmap in self.del_cmaps: cmap.delete()
-        for trigang in self.del_trigonal_angles: trigang.delete()
-        for oopbend in self.del_oopbends: oopbend.delete()
-        for tortor in self.del_tortors: tortor.delete()
-        for strbnd in self.del_strbnds: strbnd.delete()
-        if isinstance(self.parm, AmberParm):
-            self.parm.remake_parm()
+        for i in reversed(self.del_bonds):
+            self.parm.bonds[i].delete()
+            del self.parm.bonds[i]
+        for i in reversed(self.del_angles):
+            self.parm.angles[i].delete()
+            del self.parm.angles[i]
+        for i in reversed(self.del_dihedrals):
+            self.parm.dihedrals[i].delete()
+            del self.parm.dihedrals[i]
+        for i in reversed(self.del_rbtorsions):
+            self.parm.rb_torsions[i].delete()
+            del self.parm.rb_torsions[i]
+        for i in reversed(self.del_urey_bradleys):
+            self.parm.urey_bradleys[i].delete()
+            del self.parm.urey_bradleys[i]
+        for i in reversed(self.del_impropers):
+            self.parm.impropers[i].delete()
+            del self.parm.impropers[i]
+        for i in reversed(self.del_cmaps):
+            self.parm.cmaps[i].delete()
+            del self.parm.cmaps[i]
+        for i in reversed(self.del_trigonal_angles):
+            del self.parm.trigonal_angles[i]
+        for i in reversed(self.del_oopbends):
+            del self.parm.out_of_plane_bends[i]
+        for i in reversed(self.del_tortors):
+            self.parm.torsion_torsions[i].delete()
+            del self.parm.torsion_torsions[i]
+        for i in reversed(self.del_strbnds):
+            del self.parm.stretch_bends[i]
+        self.parm.prune_empty_terms()
 
 #+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3670,7 +3670,10 @@ class deleteBond(Action):
             del self.parm.torsion_torsions[i]
         for i in reversed(self.del_strbnds):
             del self.parm.stretch_bends[i]
-        self.parm.prune_empty_terms()
+        try:
+            self.parm.remake_parm()
+        except AttributeError:
+            self.parm.prune_empty_terms()
 
 #+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -640,11 +640,7 @@ class Atom(_ListItem):
     @property
     def sigma(self):
         """ Lennard-Jones sigma parameter -- directly related to Rmin """
-        if self._rmin is None:
-            if self.atom_type is not None:
-                return self.atom_type.sigma
-            return None
-        return self._rmin * 2**(-1/6) * 2
+        return self.rmin * 2**(-1/6) * 2
 
     @sigma.setter
     def sigma(self, value):

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -1057,8 +1057,8 @@ class ExtraPoint(Atom):
                     mybond = bond
                 else:
                     otherbond = bond
-            if mybond is None or otherbond is None:
-                raise RuntimeError('Strange bond pattern detected')
+            assert mybond is not None and otherbond is not None, \
+                    'Strange bond pattern detected'
             bonddist = otherbond.type.req
             if otherbond.atom1 is self.parent:
                 otheratom = otherbond.atom2
@@ -1087,8 +1087,8 @@ class ExtraPoint(Atom):
                     else:
                         other_atom = bond.atom1
                     break
-            if other_atom is None:
-                raise RuntimeError('Strange bond pattern detected')
+            assert other_atom is not None, \
+                    'Strange bond pattern detected'
             try:
                 x1, y1, z1 = other_atom.xx, other_atom.xy, other_atom.xz
                 x2, y2, z2 = self.parent.xx, self.parent.xy, self.parent.xz
@@ -1264,7 +1264,7 @@ class ThreeParticleExtraPointFrame(object):
         try:
             b1, b2 = [bond for bond in self.ep.parent.bonds
                                 if self.ep not in bond]
-        except TypeError:
+        except (ValueError, TypeError):
             raise RuntimeError('Unsupported bonding pattern in EP frame')
         if b1.atom1 is self.ep.parent:
             oatom1 = b1.atom2
@@ -1362,7 +1362,7 @@ class ThreeParticleExtraPointFrame(object):
                 theteq = math.acos((dp1*dp1+dp2*dp2-d12*d12)/(2*dp1*dp2))
             else:
                 for angle in a1.angles:
-                    if a2 in angle and a2 is not angle.atom2:
+                    if a2 in angle and a2 is not angle.atom2: #TODO test angle.type is None
                         theteq = angle.type.theteq * DEG_TO_RAD
                         break
                 else:

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -520,33 +520,6 @@ class Atom(_ListItem):
 
     #===================================================
 
-    # To alert people to changes in the API
-    @property
-    def starting_index(self):
-        warnings.warn('starting_index has been replaced by idx',
-                      DeprecationWarning)
-        return self.idx
-
-    @property
-    def atname(self):
-        warnings.warn('atname has been replaced by name', DeprecationWarning)
-        return self.name
-    @atname.setter
-    def atname(self, thing):
-        warnings.warn('atname has been replaced by name', DeprecationWarning)
-        self.name = thing
-
-    @property
-    def attype(self):
-        warnings.warn('attype has been replaced by type', DeprecationWarning)
-        return self.type
-    @attype.setter
-    def attype(self, thing):
-        warnings.warn('attype has been replaced by type', DeprecationWarning)
-        self.type = thing
-
-    #===================================================
-
     @property
     def bond_partners(self):
         """ Go through all bonded partners """
@@ -2453,11 +2426,6 @@ class UreyBradley(object):
         # Load the force constant and equilibrium distance
         self.type = type
 
-#   @property
-#   def ub_type(self):
-#       warnings.warn("ub_type has been replaced by type", DeprecationWarning)
-#       return self.type
-
     def __contains__(self, thing):
         " Quick and easy way to see if an Atom or Bond is in this Urey-Bradley "
         if isinstance(thing, Atom):
@@ -2557,12 +2525,6 @@ class Improper(_FourAtomTerm):
         # Load the force constant and equilibrium angle
         self.type = type
         self.funct = 2
-
-#   @property
-#   def improp_type(self):
-#       warnings.warn('improp_type has been replaced by type',
-#                     DeprecationWarning)
-#       return self.type
 
     def __contains__(self, thing):
         """
@@ -3099,12 +3061,6 @@ class TrigonalAngle(_FourAtomTerm):
         _FourAtomTerm.__init__(self, atom1, atom2, atom3, atom4)
         self.type = type
 
-    @property
-    def trigang_type(self):
-        warnings.warn('trigang_type has been replaced with type',
-                      DeprecationWarning)
-        return type
-
     def __contains__(self, thing):
         if isinstance(thing, Atom):
             return _FourAtomTerm.__contains(self, thing)
@@ -3143,12 +3099,6 @@ class OutOfPlaneBend(_FourAtomTerm):
     def __init__(self, atom1, atom2, atom3, atom4, type=None):
         _FourAtomTerm.__init__(self, atom1, atom2, atom3, atom4)
         self.type = type
-
-    @property
-    def oopbend_type(self):
-        warnings.warn('oopbend_type has been replaced with type',
-                      DeprecationWarning)
-        return self.type
 
     def __contains__(self, thing):
         if isinstance(thing, Atom):
@@ -3272,12 +3222,6 @@ class PiTorsion(object):
         self.atom6 = atom6
         self.type = type
 
-    @property
-    def pitor_type(self):
-        warnings.warn("pitor_type has been replaced by type",
-                      DeprecationWarning)
-        return self.type
-
     def __contains__(self, thing):
         if isinstance(thing, Atom):
             return (thing is self.atom1 or thing is self.atom2 or
@@ -3327,12 +3271,6 @@ class StretchBend(object):
         self.atom2 = atom2
         self.atom3 = atom3
         self.type = type
-
-    @property
-    def strbnd_type(self):
-        warnings.warn("strbnd_type has been replaced by type",
-                      DeprecationWarning)
-        return self.type
 
     def __contains__(self, thing):
         if isinstance(thing, Atom):
@@ -3483,12 +3421,6 @@ class TorsionTorsion(Cmap):
         atom3.tortor_to(atom4)
         atom3.tortor_to(atom5)
         atom4.tortor_to(atom5)
-
-    @property
-    def tortor_type(self):
-        warnings.warn("tortor_type has been replaced by type",
-                      DeprecationWarning)
-        return self.type
 
     def delete(self):
         """

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -14,7 +14,6 @@ from parmed.utils.six import string_types, iteritems
 from parmed.utils.six.moves import zip, range
 from copy import copy
 import math
-import warnings
 
 __all__ = ['Angle', 'AngleType', 'Atom', 'AtomList', 'Bond', 'BondType',
            'ChiralFrame', 'Cmap', 'CmapType', 'Dihedral', 'DihedralType',

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -1492,7 +1492,7 @@ class OutOfPlaneExtraPointFrame(object):
                                 if (not isinstance(bond.atom1, ExtraPoint) and
                                     not isinstance(bond.atom2, ExtraPoint))
             ]
-        except TypeError:
+        except (ValueError, TypeError):
             raise RuntimeError('Unsupported bonding pattern in EP frame')
         if b1.atom1 is self.ep.parent:
             oatom1 = b1.atom2
@@ -3006,7 +3006,7 @@ class _CmapGrid(object):
                     return False
             return True
         except AttributeError:
-            return TypeError('Bad type comparison with _CmapGrid')
+            return NotImplemented
 
     def switch_range(self):
         """
@@ -3063,7 +3063,7 @@ class TrigonalAngle(_FourAtomTerm):
 
     def __contains__(self, thing):
         if isinstance(thing, Atom):
-            return _FourAtomTerm.__contains(self, thing)
+            return _FourAtomTerm.__contains__(self, thing)
         return ((self.atom1 in thing and self.atom2 in thing) or
                 (self.atom2 in thing and self.atom3 in thing) or
                 (self.atom2 in thing and self.atom4 in thing))
@@ -3102,7 +3102,7 @@ class OutOfPlaneBend(_FourAtomTerm):
 
     def __contains__(self, thing):
         if isinstance(thing, Atom):
-            return _FourAtomTerm.__contains(self, thing)
+            return _FourAtomTerm.__contains__(self, thing)
         return ((self.atom1 in thing and self.atom2 in thing) or
                 (self.atom2 in thing and self.atom3 in thing) or
                 (self.atom2 in thing and self.atom4 in thing))
@@ -3234,11 +3234,6 @@ class PiTorsion(object):
                 (self.atom4 in thing and self.atom5 in thing) or
                 (self.atom4 in thing and self.atom6 in thing))
 
-    def delete(self):
-        """ Sets all atoms to None and deletes the type """
-        self.type = self.atom1 = self.atom2 = self.atom3 = None
-        self.atom4 = self.atom5 = self.atom6 = None
-
     def __repr__(self):
         return '<%s; (%r,%r)--%r--%r--(%r,%r); type=%r>' % (type(self).__name__,
                 self.atom1, self.atom2, self.atom3, self.atom4, self.atom5,
@@ -3279,12 +3274,8 @@ class StretchBend(object):
         return ((self.atom1 in thing and self.atom2 in thing) or
                 (self.atom2 in thing and self.atom3 in thing))
 
-    def delete(self):
-        """ Sets all of the atoms and parameter type to None """
-        self.atom1 = self.atom2 = self.atom3 = self.type = None
-
     def __repr__(self):
-        return '<%s %r--%r--%r; type=%r>' % (type(self).__name__,
+        return '<%s; %r--%r--%r; type=%r>' % (type(self).__name__,
                 self.atom1, self.atom2, self.atom3, self.type)
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -4700,9 +4700,6 @@ class Group(object):
         self.type = type
         self.move = move
 
-#   def __copy__(self): TODO delete
-#       return type(self)(self.atom, self.type, self.move)
-
     def __eq__(self, other):
         return (self.atom is other.atom and self.type == other.type and
                 self.move == other.move)
@@ -4710,9 +4707,3 @@ class Group(object):
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 NoUreyBradley = BondType(0.0, 0.0) # singleton representing lack of a U-B term
-
-#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-#if __name__ == '__main__':
-#    import doctest
-#    doctest.testmod()

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -228,6 +228,11 @@ class TestCharmmPsf(utils.FileIOTestCase):
         for cmap in cpsf.cmaps:
             self.assertEqual(sum([int(a in cmap) for a in atoms]), 5)
             self.assertEqual(sum([int(b in cmap) for b in bonds]), 4)
+        # Test CHARMM groups
+        g = to.Group(cpsf.groups[0].atom, cpsf.groups[0].type, cpsf.groups[0].move)
+        self.assertEqual(g, cpsf.groups[0])
+        g.type = 0
+        self.assertNotEqual(g, cpsf.groups[0])
 
     def testXplorPsf(self):
         """ Test Xplor-format CHARMM PSF file parsing """

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -274,12 +274,6 @@ class TestTopologyObjects(unittest.TestCase):
         self.assertEqual(a1.atomic_number, 7)
         self.assertEqual(a1.element, 7)
 
-        self.assertWarns(DeprecationWarning, lambda: a1.starting_index)
-        self.assertWarns(DeprecationWarning, lambda: a1.atname)
-        self.assertWarns(DeprecationWarning, lambda: a1.attype)
-        self.assertWarns(DeprecationWarning, lambda: setattr(a1, 'atname', 'NA'))
-        self.assertWarns(DeprecationWarning, lambda: setattr(a1, 'attype', 'N1'))
-
     #=============================================
 
     def test_extra_point(self):

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -229,6 +229,20 @@ class TestTopologyObjects(unittest.TestCase):
             atom.list = atoms
             self.assertEqual(atom.idx, i)
 
+        # Test L-J handling
+        lja1 = Atom(atomic_number=6, name='C1', type='CT', charge=-0.1,
+                    mass=12.01, nb_idx=1, radii=1.8, tree='M')
+        self.assertIs(lja1.sigma, None)
+        lja1.atom_type = AtomType('CT', 1, 12.01, 6)
+        lja1.atom_type.set_lj_params(1.0, 2.0, 1.1, 2.1)
+#       lja2 = Atom(atomic_number=6, name='C2', type='CT', charge=0.1,
+#                   mass=12.01, nb_idx=1, radii=1.8, tree='M')
+#       lja3 = Atom(atomic_number=6, name='C3', type='CT', charge=0.0,
+#                   mass=12.01, nb_idx=1, radii=1.8, tree='M')
+#       lja4 = Atom(atomic_number=6, name='C4', type='CT', charge=-0.1,
+#                   mass=12.01, nb_idx=1, radii=1.8, tree='M')
+#       lja5 = Atom(atomic_number=6, name='C2', type='CT', charge=0.1,
+#                   mass=12.01, nb_idx=1, radii=1.8, tree='M')
         # Test deprecated API
         self.assertWarns(DeprecationWarning, lambda: a1.starting_index)
         self.assertWarns(DeprecationWarning, lambda: a1.atname)

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -12,6 +12,7 @@ import parmed.topologyobjects as topologyobjects
 from parmed.topologyobjects import _ListItem, _FourAtomTerm, _strip_units
 from parmed.topologyobjects import *
 import parmed.unit as u
+from parmed.utils.six import PY3
 from parmed.utils.six.moves import range, zip
 from copy import copy
 import unittest
@@ -1422,13 +1423,15 @@ class TestTopologyObjects(unittest.TestCase):
         # Check segid assignment
         self.assertEqual(res.segid, 'SYS')
         # Deprecated behavior
-        self.assertWarns(DeprecationWarning, lambda: res[0].segid)
+        warnings.filterwarnings('error', category=DeprecationWarning)
+        self.assertRaises(DeprecationWarning, lambda: res[0].segid)
         def tmp():
             res[0].segid = 'SYS1'
-        self.assertWarns(DeprecationWarning, tmp)
-        warnings.filterwarnings('always', category=DeprecationWarning)
+        self.assertRaises(DeprecationWarning, tmp)
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
         tmp()
         self.assertEqual(res.segid, 'SYS1')
+        warnings.filterwarnings('always', category=DeprecationWarning)
 
         # __repr__ testing
         self.assertEqual(repr(atoms[0]), '<Atom CA [0]; In ALA -1>')


### PR DESCRIPTION
Fixes a few very small bugs (`__contains` -> `__contains__` for two Amoeba topology objects), removes deprecated API features, and significantly improves test coverage, although not fully complete on this module yet.