### PR TITLE
Fix minor inconsistency in docstring

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -50,7 +50,7 @@ class CharmmParameterSet(ParameterSet):
 
     Parameters
     ----------
-    filenames : list of str
+    *filenames : variable length arguments of str
         The list of topology, parameter, and stream files to load into the
         parameter set. The following file type suffixes are recognized:
             .rtf, .top -- Residue topology file


### PR DESCRIPTION
Nothing major but it stumped me for a second when I first tried to load multiple charmm files.

I couldn't find anything [official](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt) on how to document `*args`. The sphinx [napoleon](http://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_numpy.html) plugin recommends the following but I think we can provide a bit more info.

```
*args
   Variable length argument list
```