### PR TITLE
Fixed the lack of pwd module on windows

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -37,9 +37,9 @@ from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 
 if sys.platform.startswith('win'):
-    _username = os.getlogin()   # pragma: nocover
-    _userid = 0                 # pragma: nocover
-    _uname = 'Windows'          # pragma: nocover
+    _username = os.getlogin()   # pragma: no cover
+    _userid = 0                 # pragma: no cover
+    _uname = 'Windows'          # pragma: no cover
 else:
     import pwd
     _username = pwd.getpwuid(os.getuid())[0]

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -10,7 +10,6 @@ import copy
 from datetime import datetime
 import math
 import os
-import pwd
 import re
 try:
     from string import letters
@@ -37,6 +36,15 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 
+if sys.platform.startswith('win'):
+    _username = os.getlogin()   # pragma: nocover
+    _userid = 0                 # pragma: nocover
+    _uname = 'Windows'          # pragma: nocover
+else:
+    import pwd
+    _username = pwd.getpwuid(os.getuid())[0]
+    _userid = os.getuid()
+    _uname = os.uname()[1]
 
 # Gromacs uses "funct" flags in its parameter files to indicate what kind of
 # functional form is used for each of its different parameter types. This is
@@ -1342,7 +1350,7 @@ class GromacsTopologyFile(Structure):
             now = datetime.now()
             dest.write('''\
 ;
-;   File %swas generated
+;   File %s was generated
 ;   By user: %s (%d)
 ;   On host: %s
 ;   At date: %s
@@ -1356,10 +1364,9 @@ class GromacsTopologyFile(Structure):
 ;   Command line:
 ;     %s
 ;
-''' % (fname, pwd.getpwuid(os.getuid())[0], os.getuid(), os.uname()[1],
-       now.strftime('%a. %B  %w %X %Y'), os.path.split(sys.argv[0])[1],
-       __version__, os.path.split(sys.argv[0])[1], gmx.GROMACS_TOPDIR,
-       ' '.join(sys.argv)))
+''' % (fname, _username, _userid, _uname, now.strftime('%a. %B  %w %X %Y'),
+       os.path.split(sys.argv[0])[1], __version__, os.path.split(sys.argv[0])[1],
+       gmx.GROMACS_TOPDIR, ' '.join(sys.argv)))
             dest.write('\n[ defaults ]\n')
             dest.write('; nbfunc        comb-rule       gen-pairs       '
                         'fudgeLJ fudgeQQ\n')

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -36,15 +36,18 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 
-if sys.platform.startswith('win'):
-    _username = os.getlogin()   # pragma: no cover
-    _userid = 0                 # pragma: no cover
-    _uname = 'Windows'          # pragma: no cover
-else:
+try:
     import pwd
     _username = pwd.getpwuid(os.getuid())[0]
     _userid = os.getuid()
     _uname = os.uname()[1]
+except ImportError:    
+    import getpass
+    _username = getpass.getuser()   # pragma: no cover
+    _userid = 0                     # pragma: no cover
+    import platform                 # pragma: no cover
+    _uname = platform.node()        # pragma: no cover
+
 
 # Gromacs uses "funct" flags in its parameter files to indicate what kind of
 # functional form is used for each of its different parameter types. This is


### PR DESCRIPTION
All the tests except one pass on windows.  (and the failing test is not my fault:)

```
================================== FAILURES ===================================
_____________________ TestRegistry.test_load_file_errors ______________________

self = <test_parmed_formats.TestRegistry testMethod=test_load_file_errors>

    def test_load_file_errors(self):
        """ Test error handling in load_file """
        fn = get_fn('test.file', written=True)
        with open(fn, 'w') as f:
            pass
        os.chmod(fn, int('311', 8))
>       self.assertRaises(IOError, lambda: formats.load_file(fn))

test\test_parmed_formats.py:1934:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test\test_parmed_formats.py:1934: in <lambda>
    self.assertRaises(IOError, lambda: formats.load_file(fn))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

filename = 'c:\\gits\\ParmEd\\test\\files\\writes\\test.file', args = ()
kwargs = {}, name = 'PSFFile', cls = <class 'parmed.formats.psf.PSFFile'>

    def load_file(filename, *args, **kwargs):
        """
        Identifies the file format of the specified file and returns its parsed
        contents.

        Parameters
        ----------
        filename : str
            The name of the file to try to parse. If the filename starts with
            http:// or https:// or ftp://, it is treated like a URL and the file will be
            loaded directly from its remote location on the web
        structure : object, optional
            For some classes, such as the Mol2 file class, the default return object
            is not a Structure, but can be made to return a Structure if the
            ``structure=True`` keyword argument is passed. To facilitate writing
            easy code, the ``structure`` keyword is always processed and only passed
            on to the correct file parser if that parser accepts the structure
            keyword. There is no default, as each parser has its own default.
        natom : int, optional
            This is needed for some coordinate file classes, but not others. This is
            treated the same as ``structure``, above. It is the # of atoms expected
        hasbox : bool, optional
            Same as ``natom``, but indicates whether the coordinate file has unit
            cell dimensions
        *args : other positional arguments
            Some formats accept positional arguments. These will be passed along
        **kwargs : other options
            Some formats can only be instantiated with other options besides just a
            file name.

        Returns
        -------
        object
            The returned object is the result of the parsing function of the class
            associated with the file format being parsed

        Notes
        -----
        Compressed files are supported and detected by filename extension. This
        applies both to local and remote files. The following names are supported:

            - ``.gz`` : gzip compressed file
            - ``.bz2`` : bzip2 compressed file

        Raises
        ------
        IOError
            If ``filename`` does not exist

        parmed.exceptions.FormatNotFound
            If no suitable file format can be identified, a TypeError is raised

        TypeError
            If the identified format requires additional arguments that are not
            provided as keyword arguments in addition to the file name
        """
        global PARSER_REGISTRY, PARSER_ARGUMENTS

        # Check that the file actually exists and that we can read it
        if filename.startswith('http://') or filename.startswith('https://')\
                or filename.startswith('ftp://'):
            # This raises IOError if it does not exist; assert silences linters
            with closing(genopen(filename)) as f:
                assert f
        elif not os.path.exists(filename):
            raise IOError('%s does not exist' % filename)
        elif not os.access(filename, os.R_OK):
            raise IOError('%s does not have read permissions set' % filename)

        for name, cls in iteritems(PARSER_REGISTRY):
            if not hasattr(cls, 'id_format'):
                continue
            try:
                if cls.id_format(filename):
                    break
            except UnicodeDecodeError:
                continue
        else:
            # We found no file format
>           raise FormatNotFound('Could not identify file format')
E           FormatNotFound: Could not identify file format

parmed\formats\registry.py:136: FormatNotFound
============= 1 failed, 643 passed, 159 skipped in 225.45 seconds =============
```