### PR TITLE
Correct Gromacs func # for RB torsions

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -1997,7 +1997,7 @@ class Dihedral(_FourAtomTerm):
                     DihedralTypeList):
                 return 9
             elif self.type is not None and isinstance(self.type, RBTorsionType):
-                return 5
+                return 3
             return 1
         return self._funct
 


### PR DESCRIPTION
Let me know if there's something else fancy happening under the hood but `5` designates a fourier dihedral in Gromacs. These can be interconverted of course but that doesn't appear to be happening (yet!).