### PR TITLE
Leave out element for dummy atom

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -746,7 +746,7 @@ class CharmmParameterSet(ParameterSet):
         try:
             while line:
                 line = line.strip()
-                if line[:4] == 'MASS':
+                if line[:4].upper() == 'MASS':
                     words = line.split()
                     try:
                         idx = conv(words[1], int, 'atom type')
@@ -769,9 +769,9 @@ class CharmmParameterSet(ParameterSet):
                     self.atom_types_str[atype.name] = atype
                     self.atom_types_int[atype.number] = atype
                     self.atom_types_tuple[(atype.name, atype.number)] = atype
-                elif line[:4] == 'DECL':
+                elif line[:4].upper() == 'DECL':
                     pass # Not really sure what this means
-                elif line[:4] == 'DEFA':
+                elif line[:4].upper() == 'DEFA':
                     words = line.split()
                     if len(words) < 5:
                         warnings.warn('DEFA line has %d tokens; expected 5' %

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -746,7 +746,7 @@ class CharmmParameterSet(ParameterSet):
         try:
             while line:
                 line = line.strip()
-                if line[:4].upper() == 'MASS':
+                if line[:4] == 'MASS':
                     words = line.split()
                     try:
                         idx = conv(words[1], int, 'atom type')
@@ -769,9 +769,9 @@ class CharmmParameterSet(ParameterSet):
                     self.atom_types_str[atype.name] = atype
                     self.atom_types_int[atype.number] = atype
                     self.atom_types_tuple[(atype.name, atype.number)] = atype
-                elif line[:4].upper() == 'DECL':
+                elif line[:4] == 'DECL':
                     pass # Not really sure what this means
-                elif line[:4].upper() == 'DEFA':
+                elif line[:4] == 'DEFA':
                     words = line.split()
                     if len(words) < 5:
                         warnings.warn('DEFA line has %d tokens; expected 5' %

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -255,12 +255,14 @@ class OpenMMParameterSet(ParameterSet):
             if name in skip_types: continue
             assert atom_type.atomic_number >= 0, 'Atomic number not set!'
             if atom_type.atomic_number == 0:
-                element = ""
+                dest.write('  <Type name="%s" class="%s" mass="%s"/>\n'
+                           % (name, name, atom_type.mass)
+                           )
             else:
                 element = Element[atom_type.atomic_number]
-            dest.write('  <Type name="%s" class="%s" element="%s" mass="%s"/>\n'
-                       % (name, name, element, atom_type.mass)
-                       )
+                dest.write('  <Type name="%s" class="%s" element="%s" mass="%s"/>\n'
+                           % (name, name, element, atom_type.mass)
+                          )
         dest.write(' </AtomTypes>\n')
 
     def _write_omm_residues(self, dest, skip_residues):


### PR DESCRIPTION
If the atom type is a dummy atom, leave out element from attributes so that forcefield.py can parse the xml. 