### PR TITLE
Do not write identical residues to OpenMM XML // Add support for omm_overloadLevel for templates

### DIFF
--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -70,6 +70,10 @@ class ResidueTemplate(object):
         atom of this residue when this residue is the last in a chain
     groups : list of list(:class:`Atom`)
         If set, each group is a list of Atom instances making up each group
+    omm_overloadLevel : integer
+        For use with OpenMM ResidueTemplates. If OpenMM ForceField is given multiple
+        identically-matching residue templates with the same names it choses
+        (overloads with) the one with the highest overloadLevel. Default is 0.
     """
 
     def __init__(self, name=''):
@@ -84,6 +88,7 @@ class ResidueTemplate(object):
         self.first_patch = None
         self.last_patch = None
         self.groups = []
+        self.omm_overloadLevel = 0
 
     def __repr__(self):
         if self.head is not None:
@@ -739,4 +744,3 @@ class ResidueTemplateContainer(list):
             AmberOFFLibrary.write(self.to_library(), fname, **kwargs)
         else:
             raise ValueError('Unrecognized format for ResidueTemplate save')
-

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -70,10 +70,11 @@ class ResidueTemplate(object):
         atom of this residue when this residue is the last in a chain
     groups : list of list(:class:`Atom`)
         If set, each group is a list of Atom instances making up each group
-    omm_overloadLevel : integer
+    overload_level : integer
         For use with OpenMM ResidueTemplates. If OpenMM ForceField is given multiple
         identically-matching residue templates with the same names it choses
-        (overloads with) the one with the highest overloadLevel. Default is 0.
+        (overloads with) the one with the highest overload_level
+        (overloadLevel in OpenMM). Default is 0.
     """
 
     def __init__(self, name=''):
@@ -88,7 +89,7 @@ class ResidueTemplate(object):
         self.first_patch = None
         self.last_patch = None
         self.groups = []
-        self.omm_overloadLevel = 0
+        self.overload_level = 0
 
     def __repr__(self):
         if self.head is not None:

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -268,11 +268,10 @@ class OpenMMParameterSet(ParameterSet):
         written_residues = set()
         dest.write(' <Residues>\n')
         for name, residue in iteritems(self.residues):
-            if name in skip_residues:
-                continue
-            if OpenMMParameterSet._templhasher(residue) in written_residues:
-                continue
-            written_residues.add(self._templhasher(residue))
+            if name in skip_residues: continue
+            templhash = OpenMMParameterSet._templhasher(residue)
+            if templhash in written_residues: continue
+            written_residues.add(templhash)
             if residue.overload_level == 0:
                 dest.write('  <Residue name="%s">\n' % residue.name)
             else:

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -214,6 +214,13 @@ class OpenMMParameterSet(ParameterSet):
                     keep_types.add(atom.type)
         return {typ for typ in self.atom_types if typ not in keep_types}
 
+    def templhasher(self, residue):
+        if len(residue.atoms) == 1:
+            atom = residue.atoms[0]
+            return hash((atom.atomic_number, atom.type, atom.charge))
+        # TODO implement hash for polyatomic residues
+        return id(residue)
+
     def _write_omm_provenance(self, dest, provenance):
         dest.write(' <Info>\n')
         dest.write('  <DateGenerated>%02d-%02d-%02d</DateGenerated>\n' %
@@ -257,11 +264,18 @@ class OpenMMParameterSet(ParameterSet):
 
     def _write_omm_residues(self, dest, skip_residues):
         if not self.residues: return
+        written_residues = set()
         dest.write(' <Residues>\n')
         for name, residue in iteritems(self.residues):
-            if not isinstance(residue, ResidueTemplate) or name in skip_residues:
+            if (not isinstance(residue, ResidueTemplate) or name in skip_residues
+                or self.templhasher(residue) in written_residues):
                 continue
-            dest.write('  <Residue name="%s">\n' % residue.name)
+            written_residues.add(self.templhasher(residue))
+            if residue.omm_overloadLevel != 0:
+                dest.write('  <Residue name="%s" overload="%d">\n' % (residue.name,
+                           residue.omm_overloadLevel))
+            else:
+                dest.write('  <Residue name="%s">\n' % residue.name)
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %
                            (atom.name, atom.type, atom.charge))

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -271,11 +271,11 @@ class OpenMMParameterSet(ParameterSet):
                 or self._templhasher(residue) in written_residues):
                 continue
             written_residues.add(self._templhasher(residue))
-            if residue.omm_overloadLevel != 0:
+            if residue.omm_overloadLevel == 0:
+                dest.write('  <Residue name="%s">\n' % residue.name)
+            else:
                 dest.write('  <Residue name="%s" overload="%d">\n' % (residue.name,
                            residue.omm_overloadLevel))
-            else:
-                dest.write('  <Residue name="%s">\n' % residue.name)
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %
                            (atom.name, atom.type, atom.charge))

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -214,7 +214,7 @@ class OpenMMParameterSet(ParameterSet):
                     keep_types.add(atom.type)
         return {typ for typ in self.atom_types if typ not in keep_types}
 
-    def templhasher(self, residue):
+    def _templhasher(self, residue):
         if len(residue.atoms) == 1:
             atom = residue.atoms[0]
             return hash((atom.atomic_number, atom.type, atom.charge))
@@ -268,9 +268,9 @@ class OpenMMParameterSet(ParameterSet):
         dest.write(' <Residues>\n')
         for name, residue in iteritems(self.residues):
             if (not isinstance(residue, ResidueTemplate) or name in skip_residues
-                or self.templhasher(residue) in written_residues):
+                or self._templhasher(residue) in written_residues):
                 continue
-            written_residues.add(self.templhasher(residue))
+            written_residues.add(self._templhasher(residue))
             if residue.omm_overloadLevel != 0:
                 dest.write('  <Residue name="%s" overload="%d">\n' % (residue.name,
                            residue.omm_overloadLevel))

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -214,7 +214,8 @@ class OpenMMParameterSet(ParameterSet):
                     keep_types.add(atom.type)
         return {typ for typ in self.atom_types if typ not in keep_types}
 
-    def _templhasher(self, residue):
+    @staticmethod
+    def _templhasher(residue):
         if len(residue.atoms) == 1:
             atom = residue.atoms[0]
             return hash((atom.atomic_number, atom.type, atom.charge))
@@ -267,15 +268,16 @@ class OpenMMParameterSet(ParameterSet):
         written_residues = set()
         dest.write(' <Residues>\n')
         for name, residue in iteritems(self.residues):
-            if (not isinstance(residue, ResidueTemplate) or name in skip_residues
-                or self._templhasher(residue) in written_residues):
+            if name in skip_residues:
+                continue
+            if OpenMMParameterSet._templhasher(residue) in written_residues:
                 continue
             written_residues.add(self._templhasher(residue))
-            if residue.omm_overloadLevel == 0:
+            if residue.overload_level == 0:
                 dest.write('  <Residue name="%s">\n' % residue.name)
             else:
                 dest.write('  <Residue name="%s" overload="%d">\n' % (residue.name,
-                           residue.omm_overloadLevel))
+                           residue.overload_level))
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %
                            (atom.name, atom.type, atom.charge))

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -9,6 +9,7 @@ import parmed as pmd
 from parmed import openmm, load_file, exceptions, ExtraPoint, unit as u
 import unittest
 from utils import get_fn, mm, app, has_openmm, FileIOTestCase
+from collections import OrderedDict
 
 import warnings
 
@@ -515,11 +516,11 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         warnings.filterwarnings('ignore', category=exceptions.ParameterWarning)
         params.write(ffxml)
         ffxml.seek(0)
-        self.assertEqual(len(ffxml.readlines()), 231)
+        self.assertEqual(len(ffxml.readlines()), 222)
         ffxml = StringIO()
         params.write(ffxml, write_unused=False)
         ffxml.seek(0)
-        self.assertEqual(len(ffxml.readlines()), 66)
+        self.assertEqual(len(ffxml.readlines()), 57)
 
     def test_write_xml_small_amber(self):
         """ Test writing small XML modifications """
@@ -541,3 +542,39 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                          Reference='MacKerrell'
                      )
         )
+
+    def test_not_write_residues_with_same_templhash(self):
+        """Test that no identical residues are written to XML, using the
+           templhasher function."""
+        # TODO add testing for multiatomic residues when support for those added
+        params = openmm.OpenMMParameterSet.from_parameterset(
+                 pmd.amber.AmberParameterSet(get_fn('atomic_ions.lib'))
+                 )
+        new_residues = OrderedDict()
+        for name in ('K', 'K+', 'NA', 'Na+', 'CL', 'Cl-'):
+            new_residues[name] = params.residues[name]
+        params.residues = new_residues
+        ffxml = StringIO()
+        params.write(ffxml)
+        ffxml.seek(0)
+        self.assertEqual(len(ffxml.readlines()), 16)
+
+    def test_omm_overloadLevel(self):
+        """Test correct support for the omm_overloadLevel attribute of
+           ResidueTemplates and correct writing to XML tag"""
+        params = openmm.OpenMMParameterSet.from_parameterset(
+                 pmd.amber.AmberParameterSet(get_fn('atomic_ions.lib'))
+                 )
+        new_residues = OrderedDict()
+        new_residues['K'] = params.residues['K']
+        new_residues['NA'] = params.residues['NA']
+        new_residues['K'].omm_overloadLevel = 1
+        params.residues = new_residues
+        ffxml = StringIO()
+        params.write(ffxml)
+        ffxml.seek(0)
+        output_lines = ffxml.readlines()
+        control_line1 = '  <Residue name="K" overload="1">\n'
+        control_line2 = '  <Residue name="NA">\n'
+        self.assertEqual(output_lines[5], control_line1)
+        self.assertEqual(output_lines[8], control_line2)

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -559,8 +559,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 16)
 
-    def test_omm_overloadLevel(self):
-        """Test correct support for the omm_overloadLevel attribute of
+    def test_overload_level(self):
+        """Test correct support for the overload_level attribute of
            ResidueTemplates and correct writing to XML tag"""
         params = openmm.OpenMMParameterSet.from_parameterset(
                  pmd.amber.AmberParameterSet(get_fn('atomic_ions.lib'))
@@ -568,7 +568,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         new_residues = OrderedDict()
         new_residues['K'] = params.residues['K']
         new_residues['NA'] = params.residues['NA']
-        new_residues['K'].omm_overloadLevel = 1
+        new_residues['K'].overload_level = 1
         params.residues = new_residues
         ffxml = StringIO()
         params.write(ffxml)


### PR DESCRIPTION
Fresh PR for https://github.com/ParmEd/ParmEd/issues/629 + overload support for residue templates (implemented in https://github.com/pandegroup/openmm/pull/1373 and https://github.com/rafwiewiora/openmm/commit/4e9b65cf26f10820f4c46f4fc9dadc32e2264a61 specifically). 

Summary of the overloading for reference:
* residue templates in XML `overload` attribute like such:
``` xml
<Residue name="Ag" overload="1"/>
```
* default is zero, that does not have to be present in the XML
* internal variable called `overloadLevel` so I made it `omm_overloadLevel` in ParmEd
* higher `overloadLevel` wins if names are the same for 'identically matching' templates
* `residue.omm_overloadLevel` will be set for templates in `OpenMMParameterSet` by conversion script