### PR TITLE
OpenMM provenance tweaks

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -127,8 +127,24 @@ class OpenMMParameterSet(ParameterSet):
             attribute) to which the XML file will be written
         provenance : dict, optional
             If present, the XML file will be tagged with the available fields.
-            The keys of this dictionary are turned into the XML tags, and the
-            values become the contents of that tag. Default is no provenance
+            Keys of the dictionary become XML element tags, the values of the
+            dictionary must be instances of any of:
+            - str / unicode (Py2) or str (Py3) - one XML element with this
+            content is written
+            - list - one XML element per each item of the list is written, all
+            these XML elements use the same tag (key in provenance dict)
+            - dict - one of the keys of this dict must be the same as the key of
+            of the provenance dict under which this dict is nested. The value
+            under this key becomes the content of the XML element. Remaining keys
+            and their values are used to construct attributes of the XML element.
+            Note that OrderedDict's should be used to ensure appropriate order
+            of the XML elements and their attributes.
+            Default is no provenance.
+            Example (unordered):
+            provenance = {'Reference' : ['Nature', 'Cell'],
+                          'Source' : {'Source': 'leaprc.ff14SB', sourcePackage :
+                          'AmberTools', sourcePackageVersion : '15'},
+                          'User' : 'Mark'}
         write_unused : bool
             If False, atom types that are not used in any of the residue templates
             and parameters including those atom types will not be written

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -467,7 +467,9 @@ CHIS = CHIE
         )
         params.write(get_fn('amber_conv.xml', written=True),
                      provenance=dict(OriginalFile='leaprc.ff14SB',
-                     Reference='Maier & Simmerling')
+                     Reference=['Maier & Simmerling', 'Simmerling & Maier'],
+                     Source=dict(Source='leaprc.ff14SB',
+                     sourcePackage='AmberTools', sourcePackageVersion='15'))
         )
 
 


### PR DESCRIPTION
Not tested yet, just want to show you the idea first.

* Write multiple elements with the same tag - e.g. two references, by having `provenance = {'Reference' : ['reference1', 'reference2']`}

* Write elements with attributes - the Source element, by having:
``` python
provenance = {'Source' : {'Source' : 'leaprc.ff14SB', 'md5hash' : '...', 'sourcePackage' : 'AmberTools', 'sourcePackageVersion' : 15}
```

i.e. pass nested dict, one of the keys has to be identical to the element tag, that becomes the content, rest of keys feed attributes. 