### PR TITLE
do not write double external bonds if head == tail

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -260,7 +260,7 @@ class OpenMMParameterSet(ParameterSet):
             if residue.head is not None:
                 dest.write('   <ExternalBond atomName="%s"/>\n' %
                            residue.head.name)
-            if residue.tail is not None and residue.tail != residue.head:
+            if residue.tail is not None and residue.tail is not residue.head:
                 dest.write('   <ExternalBond atomName="%s"/>\n' %
                            residue.tail.name)
             dest.write('  </Residue>\n')

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -260,7 +260,7 @@ class OpenMMParameterSet(ParameterSet):
             if residue.head is not None:
                 dest.write('   <ExternalBond atomName="%s"/>\n' %
                            residue.head.name)
-            if residue.tail is not None:
+            if residue.tail is not None and residue.tail != residue.head:
                 dest.write('   <ExternalBond atomName="%s"/>\n' %
                            residue.tail.name)
             dest.write('  </Residue>\n')


### PR DESCRIPTION
Any advantages / disadvantages to using `!=` or `is not`?

This should fix https://github.com/choderalab/openmm/issues/10