### PR TITLE
Warn when setting L-J parameters on atom types that don't exist

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -245,7 +245,7 @@ class CharmmParameterSet(ParameterSet):
         -------
         New CharmmParameterSet populated with parameters found in the provided
         files
-            
+
         Notes
         -----
         The RTF file is read first (if provided), followed by the PAR file,
@@ -330,7 +330,7 @@ class CharmmParameterSet(ParameterSet):
             if line.startswith('ANGLE') or line.startswith('THETA'):
                 section = 'ANGLES'
                 continue
-            if line.startswith('DIHE') or line.startswith('PHI'): 
+            if line.startswith('DIHE') or line.startswith('PHI'):
                 section = 'DIHEDRALS'
                 continue
             if line.startswith('IMPROPER') or line.startswith('IMPHI'):
@@ -463,11 +463,13 @@ class CharmmParameterSet(ParameterSet):
                 angle_type = AngleType(k, theteq)
                 key = (type1, type2, type3)
                 if key in self.angle_types:
-                    # See if the existing angle type list has a different value and replaces it with a warning
+                    # See if the existing angle type list has a different value
+                    # and replaces it with a warning
                     if self.angle_types[key] != angle_type:
                         # Replace. Warn if they are different
                         warnings.warn('Replacing angle %r, %r with %r' %
-                                      (key, self.angle_types[key], angle_type), ParameterWarning)
+                                      (key, self.angle_types[key], angle_type),
+                                      ParameterWarning)
                         self.bond_types[(type1, type2, type3)] = angle_type
                         self.bond_types[(type3, type2, type1)] = angle_type
                 else: # key not present
@@ -713,8 +715,8 @@ class CharmmParameterSet(ParameterSet):
             for key in nonbonded_types:
                 self.atom_types_str[key].set_lj_params(*nonbonded_types[key])
         except KeyError:
-            raise RuntimeError('Atom type %s not present in AtomType list' %
-                               key)
+            warnings.warn('Atom type %s not present in AtomType list' % key,
+                          ParameterWarning)
         if parameterset is not None: self.parametersets.append(parameterset)
         if own_handle: f.close()
 

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -26,7 +26,7 @@ get_fn = utils.get_fn
 
 class TestCharmmCoords(utils.FileIOTestCase):
     """ Test CHARMM coordinate file parsers """
-    
+
     def test_charmm_crd(self):
         """ Test CHARMM coordinate file parser """
         self.assertTrue(charmmcrds.CharmmCrdFile.id_format(get_fn('1tnm.crd')))
@@ -122,7 +122,7 @@ class TestCharmmCoords(utils.FileIOTestCase):
 
 class TestCharmmPsf(utils.FileIOTestCase):
     """ Test CHARMM PSF file capabilities """
-    
+
     def test_private_internals(self):
         """ Test private internal functions for CHARMM psf file """
         # _catchindexerror
@@ -330,7 +330,7 @@ class TestCharmmPsf(utils.FileIOTestCase):
         self.assertEqual(len(cpsf.impropers), 295)
         self.assertEqual(len(cpsf.residues), 109)
         self.assertEqual(len(cpsf.title), 3)
-    
+
     def test_vmd_psf(self):
         """ Test parsing of CHARMM PSF from VMD """
         cpsf = psf.CharmmPsfFile(get_fn('ala_ala_ala_autopsf.psf'))
@@ -581,8 +581,10 @@ class TestCharmmParameters(utils.FileIOTestCase):
     def test_single_parameterset(self):
         """ Test reading a single parameter set """
         # Make sure we error if trying to load parameters before topology
-        self.assertRaises(RuntimeError, lambda: parameters.CharmmParameterSet(
-                                                get_fn('par_all22_prot.inp')))
+        warnings.filterwarnings('error', category=exceptions.ParameterWarning)
+        self.assertRaises(exceptions.ParameterWarning, lambda:
+                parameters.CharmmParameterSet(get_fn('par_all22_prot.inp')))
+        warnings.filterwarnings('always', category=exceptions.ParameterWarning)
         # Test error handling for loading files with unsupported extensions
         self.assertRaises(ValueError, lambda:
                 parameters.CharmmParameterSet(get_fn('trx.prmtop'))
@@ -684,7 +686,7 @@ class TestCharmmParameters(utils.FileIOTestCase):
     def test_collection(self):
         """ Test reading a large number of parameter files """
         p = parameters.CharmmParameterSet(
-                    get_fn('top_all36_prot.rtf'), 
+                    get_fn('top_all36_prot.rtf'),
                     get_fn('top_all36_carb.rtf'),
                     get_fn('par_all36_prot.prm'),
                     get_fn('par_all36_carb.prm'),


### PR DESCRIPTION
Currently the CHARMM parameter set parsers raise a fatal exception when L-J parameters are set on an atom type that doesn't exist.  This change simply warns when that happens and soldiers on (it will later quit with a KeyError if you try and *use* that atom type).