### PR TITLE
allow reading of .lib files through AmberParameterSet() call

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -94,13 +94,7 @@ class AmberParameterSet(ParameterSet):
         is_fmt : bool
             True if it is an Amber-style parameter file. False otherwise.
         """
-        if isinstance(filename, string_types):
-            f = genopen(filename, 'r')
-            own_handle = True
-        else:
-            f = filename
-            own_handle = False
-        try:
+        with closing(genopen(filename, 'r')) as f:
             f.readline()
             line = f.readline()
             if not line.strip(): # Must be an frcmod file
@@ -197,11 +191,6 @@ class AmberParameterSet(ParameterSet):
                     return True
             else:
                 return True
-        finally:
-            if own_handle:
-                f.close()
-            else:
-                f.seek(0)
 
     #===================================================
 
@@ -211,22 +200,19 @@ class AmberParameterSet(ParameterSet):
         self.residues = dict()
         for filename in filenames:
             if isinstance(filename, string_types):
-                if self.id_format(filename): # dat or frcmod file
-                    self.load_parameters(filename)
-                else: # assume it's a lib or off file
+                if AmberOFFLibrary.id_format(filename):
                     self.residues.update(AmberOFFLibrary.parse(filename))
+                else:
+                    self.load_parameters(filename)
             elif isinstance(filename, Sequence):
                 for fname in filename:
-                    if self.id_format(filename):
-                        self.load_parameters(fname)
+                    if AmberOFFLibrary.id_format(fname):
+                        self.residues.update(AmberOFFLibrary.parse(fname))
                     else:
-                        self.residues.update(AmberOFFLibrary.parse(filename))
+                        self.load_parameters(fname)
             else:
                 # Assume open file object
-                if self.id_format(filename):
-                    self.load_parameters(filename)
-                else:
-                    self.residues.update(AmberOFFLibrary.parse(filename))
+                self.load_parameters(filename)
 
     #===================================================
 

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -1174,6 +1174,33 @@ class TestParameterFiles(FileIOTestCase):
         parm._truncate_array('ATOM_NAME', 2)
         self.assertEqual(len(parm.parm_data['ATOM_NAME']), 2)
 
+    def test_load_lib(self):
+        """ Test parsing Amber .lib files within a set of parameter files """
+        params = parameters.AmberParameterSet(
+                os.path.join(get_fn('parm'), 'parm10.dat'),
+                os.path.join(get_fn('parm'), 'frcmod.ff14SB'),
+                os.path.join(get_fn('amino12.lib')),
+                os.path.join(get_fn('aminoct12.lib'))
+        )
+        self.assertTrue(params.atom_types)
+        self.assertTrue(params.bond_types)
+        self.assertTrue(params.angle_types)
+        self.assertTrue(params.dihedral_types)
+        self.assertTrue(params.improper_periodic_types)
+        self.assertTrue(params.residues)
+        params = parameters.AmberParameterSet(
+                [os.path.join(get_fn('parm'), 'parm10.dat'),
+                os.path.join(get_fn('parm'), 'frcmod.ff14SB')],
+                [os.path.join(get_fn('amino12.lib')),
+                os.path.join(get_fn('aminoct12.lib'))]
+        )
+        self.assertTrue(params.atom_types)
+        self.assertTrue(params.bond_types)
+        self.assertTrue(params.angle_types)
+        self.assertTrue(params.dihedral_types)
+        self.assertTrue(params.improper_periodic_types)
+        self.assertTrue(params.residues)
+
 class TestCoordinateFiles(FileIOTestCase):
     """ Tests the various coordinate file classes """
     


### PR DESCRIPTION
As discussed in https://github.com/ParmEd/ParmEd/issues/486#issuecomment-177010286

Can now call `AmberParameterSet(file)` with .lib and .off files in addition to .dat and frcmod. 