### PR TITLE
Remove GmxTests from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 graft examples
 graft src
 graft test
-graft GmxTests


### PR DESCRIPTION
These are never used and should probably ultimately be removed from the repo altogether, but it does have some neat stuff from Lee-Ping that I occasionally still use.