### PR TITLE
Add warning when replacing residues

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -791,6 +791,9 @@ class CharmmParameterSet(ParameterSet):
                     # Get the residue definition
                     words = line.split()
                     resname = words[1].upper()
+                    if resname in (self.residues):
+                        warnings.warn('Replacing residue %r' %
+                                              (resname), ParameterWarning)
                     # Assign default patches
                     hpatches[resname] = hpatch
                     tpatches[resname] = tpatch

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -791,9 +791,9 @@ class CharmmParameterSet(ParameterSet):
                     # Get the residue definition
                     words = line.split()
                     resname = words[1].upper()
-                    if resname in (self.residues):
+                    if resname in self.residues:
                         warnings.warn('Replacing residue %r' %
-                                              (resname), ParameterWarning)
+                                              resname, ParameterWarning)
                     # Assign default patches
                     hpatches[resname] = hpatch
                     tpatches[resname] = tpatch


### PR DESCRIPTION
Turns out CharMM has many duplicate residues with different atom types across different force fields that should be compatible. I didn't check yet if the parameters are identical for these atom types, but I thought it's good to get a warning when they get overwritten. I still need to figure out how to handle this. If the parameters are all identical, it shouldn't matter. But if they're not, we might need to write out both and use  overload. 