### PR TITLE
Implement improved processing of parm.dat files when equivalence lines LIE

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.2.2'
+__version__ = '2.2.3'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -13,7 +13,7 @@ import math
 import os
 from parmed.amber.offlib import AmberOFFLibrary
 from parmed.constants import TINY
-from parmed.exceptions import ParameterError, ParameterWarning
+from parmed.exceptions import ParameterError, AmberWarning
 from parmed.formats.registry import FileFormatType
 from parmed.parameters import ParameterSet
 from parmed.periodic_table import Mass, element_by_mass, AtomicNum
@@ -546,7 +546,7 @@ class AmberParameterSet(ParameterSet):
                             or abs(otyp.rmin-self.atom_types[atyp].rmin) > TINY):
                         warnings.warn('Equivalency defined between %s and %s '
                                       'but parameters are not equal' %
-                                      (otyp.name, atyp), ParameterWarning)
+                                      (otyp.name, atyp), AmberWarning)
                         # Remove from equivalent types
                         equivalent_types[otyp.name].remove(atyp)
                         continue

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -13,7 +13,7 @@ import sys
 from parmed.amber import (readparm, asciicrd, mask, parameters, mdin,
                           FortranFormat, titratable_residues, AmberOFFLibrary)
 from parmed.exceptions import (AmberWarning, MoleculeError, AmberError,
-                               MaskError, InputError, ParameterWarning)
+                               MaskError, InputError)
 from parmed import topologyobjects, load_file, Structure
 import parmed.unit as u
 from parmed.utils.six import string_types, iteritems
@@ -901,7 +901,16 @@ class TestParameterFiles(FileIOTestCase):
 
     def test_parm_dat_bad_equivalencing(self):
         """ Test handling of erroneous atom equivalencing in parm.dat files """
-        warnings.filterwarnings('ignore', category=ParameterWarning)
+        # Now make sure it warns
+        warnings.filterwarnings('error', category=AmberWarning)
+        self.assertRaises(AmberWarning, lambda:
+                parameters.AmberParameterSet(
+                        os.path.join(get_fn('parm'), 'parmAM1.dat')
+                )
+        )
+        warnings.filterwarnings('always', category=AmberWarning)
+        # Now check it does the right thing.
+        warnings.filterwarnings('ignore', category=AmberWarning)
         params = parameters.AmberParameterSet(
                 os.path.join(get_fn('parm'), 'parmAM1.dat')
         )
@@ -911,14 +920,6 @@ class TestParameterFiles(FileIOTestCase):
         self.assertEqual(params.atom_types['C'].epsilon, 0.086)
         self.assertEqual(params.atom_types['CA'].rmin, 1.9061)
         self.assertEqual(params.atom_types['CA'].epsilon, 0.086)
-        # Now make sure it warns
-        warnings.filterwarnings('error', category=ParameterWarning)
-        self.assertRaises(ParameterWarning, lambda:
-                parameters.AmberParameterSet(
-                        os.path.join(get_fn('parm'), 'parmAM1.dat')
-                )
-        )
-        warnings.filterwarnings('always', category=ParameterWarning)
 
     def test_frcmod_with_tabstops(self):
         """ Test parsing an Amber frcmod file with tabs instead of spaces """

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -13,7 +13,7 @@ import sys
 from parmed.amber import (readparm, asciicrd, mask, parameters, mdin,
                           FortranFormat, titratable_residues, AmberOFFLibrary)
 from parmed.exceptions import (AmberWarning, MoleculeError, AmberError,
-                               MaskError, InputError)
+                               MaskError, InputError, ParameterWarning)
 from parmed import topologyobjects, load_file, Structure
 import parmed.unit as u
 from parmed.utils.six import string_types, iteritems
@@ -898,6 +898,27 @@ class TestParameterFiles(FileIOTestCase):
                     os.path.join(get_fn('parm'), 'frcmod.1')
                 )
         )
+
+    def test_parm_dat_bad_equivalencing(self):
+        """ Test handling of erroneous atom equivalencing in parm.dat files """
+        warnings.filterwarnings('ignore', category=ParameterWarning)
+        params = parameters.AmberParameterSet(
+                os.path.join(get_fn('parm'), 'parmAM1.dat')
+        )
+        # Make sure CA and C have different types, even though they are
+        # explicitly equivalenced
+        self.assertEqual(params.atom_types['C'].rmin, 1.9127)
+        self.assertEqual(params.atom_types['C'].epsilon, 0.086)
+        self.assertEqual(params.atom_types['CA'].rmin, 1.9061)
+        self.assertEqual(params.atom_types['CA'].epsilon, 0.086)
+        # Now make sure it warns
+        warnings.filterwarnings('error', category=ParameterWarning)
+        self.assertRaises(ParameterWarning, lambda:
+                parameters.AmberParameterSet(
+                        os.path.join(get_fn('parm'), 'parmAM1.dat')
+                )
+        )
+        warnings.filterwarnings('always', category=ParameterWarning)
 
     def test_frcmod_with_tabstops(self):
         """ Test parsing an Amber frcmod file with tabs instead of spaces """


### PR DESCRIPTION
See the discussion in choderalab/openmm#7.  This commit should fix that issue.