### PR TITLE
Don't add self exceptions to bond graph exceptions

### DIFF
--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -392,11 +392,11 @@ def _process_nonbonded(struct, force):
     bond_graph_exceptions = defaultdict(set)
     for atom in struct.atoms:
         for a2 in atom.bond_partners:
-            if atom != a2:
+            if atom is not a2:
                 bond_graph_exceptions[atom].add(a2)
             for a3 in a2.bond_partners:
                 if a3 is atom: continue
-                if atom != a3:
+                if atom is not a3:
                     bond_graph_exceptions[atom].add(a3)
 
     # TODO should we compress exception types?

--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -392,10 +392,12 @@ def _process_nonbonded(struct, force):
     bond_graph_exceptions = defaultdict(set)
     for atom in struct.atoms:
         for a2 in atom.bond_partners:
-            bond_graph_exceptions[atom].add(a2)
+            if atom != a2:
+                bond_graph_exceptions[atom].add(a2)
             for a3 in a2.bond_partners:
                 if a3 is atom: continue
-                bond_graph_exceptions[atom].add(a3)
+                if atom != a3:
+                    bond_graph_exceptions[atom].add(a3)
 
     # TODO should we compress exception types?
     for ii in range(force.getNumExceptions()):


### PR DESCRIPTION
We were getting warnings like this for molecules containing three-membered rings:
```
/Users/choderaj/miniconda/lib/python2.7/site-packages/parmed/openmm/topsystem.py:428: OpenMMWarning: Detected incomplete exceptions. Not supported.
  OpenMMWarning)
```
This change fixes the construction of [`bond_graph_exceptions`](https://github.com/ParmEd/ParmEd/blob/master/parmed/openmm/topsystem.py#L392-L398) to exclude entries where `parmed` thinks an atom should be excluded from itself.