### PR TITLE
Add a bunch of tests to the openmm package.

### DIFF
--- a/parmed/openmm/utils.py
+++ b/parmed/openmm/utils.py
@@ -5,10 +5,6 @@ from parmed import unit as u
 from parmed.utils.decorators import needs_openmm
 from parmed.utils.six import iteritems
 from parmed.utils.six.moves import range, zip, map
-try:
-    from simtk import openmm as mm
-except ImportError:
-    mm = None
 
 def energy_decomposition(structure, context, nrg=u.kilocalories_per_mole):
     """
@@ -31,7 +27,7 @@ def energy_decomposition(structure, context, nrg=u.kilocalories_per_mole):
     dict {str:float}
         A dictionary mapping the name of the force group (taken from the
         attribute names of the format XXX_FORCE_GROUP in the structure object)
-        with the energy of that group in 
+        with the energy of that group in
     """
     all_names = dict()
     force_group_names = dict()
@@ -81,6 +77,7 @@ def energy_decomposition_system(structure, system, platform=None,
         Each entry is a tuple with the name of the force followed by its
         contribution
     """
+    import simtk.openmm as mm
     # First get all of the old force groups so we can restore them
     old_groups = [f.getForceGroup() for f in system.getForces()]
     old_recip_group = []

--- a/parmed/openmm/xmlfile.py
+++ b/parmed/openmm/xmlfile.py
@@ -5,6 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 from contextlib import closing
 import numpy as np
+from parmed.vec3 import Vec3
 from parmed.formats.registry import FileFormatType
 from parmed.geometry import box_vectors_to_lengths_and_angles
 import parmed.unit as u
@@ -165,4 +166,4 @@ class _OpenMMStateContents(object):
 
     @property
     def positions(self):
-        return [mm.Vec3(*xyz) for xyz in self.coordinates[0]]
+        return [Vec3(*xyz) for xyz in self.coordinates[0]]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+    kws = dict(entry_points={
+            'console_scripts' : ['parmed = parmed.scripts:clapp'],
+            'gui_scripts' : ['xparmed = parmed.scripts:guiapp']}
+    )
+except ImportError:
+    from distutils.core import setup, Extension
+    kws = {'scripts' : [os.path.join('scripts', 'parmed'),
+                        os.path.join('scripts', 'xparmed')]
+    }
+
 import os
 import sys
 
@@ -40,8 +51,6 @@ extensions = [Extension('parmed.amber._rdparm',
 
 if __name__ == '__main__':
 
-    from distutils.command.build_py import build_py
-    from distutils.command.build_scripts import build_scripts
     import shutil
     import parmed
 
@@ -101,18 +110,14 @@ if __name__ == '__main__':
         if os.path.exists(pmdc): delfile(pmdc)
         if os.path.exists(xpmdc): delfile(xpmdc)
 
-    scripts = [os.path.join('scripts', 'parmed'),
-               os.path.join('scripts', 'xparmed')]
-
     setup(name='ParmEd',
           version=parmed.__version__,
           description='Amber parameter file editor',
           author='Jason Swails',
           author_email='jason.swails -at- gmail.com',
           url='http://jswails.wikidot.com/parmed',
-          license='GPL v2 or later',
+          license='LGPL (or GPL if released with AmberTools)',
           packages=packages,
           ext_modules=extensions,
-          cmdclass={'build_py' : build_py},
-          scripts=scripts,
+          **kws
     )

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -11,7 +11,7 @@ omit =
     */parmed/unit/*
 [paths]
 source =
-    */site-packages/
+    /home/*/site-packages/ParmEd-*.egg/
 
 [report]
 exclude_lines =

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -2,24 +2,37 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from parmed import openmm, load_file, exceptions
 import os
+from parmed import openmm, load_file, exceptions, ExtraPoint, unit as u
 import unittest
-from utils import get_fn, mm, app, has_openmm
+from utils import get_fn, mm, app, has_openmm, FileIOTestCase
+import warnings
 
 @unittest.skipUnless(has_openmm, "Cannot test without OpenMM")
-class TestOpenMM(unittest.TestCase):
+class TestOpenMM(FileIOTestCase):
 
     def setUp(self):
         # Take one of the distributed OpenMM FF XML files as a test
         self.ffxml = os.path.join(os.path.split(app.__file__)[0], 'data',
                                   'amber99sbildn.xml')
+        warnings.filterwarnings('error', category=exceptions.OpenMMWarning)
+        super(TestOpenMM, self).setUp()
+
+    def tearDown(self):
+        warnings.filterwarnings('always', category=exceptions.OpenMMWarning)
+        super(TestOpenMM, self).tearDown()
+
     def test_format_id(self):
         """ Tests automatic format determination of OpenMM XML files """
         self.assertTrue(openmm.XmlFile.id_format(get_fn('system_974wat.xml')))
         self.assertTrue(openmm.XmlFile.id_format(get_fn('state_974wat.xml')))
         self.assertTrue(openmm.XmlFile.id_format(get_fn('integrator.xml')))
         self.assertTrue(openmm.XmlFile.id_format(self.ffxml))
+        fn = get_fn('test.xml', written=True)
+        with open(fn, 'w') as f:
+            f.write('<NoRecognizedObject>\n <SomeElement attr="yes" '
+                    '/>\n</NoRecognizedObject>\n')
+        self.assertFalse(openmm.XmlFile.id_format(fn))
 
     def test_deserialize_system(self):
         """ Tests automatic deserialization of a System XML file """
@@ -30,6 +43,15 @@ class TestOpenMM(unittest.TestCase):
     def test_deserialize_state(self):
         """ Tests automatic deserialization of a State XML file """
         state = openmm.XmlFile.parse(get_fn('state_974wat.xml'))
+        self.assertEqual(state.coordinates.shape, (1, 6638, 3))
+        self.assertEqual(state.velocities.shape, (1, 6638, 3))
+        self.assertEqual(state.forces.shape, (1, 6638, 3))
+        np.testing.assert_allclose(state.box, [35.05, 40.5, 42.37, 90, 90, 90])
+        self.assertAlmostEqual(state.time, 20000.000003615783)
+        self.assertIs(state.energy, None)
+        # Test with open file handle
+        with open(get_fn('state_974wat.xml'), 'r') as f:
+            state = openmm.XmlFile.parse(f)
         self.assertEqual(state.coordinates.shape, (1, 6638, 3))
         self.assertEqual(state.velocities.shape, (1, 6638, 3))
         self.assertEqual(state.forces.shape, (1, 6638, 3))
@@ -51,7 +73,6 @@ class TestOpenMM(unittest.TestCase):
     def test_load_topology(self):
         """ Tests loading an OpenMM Topology and System instance """
         import warnings
-        warnings.filterwarnings('error', category=exceptions.OpenMMWarning)
         ommparm = app.AmberPrmtopFile(get_fn('complex.prmtop'))
         parm = load_file(get_fn('complex.prmtop'))
         system = ommparm.createSystem(implicitSolvent=app.OBC1)
@@ -59,4 +80,63 @@ class TestOpenMM(unittest.TestCase):
         self.assertEqual(len(parm.atoms), len(structure.atoms))
         self.assertEqual(len(parm.residues), len(structure.residues))
         self.assertEqual(len(parm.bonds), len(structure.bonds))
-        warnings.filterwarnings('always', category=exceptions.OpenMMWarning)
+
+    def test_load_topology_extra_bonds(self):
+        """ Test loading extra bonds not in Topology """
+        parm = load_file(get_fn('ash.parm7'))
+        system = parm.createSystem()
+        for force in system.getForces():
+            if isinstance(force, mm.HarmonicBondForce):
+                force.addBond(0, parm[-1].idx, 1, 500)
+        self.assertRaises(exceptions.OpenMMWarning, lambda:
+                openmm.load_topology(parm.topology, system))
+        warnings.filterwarnings('ignore', category=exceptions.OpenMMWarning)
+        top = openmm.load_topology(parm.topology, system)
+        self.assertIn(top[-1], top[0].bond_partners)
+        self.assertEqual(len(top.bonds), len(parm.bonds)+1)
+
+    def test_load_topology_eps(self):
+        """ Tests loading an OpenMM Topology with Extra Points """
+        parm = load_file(get_fn('tip4p.parm7'), get_fn('tip4p.rst7'))
+        struct = openmm.load_topology(parm.topology, xyz=get_fn('tip4p.rst7'))
+        has_eps = False
+        self.assertEqual(len(parm.atoms), len(struct.atoms))
+        for a1, a2 in zip(parm.atoms, struct.atoms):
+            self.assertIs(type(a1), type(a2))
+            has_eps = isinstance(a1, ExtraPoint) or has_eps
+        self.assertTrue(has_eps)
+        np.testing.assert_equal(parm.coordinates, struct.coordinates)
+        np.testing.assert_equal(parm.box, struct.box)
+        # Now try passing in coordinates
+        struct = openmm.load_topology(parm.topology, xyz=parm.coordinates)
+        np.testing.assert_equal(parm.coordinates, struct.coordinates)
+        np.testing.assert_allclose(parm.box, struct.box) # taken from Topology
+        struct = openmm.load_topology(parm.topology, xyz=parm.coordinates)
+        np.testing.assert_equal(parm.coordinates, struct.coordinates)
+        struct = openmm.load_topology(parm.topology, xyz=parm.coordinates,
+                                      box=[10, 10, 10, 90, 90, 90])
+        np.testing.assert_equal(parm.coordinates, struct.coordinates)
+        np.testing.assert_equal(struct.box, [10, 10, 10, 90, 90, 90])
+
+    def test_load_topology_error(self):
+        """ Test error handling in load_topology """
+        parm = load_file(get_fn('ash.parm7'), get_fn('ash.rst7'))
+        parm2 = load_file(get_fn('solv2.parm7'), get_fn('solv2.rst7'))
+        self.assertRaises(TypeError, lambda:
+                openmm.load_topology(parm.topology, system=get_fn('integrator.xml'))
+        )
+        self.assertRaises(TypeError, lambda:
+                openmm.load_topology(parm2.topology, system=parm.createSystem())
+        )
+        system = parm.createSystem()
+        system.addForce(mm.CustomTorsionForce('theta**2'))
+        self.assertRaises(exceptions.OpenMMWarning, lambda:
+                openmm.load_topology(parm.topology, system))
+
+    def test_box_from_system(self):
+        """ Tests loading box from System """
+        parm = load_file(get_fn('solv2.parm7'), get_fn('solv2.rst7'))
+        system = parm.createSystem(nonbondedMethod=app.PME,
+                                   nonbondedCutoff=8*u.angstroms)
+        top = openmm.load_topology(parm.topology, system)
+        np.testing.assert_allclose(parm.box, top.box)


### PR DESCRIPTION
Also fixes a couple small issues:

- passing an open file handle (instead of a file name) to XmlFile.parse failed
- atom type compression for L-J types was not implemented correctly, although
  the resulting systems were correct from a FF perspective. The only side-effect
  is that a Structure loaded from an OpenMM System might have had nonbonded type
  tables that were larger than they needed to be (and as a result might have had
  GPU performance implications for large systems).