### PR TITLE
absolute value for Epsilon

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -464,7 +464,7 @@ class OpenMMParameterSet(ParameterSet):
                                      "epsilon != 0." % name)
 
             dest.write('  <Atom type="%s" sigma="%s" epsilon="%s"/>\n' %
-                       (name, sigma, epsilon))
+                       (name, sigma, abs(epsilon)))
         dest.write(' </NonbondedForce>\n')
 
     def _write_omm_scripts(self, dest, skip_types):


### PR DESCRIPTION
Since CharMM uses the negative value for epsilon only to signal that it's indeed an epsilon, we should write out the absolute value for epsilon. 