### PR TITLE
Detect element when reading .mol2 files

### DIFF
--- a/parmed/formats/mol2.py
+++ b/parmed/formats/mol2.py
@@ -9,6 +9,7 @@ from parmed.exceptions import Mol2Error
 from parmed.formats.registry import FileFormatType
 from parmed.modeller.residue import ResidueTemplate, ResidueTemplateContainer
 from parmed.residue import AminoAcidResidue, RNAResidue, DNAResidue
+from parmed.periodic_table import element_by_name, AtomicNum
 from parmed.structure import Structure
 from parmed.topologyobjects import Atom, Bond
 from parmed.utils.io import genopen
@@ -149,6 +150,8 @@ class Mol2File(object):
                     words = line.split()
                     id = int(words[0])
                     name = words[1]
+                    elem = element_by_name(name)
+                    atomic_number = AtomicNum[elem]
                     x = float(words[2])
                     y = float(words[3])
                     z = float(words[4])
@@ -171,7 +174,8 @@ class Mol2File(object):
                     if last_residue is None:
                         last_residue = (resid, resname)
                         restemp.name = resname
-                    atom = Atom(name=name, type=typ, number=id, charge=charge)
+                    atom = Atom(name=name, atomic_number=atomic_number,type=typ,
+                                number=id, charge=charge)
                     atom.xx, atom.xy, atom.xz = x, y, z
                     struct.add_atom(atom, resname, resid)
                     if last_residue != (resid, resname):

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -133,6 +133,7 @@ class TestFileLoader(FileIOTestCase):
         for atom in mol2.atoms:
             self.assertEqual(atom.charge, 0)
             self.assertEqual(atom.residue.name, 'UNK')
+            self.assertNotEqual(atom.atomic_number, 0)
         # Check mol2 where last several columns do not exist in SUBSTRUCTURE
         mol2 = formats.load_file(get_fn('tripos4.mol2'), structure=True)
         self.assertIsInstance(mol2, Structure)


### PR DESCRIPTION
Same as what's done in the .gro reader. This is obviously not robust so let me know if this is a particular concern for this reader.