### PR TITLE
Avoid writing empty sections in the ffxml / fix typeify_templates / change how the templates are typeified / only add ResidueTemplates to OpenMM residues

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -168,6 +168,7 @@ class OpenMMParameterSet(ParameterSet):
         dest.write(' </Info>\n')
 
     def _write_omm_atom_types(self, dest):
+        if not self.atom_types: return
         dest.write(' <AtomTypes>\n')
         for name, atom_type in iteritems(self.atom_types):
             assert atom_type.atomic_number >= 0, 'Atomic number not set!'
@@ -178,6 +179,7 @@ class OpenMMParameterSet(ParameterSet):
         dest.write(' </AtomTypes>\n')
 
     def _write_omm_residues(self, dest):
+        if not self.residues: return
         dest.write(' <Residues>\n')
         for name, residue in iteritems(self.residues):
             if not isinstance(residue, ResidueTemplate):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -18,6 +18,7 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 import warnings
+from parmed.modeller import ResidueTemplate
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -107,9 +108,12 @@ class OpenMMParameterSet(ParameterSet):
         new_params.pair_types = params.pair_types
         new_params.parametersets = params.parametersets
         new_params._combining_rule = params.combining_rule
-        new_params.residues = params.residues
         new_params.default_scee = params.default_scee
         new_params.default_scnb = params.default_scnb
+        # add only ResidueTemplate instances (no ResidueTemplateContainers)
+        for name, residue in iteritems(params.residues):
+            if isinstance(residue, ResidueTemplate):
+                new_params.residues[name] = residue
 
         return new_params
 

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -18,7 +18,6 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 import warnings
-from parmed.modeller import ResidueTemplate
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -137,7 +137,7 @@ class OpenMMParameterSet(ParameterSet):
             own_handle = True
         else:
             own_handle = False
-        self.typeify_templates()
+#       self.typeify_templates()
         try:
             dest.write('<ForceField>\n')
             self._write_omm_provenance(dest, provenance)
@@ -184,6 +184,11 @@ class OpenMMParameterSet(ParameterSet):
         for name, residue in iteritems(self.residues):
             if not isinstance(residue, ResidueTemplate):
                 continue
+            # if AtomTypes are available, this will throw an exception if the
+            # residue is claiming a Type that doesn't exist
+            if self.atom_types:
+                for atom in residue:
+                    atom.atom_type = self.atom_types[atom.type]
             dest.write('  <Residue name="%s">\n' % residue.name)
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -142,8 +142,8 @@ class OpenMMParameterSet(ParameterSet):
             try:
                 self.typeify_templates()
             except:
-                warnings.warn("Some residue templates are using
-                unavailable AtomTypes!")
+                warnings.warn('Some residue templates are using unavailable ' 
+                              'AtomTypes')
         try:
             dest.write('<ForceField>\n')
             self._write_omm_provenance(dest, provenance)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -17,6 +17,7 @@ from parmed import unit as u
 from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
+import warnings
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -137,7 +138,12 @@ class OpenMMParameterSet(ParameterSet):
             own_handle = True
         else:
             own_handle = False
-#       self.typeify_templates()
+        if self.atom_types:
+            try:
+                self.typeify_templates()
+            except:
+                warnings.warn("Some residue templates are using
+                unavailable AtomTypes!")
         try:
             dest.write('<ForceField>\n')
             self._write_omm_provenance(dest, provenance)
@@ -184,11 +190,6 @@ class OpenMMParameterSet(ParameterSet):
         for name, residue in iteritems(self.residues):
             if not isinstance(residue, ResidueTemplate):
                 continue
-            # if AtomTypes are available, this will throw an exception if the
-            # residue is claiming a Type that doesn't exist
-            if self.atom_types:
-                for atom in residue:
-                    atom.atom_type = self.atom_types[atom.type]
             dest.write('  <Residue name="%s">\n' % residue.name)
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -145,7 +145,7 @@ class OpenMMParameterSet(ParameterSet):
         if self.atom_types:
             try:
                 self.typeify_templates()
-            except:
+            except KeyError:
                 warnings.warn('Some residue templates are using unavailable ' 
                               'AtomTypes')
         try:

--- a/parmed/parameters.py
+++ b/parmed/parameters.py
@@ -449,7 +449,7 @@ class ParameterSet(object):
         for name, residue in iteritems(self.residues):
             if isinstance(residue, ResidueTemplateContainer):
                 for res in residue:
-                    for atom in residue:
+                    for atom in res:
                         atom.atom_type = self.atom_types[atom.type]
             else:
                 assert isinstance(residue, ResidueTemplate), 'Wrong type!'


### PR DESCRIPTION
Just adding these, for a) consistency with not writing other sections (i.e. just opening and closing tags) if there's nothing there b) to not have the empty tags to worry about when writing only residue template or only parameters files 