### PR TITLE
Add args to: ignore ions/solvents at leaprc reading, only write out atom types that are used in templates in ffxml

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -223,7 +223,7 @@ class AmberParameterSet(ParameterSet):
     #===================================================
 
     @classmethod
-    def from_leaprc(cls, fname, ions=True, solvents=True):
+    def from_leaprc(cls, fname):
         """ Load a parameter set from a leaprc file
 
         Parameters
@@ -231,13 +231,6 @@ class AmberParameterSet(ParameterSet):
         fname : str or file-like
             Name of the file or open file-object from which a leaprc-style file
             will be read
-        ions :  bool
-            If False, loadOffs of ion templates (atomic_ions.lib, ions94.lib, 
-            ions91.lib) are ignored. The names of ignored files are current as of 
-            Amber14/AmberTools15
-        solvents : bool
-            If False, loadOffs of the solvent templates (solvents.lib). The name 
-            of the ignored file is current as of Amber14/AmberTool15       
 
         Notes
         -----
@@ -267,13 +260,7 @@ class AmberParameterSet(ParameterSet):
         for fname in _loadparamsre.findall(text):
             params.load_parameters(_find_amber_file(fname))
         # Now process the library file
-        lib_files = _loadoffre.findall(text)
-        if not ions:
-            lib_files = [fname for fname in lib_files if fname not in 
-            ('atomic_ions.lib', 'ions94.lib', 'ions91.lib')]
-        if not solvents:
-            lib_files = [fname for fname in lib_files if fname != 'solvents.lib']    
-        for fname in lib_files:
+        for fname in _loadoffre.findall(text):
             params.residues.update(
                     AmberOFFLibrary.parse(_find_amber_file(fname))
             )

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -524,7 +524,8 @@ class AmberParameterSet(ParameterSet):
         # Now assign all of the equivalenced atoms
         for atyp, otyp in iteritems(equivalent_ljtypes):
             otyp = self.atom_types[otyp]
-            self.atom_types[atyp].set_lj_params(otyp.epsilon, otyp.rmin)
+            if atyp in self.atom_types:
+                self.atom_types[atyp].set_lj_params(otyp.epsilon, otyp.rmin)
         line = next(fiter).strip()
         if line == 'LJEDIT':
             rawline = next(fiter)

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -223,7 +223,7 @@ class AmberParameterSet(ParameterSet):
     #===================================================
 
     @classmethod
-    def from_leaprc(cls, fname):
+    def from_leaprc(cls, fname, ions=True, solvents=True):
         """ Load a parameter set from a leaprc file
 
         Parameters
@@ -231,6 +231,13 @@ class AmberParameterSet(ParameterSet):
         fname : str or file-like
             Name of the file or open file-object from which a leaprc-style file
             will be read
+        ions :  bool
+            If False, loadOffs of ion templates (atomic_ions.lib, ions94.lib, 
+            ions91.lib) are ignored. The names of ignored files are current as of 
+            Amber14/AmberTools15
+        solvents : bool
+            If False, loadOffs of the solvent templates (solvents.lib). The name 
+            of the ignored file is current as of Amber14/AmberTool15       
 
         Notes
         -----
@@ -260,7 +267,13 @@ class AmberParameterSet(ParameterSet):
         for fname in _loadparamsre.findall(text):
             params.load_parameters(_find_amber_file(fname))
         # Now process the library file
-        for fname in _loadoffre.findall(text):
+        lib_files = _loadoffre.findall(text)
+        if not ions:
+            lib_files = [fname for fname in lib_files if fname not in 
+            ('atomic_ions.lib', 'ions94.lib', 'ions91.lib')]
+        if not solvents:
+            lib_files = [fname for fname in lib_files if fname != 'solvents.lib']    
+        for fname in lib_files:
             params.residues.update(
                     AmberOFFLibrary.parse(_find_amber_file(fname))
             )

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -18,6 +18,7 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 import warnings
+from parmed.exceptions import ParameterWarning
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -151,12 +152,15 @@ class OpenMMParameterSet(ParameterSet):
                 typeified = True
             except KeyError:
                 warnings.warn('Some residue templates are using unavailable '
-                              'AtomTypes')
+                              'AtomTypes', ParameterWarning)
         if not write_unused:
             if not typeified:
                 warnings.warn('Typification of the templates was not successful. '
-                              'Proceeding with write_unused=False is not advised')
-            skip_types = _find_unused_types()
+                              'Proceeding with write_unused=False is not advised',
+                               ParameterWarning)
+            skip_types = self._find_unused_types()
+        else:
+            skip_types = set()
         try:
             dest.write('<ForceField>\n')
             self._write_omm_provenance(dest, provenance)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -40,6 +40,7 @@ class OpenMMParameterSet(ParameterSet):
     --------
     :class:`parmed.parameters.ParameterSet`
     """
+
     @staticmethod
     def id_format(filename):
         """

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -132,6 +132,7 @@ class OpenMMParameterSet(ParameterSet):
         clean_params : bool
             If True, any atom types which are not used in the residue templates
             and any parameters using those atom types will not be written
+
         Notes
         -----
         The generated XML file will have the XML tag ``DateGenerated`` added to
@@ -437,4 +438,7 @@ class OpenMMParameterSet(ParameterSet):
             raise NotImplementedError('Geometric combining rule not currently '
                                       'supported.')
         if len(self.nbfix_types) > 0:
-            raise NotImplementedError('NBFIX not currently supported')
+            for (a1, a2), nbfix in iteritems(self.nbfix_types):
+                if any((a in self.skip_types for a in (a1, a2))): continue
+                else:
+                    raise NotImplementedError('NBFIX not currently supported')

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -489,6 +489,23 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                      Reference=citations)
         )
 
+    def test_write_xml_parameters_amber_clean_params(self):
+        """ Test writing XML parameters loaded from part of the ff14SB ForceField
+        files, with clean_params = False and clean_params = True"""
+        params = openmm.OpenMMParameterSet.from_parameterset(
+                pmd.amber.AmberParameterSet(get_fn('amino12.lib'),
+                os.path.join(get_fn('parm'), 'parm10.dat'),
+                os.path.join(get_fn('parm'), 'frcmod.ff14SB'))
+        )
+        ffxml = StringIO()
+        params.write(ffxml)
+        ffxml.seek(0)
+        self.assertEqual(len(ffxml.readlines()), 2178)
+        ffxml = StringIO()
+        params.write(ffxml, clean_params=True)
+        ffxml.seek(0)
+        self.assertEqual(len(ffxml.readlines()), 1646)
+
     def test_write_xml_small_amber(self):
         """ Test writing small XML modifications """
         params = openmm.OpenMMParameterSet.from_parameterset(
@@ -509,4 +526,3 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                          Reference='MacKerrell'
                      )
         )
-

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -490,7 +490,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         )
 
     def test_write_xml_parameters_amber_write_unused(self):
-        """ Test writing XML parameters loaded from part of the ff14SB ForceField
+        """ Test writing XML parameters loaded from part of the ff14SB forcefield
         files, using the write_unused argument"""
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.amber.AmberParameterSet(get_fn('amino12.lib'),

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -489,9 +489,9 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                      Reference=citations)
         )
 
-    def test_write_xml_parameters_amber_clean_params(self):
+    def test_write_xml_parameters_amber_write_unused(self):
         """ Test writing XML parameters loaded from part of the ff14SB ForceField
-        files, with clean_params = False and clean_params = True"""
+        files, using the write_unused argument"""
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.amber.AmberParameterSet(get_fn('amino12.lib'),
                 os.path.join(get_fn('parm'), 'parm10.dat'),
@@ -502,7 +502,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 2178)
         ffxml = StringIO()
-        params.write(ffxml, clean_params=True)
+        params.write(ffxml, write_unused=False)
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 1646)
 


### PR DESCRIPTION
- [x] Add arguments for ignore ions and solvents in leaprc
- [x] Add argument for only write out those Atom Types to ffxml that are used in the templates (this will clean up all the ions, EP/LP etc.)
