### PR TITLE
addAtomTypes only updates atomic number info for types existing in .dat/frcmod // hard-code EP and LP

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -211,7 +211,7 @@ class AmberParameterSet(ParameterSet):
     #===================================================
 
     @classmethod
-    def from_leaprc(cls, fname):
+    def from_leaprc(cls, fname, addAtomTypes=True):
         """ Load a parameter set from a leaprc file
 
         Parameters
@@ -219,6 +219,10 @@ class AmberParameterSet(ParameterSet):
         fname : str or file-like
             Name of the file or open file-object from which a leaprc-style file
             will be read
+        addAtomTypes : bool
+            If False, the addAtomTypes section of the leaprc is ignored
+            (useful when one does not want to create extra AtomType's which may
+            be called in the leaprc, but not defined in the parameter files)
 
         Notes
         -----
@@ -275,14 +279,15 @@ class AmberParameterSet(ParameterSet):
                 i += 1
             atom_types_str = ''.join(chars).strip()
         for _, name, symb, hyb in _atomtypere.findall(atom_types_str):
-            if symb not in AtomicNum:
-                raise ParameterError('%s is not a recognized element' % symb)
-            if name in params.atom_types:
-                params.atom_types[name].atomic_number = AtomicNum[symb]
-            else:
-                params.atom_types[name] = \
-                        AtomType(name, len(params.atom_types)+1, Mass[symb],
-                                 AtomicNum[symb])
+            if addAtomTypes:
+                if symb not in AtomicNum:
+                    raise ParameterError('%s is not a recognized element' % symb)
+                if name in params.atom_types:
+                    params.atom_types[name].atomic_number = AtomicNum[symb]
+                else:
+                    params.atom_types[name] = \
+                            AtomType(name, len(params.atom_types)+1, Mass[symb],
+                                     AtomicNum[symb])
         # Now process the parameter files
         for fname in _loadparamsre.findall(text):
             params.load_parameters(_find_amber_file(fname))

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -242,13 +242,21 @@ class AmberParameterSet(ParameterSet):
         text = f.read()
         if own_handle: f.close()
         lowertext = text.lower() # commands are case-insensitive
+        # Now process the parameter files
+        for fname in _loadparamsre.findall(text):
+            params.load_parameters(_find_amber_file(fname))
+        # Now process the library file
+        for fname in _loadoffre.findall(text):
+            params.residues.update(
+                    AmberOFFLibrary.parse(_find_amber_file(fname))
+            )
+        # Now process the addAtomTypes
         try:
             idx = lowertext.index('addatomtypes')
         except ValueError:
             # Does not exist in this file
             atom_types_str = ''
         else:
-            # Now process the addAtomTypes
             i = idx + len('addatomtypes')
             while i < len(text) and text[i] != '{':
                 if text[i] not in '\r\n\t ':
@@ -279,19 +287,6 @@ class AmberParameterSet(ParameterSet):
                 raise ParameterError('%s is not a recognized element' % symb)
             if name in params.atom_types:
                 params.atom_types[name].atomic_number = AtomicNum[symb]
-            else:
-                params.atom_types[name] = \
-                        AtomType(name, len(params.atom_types)+1, Mass[symb],
-                                 AtomicNum[symb])
-
-        # Now process the parameter files
-        for fname in _loadparamsre.findall(text):
-            params.load_parameters(_find_amber_file(fname))
-        # Now process the library file
-        for fname in _loadoffre.findall(text):
-            params.residues.update(
-                    AmberOFFLibrary.parse(_find_amber_file(fname))
-            )
         return params
 
     #===================================================
@@ -540,6 +535,9 @@ class AmberParameterSet(ParameterSet):
             raise ParameterError('Error parsing MASS line. Not enough tokens')
         if words[0] in self.atom_types:
             self.atom_types[words[0]].mass = mass
+        elif words[0] in ('EP', 'LP'):
+            atype = AtomType(words[0], len(self.atom_types)+1, mass, 0)
+            self.atom_types[words[0]] = atype
         else:
             atype = AtomType(words[0], len(self.atom_types)+1, mass,
                              AtomicNum[element_by_mass(mass)])

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -278,8 +278,8 @@ class AmberParameterSet(ParameterSet):
                 chars.append(char)
                 i += 1
             atom_types_str = ''.join(chars).strip()
-        for _, name, symb, hyb in _atomtypere.findall(atom_types_str):
-            if addAtomTypes:
+        if addAtomTypes:
+            for _, name, symb, hyb in _atomtypere.findall(atom_types_str):
                 if symb not in AtomicNum:
                     raise ParameterError('%s is not a recognized element' % symb)
                 if name in params.atom_types:

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -211,7 +211,7 @@ class AmberParameterSet(ParameterSet):
     #===================================================
 
     @classmethod
-    def from_leaprc(cls, fname, addAtomTypes=True):
+    def from_leaprc(cls, fname):
         """ Load a parameter set from a leaprc file
 
         Parameters
@@ -219,10 +219,6 @@ class AmberParameterSet(ParameterSet):
         fname : str or file-like
             Name of the file or open file-object from which a leaprc-style file
             will be read
-        addAtomTypes : bool
-            If False, the addAtomTypes section of the leaprc is ignored
-            (useful when one does not want to create extra AtomType's which may
-            be called in the leaprc, but not defined in the parameter files)
 
         Notes
         -----
@@ -278,16 +274,16 @@ class AmberParameterSet(ParameterSet):
                 chars.append(char)
                 i += 1
             atom_types_str = ''.join(chars).strip()
-        if addAtomTypes:
-            for _, name, symb, hyb in _atomtypere.findall(atom_types_str):
-                if symb not in AtomicNum:
-                    raise ParameterError('%s is not a recognized element' % symb)
-                if name in params.atom_types:
-                    params.atom_types[name].atomic_number = AtomicNum[symb]
-                else:
-                    params.atom_types[name] = \
-                            AtomType(name, len(params.atom_types)+1, Mass[symb],
-                                     AtomicNum[symb])
+        for _, name, symb, hyb in _atomtypere.findall(atom_types_str):
+            if symb not in AtomicNum:
+                raise ParameterError('%s is not a recognized element' % symb)
+            if name in params.atom_types:
+                params.atom_types[name].atomic_number = AtomicNum[symb]
+            else:
+                params.atom_types[name] = \
+                        AtomType(name, len(params.atom_types)+1, Mass[symb],
+                                 AtomicNum[symb])
+
         # Now process the parameter files
         for fname in _loadparamsre.findall(text):
             params.load_parameters(_find_amber_file(fname))

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -1094,13 +1094,13 @@ class TestParameterFiles(FileIOTestCase):
         )
         self.assertEqual(params.atom_types['H'].atomic_number, 1)
         self.assertEqual(params.atom_types['3C'].atomic_number, 6)
-        self.assertEqual(params.atom_types['K+'].atomic_number, 19)
+        self.assertEqual(params.atom_types['EP'].atomic_number, 0)
         self.assertTrue(params.residues)
         with open(os.path.join(os.getenv('AMBERHOME'), 'dat', 'leap', 'cmd', 'leaprc.ff14SB')) as f:
             params = parameters.AmberParameterSet.from_leaprc(f)
         self.assertEqual(params.atom_types['H'].atomic_number, 1)
         self.assertEqual(params.atom_types['3C'].atomic_number, 6)
-        self.assertEqual(params.atom_types['K+'].atomic_number, 19)
+        self.assertEqual(params.atom_types['EP'].atomic_number, 0)
         self.assertTrue(params.residues)
 
     def test_parm_set_parsing(self):


### PR DESCRIPTION
As we discussed in https://github.com/ParmEd/ParmEd/issues/486 . 

Not sure if this is the best approach here, what do you think? 