### PR TITLE
Fix setuptools install

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ try:
         sys.argv.remove('--no-setuptools')
         raise ImportError() # Don't import setuptools...
     from setuptools import setup, Extension
-    from setuptools.command.clean import clean as Clean
     kws = dict(entry_points={
             'console_scripts' : ['parmed = parmed.scripts:clapp'],
             'gui_scripts' : ['xparmed = parmed.scripts:guiapp']}
@@ -22,6 +21,7 @@ except ImportError:
     kws = {'scripts' : [os.path.join('scripts', 'parmed'),
                         os.path.join('scripts', 'xparmed')]
     }
+from distutils.command.clean import clean as Clean
 
 class CleanCommand(Clean):
     """python setup.py clean

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ try:
     )
 except ImportError:
     from distutils.core import setup, Extension
-    from distutils.command.clean import clean as Clean
     kws = {'scripts' : [os.path.join('scripts', 'parmed'),
                         os.path.join('scripts', 'xparmed')]
     }
+
 from distutils.command.clean import clean as Clean
 
 class CleanCommand(Clean):


### PR DESCRIPTION
setuptools.command.clean does not exist. It didn't fail because the exception
catching just made setup.py fall back on distutils even when setuptools was
available.