### PR TITLE
Adds a charge attribute to AtomType

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.1.4'
+__version__ = '2.1.5'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -693,12 +693,12 @@ class GromacsTopologyFile(Structure):
                     mass = float(words[massidx])
                     if mass > 0 and atnum == -1:
                         atnum = AtomicNum[element_by_mass(mass)]
-#                   chg = float(words[3])
+                    chg = float(words[massidx+1])
                     ptype = words[ptypeidx]
                     sig = float(words[sigidx]) * u.nanometers
                     eps = float(words[sigidx+1]) * u.kilojoules_per_mole
                     typ = AtomType(attype, None, mass, atnum,
-                                   bond_type=bond_type)
+                                   bond_type=bond_type, charge=chg)
                     typ.set_lj_params(eps, sig*2**(1/6)/2)
                     params.atom_types[attype] = typ
                 elif current_section == 'nonbond_params':

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -930,7 +930,7 @@ class Atom(_ListItem):
 
     def __getstate__(self):
         retval = dict(name=self.name, type=self.type, atom_type=self.atom_type,
-                      charge=self.charge, mass=self.mass, nb_idx=self.nb_idx,
+                      _charge=self._charge, mass=self.mass, nb_idx=self.nb_idx,
                       radii=self.radii, screen=self.screen, tree=self.tree,
                       join=self.join, irotat=self.irotat, bfactor=self.bfactor,
                       altloc=self.altloc, occupancy=self.occupancy,
@@ -4616,16 +4616,6 @@ class AtomType(object):
 
     def __str__(self):
         return self.name
-
-    # Comparisons are all based on number
-#   def __gt__(self, other):
-#       return self._member_number > other._member_number
-#   def __lt__(self, other):
-#       return self._member_number < other._member_number
-#   def __ge__(self, other):
-#       return self._member_number > other._member_number or self == other
-#   def __le__(self, other):
-#       return self._member_number < other._member_number or self == other
 
     def __copy__(self):
         cp = AtomType(self.name, self.number, self.mass, self.atomic_number,

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -4518,7 +4518,7 @@ class AtomType(object):
             # also equal
             has_all = True
             has_none = True
-            for attr in ('epsilon', 'rmin', 'epsilon_14', 'rmin_14', 'charge'):
+            for attr in ('epsilon', 'rmin', 'epsilon_14', 'rmin_14'):
                 if getattr(self, attr) is None and getattr(other, attr) is None:
                     has_all = False
                     continue
@@ -4529,6 +4529,12 @@ class AtomType(object):
             assert (has_all and not has_none) or (has_none and not has_all), \
                     'Should have all or none at this point'
             if not has_all:
+                return True
+            # Check charges
+            if self.charge is None or other.charge is None:
+                if self.charge is not other.charge:
+                    return False
+            elif abs(self.charge - other.charge) > TINY:
                 return True
             # At this point, we have all the attributes we need to compare
             return (abs(self.epsilon - other.epsilon) < TINY and

--- a/test/test_parmed_gromacs.py
+++ b/test/test_parmed_gromacs.py
@@ -232,6 +232,8 @@ class TestGromacsTop(FileIOTestCase):
         parm.write(get_fn('test.topol', written=True), combine='all')
         parm2 = load_file(get_fn('test.topol', written=True))
         self.assertEqual(len(parm.atoms), len(parm2.atoms))
+        # Check that the charge attribute is read correctly
+        self.assertEqual(parm.parameterset.atom_types['opls_001'].charge, 0.5)
 
     def test_without_parametrize(self):
         """ Tests loading a Gromacs topology without parametrizing """

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -316,6 +316,17 @@ class TestTopologyObjects(unittest.TestCase):
         self.assertEqual(a.epsilon, 0.5)
         self.assertEqual(a.epsilon_14, 0.25)
 
+        # Test behavior of charge so that it falls back to the charge on the
+        # atom type if it's not set on the atom
+        a = Atom(name='CA', type='CX', mass=12.01, atomic_number=6)
+        self.assertEqual(a.charge, 0)
+        at = AtomType('CX', 1, 12.01, 6, charge=0.5)
+        a.atom_type = at
+        self.assertEqual(a.charge, 0.5)
+        a.charge = 0.3
+        self.assertEqual(a.charge, 0.3)
+        self.assertEqual(at.charge, 0.5)
+
     #=============================================
 
     def test_atom_type(self):
@@ -341,6 +352,11 @@ class TestTopologyObjects(unittest.TestCase):
         at3.sigma_14 = 1.0
         self.assertEqual(at3.sigma_14, 1.0)
         self.assertEqual(at3.rmin_14, 2**(-5/6))
+        # Check charge
+        at5 = AtomType('CX', 2, 12.01, 6, charge=0.5)
+        self.assertEqual(at5.charge, 0.5)
+        at4.charge = 0.3
+        self.assertEqual(at4.charge, 0.3)
 
     #=============================================
 


### PR DESCRIPTION
The basic behavior here is that AtomType *can* have a charge, and if an `Atom` has an `atom_type` attribute, but never has a charge set, it will see the charge from its `atom_type`.  However, setting a charge on an `Atom` directly overrides its `atom_type`.

GROMACS parsers now assign the parsed charge to its atom type when reading `[ atom_types ]`.  This should address #544.

@ctk3b -- does this work for you?  What do you think of it?