### PR TITLE
Added a copy option to load_parameters

### DIFF
--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -448,7 +448,7 @@ class CharmmPsfFile(Structure):
 
     #===================================================
 
-    def load_parameters(self, parmset):
+    def load_parameters(self, parmset, copy=True):
         """
         Loads parameters from a parameter set that was loaded via CHARMM RTF,
         PAR, and STR files.
@@ -457,6 +457,10 @@ class CharmmPsfFile(Structure):
         ----------
         parmset : :class:`CharmmParameterSet`
             List of all parameters
+
+        copy : bool
+            if False, parmset will not be copied. This will silently modify the references to types in the structure
+            type_list so use with caution. Default is True
 
         Notes
         -----
@@ -473,7 +477,8 @@ class CharmmPsfFile(Structure):
         ------
         ParameterError if any parameters cannot be found
         """
-        parmset = _copy(parmset)
+        if copy:
+            parmset = _copy(parmset)
         self.combining_rule = parmset.combining_rule
         # First load the atom types
         for atom in self.atoms:

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -448,7 +448,7 @@ class CharmmPsfFile(Structure):
 
     #===================================================
 
-    def load_parameters(self, parmset, copy=True):
+    def load_parameters(self, parmset, copy_parameters=True):
         """
         Loads parameters from a parameter set that was loaded via CHARMM RTF,
         PAR, and STR files.
@@ -458,9 +458,31 @@ class CharmmPsfFile(Structure):
         parmset : :class:`CharmmParameterSet`
             List of all parameters
 
-        copy : bool
-            if False, parmset will not be copied. This will silently modify the references to types in the structure
-            type_list so use with caution. Default is True
+        copy_parameters : bool
+            if False, parmset will not be copied.
+
+            Warning:
+            -------
+            Not copying parmset will allow ParameterSet and Structure to share reference to types.
+            If you modify the original parameter set, the references in Structure list_types will be silently modified.
+            However, if you change any reference in the parameter set, then that reference will no longer be shared with
+            structure.
+
+            Example where the reference in ParameterSet is changed. This will NOT modify the paraemters in the psf.
+
+            psf.load_parameters(parmset, copy_parameters=False)
+            parmset.dihedral_type[('a1', 'a2', a3', a4)] = DihedralType(1, 2, 3)
+
+            This WILL change the parameter in the psf because the reference has not been changed in ParameterSet
+
+            psf.load_parameters(parmset, copy_parameters=False)
+
+            d = parmset.dihedral_types[('a1', 'a2', 'a3', 'a4')]
+            d.phi_k = 10
+            d.per = 2
+            d.phase = 180
+
+            Use with caution!
 
         Notes
         -----
@@ -477,7 +499,7 @@ class CharmmPsfFile(Structure):
         ------
         ParameterError if any parameters cannot be found
         """
-        if copy:
+        if copy_parameters:
             parmset = _copy(parmset)
         self.combining_rule = parmset.combining_rule
         # First load the atom types

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -461,26 +461,34 @@ class CharmmPsfFile(Structure):
         copy_parameters : bool
             if False, parmset will not be copied.
 
-            Warning:
+            WARNING:
             -------
-            Not copying parmset will allow ParameterSet and Structure to share reference to types.
+            Not copying parmset will cause ParameterSet and Structure to share references to types.
             If you modify the original parameter set, the references in Structure list_types will be silently modified.
             However, if you change any reference in the parameter set, then that reference will no longer be shared with
             structure.
 
-            Example where the reference in ParameterSet is changed. This will NOT modify the paraemters in the psf.
+            Example where the reference in ParameterSet is changed. This will NOT modify the parameters in the psf.
 
             psf.load_parameters(parmset, copy_parameters=False)
-            parmset.dihedral_type[('a1', 'a2', a3', a4)] = DihedralType(1, 2, 3)
+            parmset.angle_types[('a1', 'a2', a3')] = AngleType(1, 2)
 
             This WILL change the parameter in the psf because the reference has not been changed in ParameterSet
 
             psf.load_parameters(parmset, copy_parameters=False)
 
-            d = parmset.dihedral_types[('a1', 'a2', 'a3', 'a4')]
-            d.phi_k = 10
-            d.per = 2
-            d.phase = 180
+            a = parmset.angle_types[('a1', 'a2', 'a3')]
+            a.k_k = 10
+            d.theteq = 100
+
+            Extra care should be taken when trying this with dihedral_types. Since dihedral_type is a Fourier sequence,
+            ParameterSet stores DihedralType for every term in DihedralTypeList. Therefore, the example below will STILL
+            modify the type in the Structure list_types.
+
+            parmset.dihedral_types[('a', 'b', 'c', 'd')][0] = DihedralType(1, 2, 3)
+
+            This assigns a new instance of DihedralType to an existing DihedralTypeList that ParameterSet and Structure
+            are tracking and the shared reference is NOT changed.
 
             Use with caution!
 

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -478,7 +478,7 @@ class CharmmPsfFile(Structure):
             psf.load_parameters(parmset, copy_parameters=False)
 
             a = parmset.angle_types[('a1', 'a2', 'a3')]
-            a.k_k = 10
+            a.k = 10
             d.theteq = 100
 
             Extra care should be taken when trying this with dihedral_types. Since dihedral_type is a Fourier sequence,

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -479,7 +479,7 @@ class CharmmPsfFile(Structure):
 
             a = parmset.angle_types[('a1', 'a2', 'a3')]
             a.k = 10
-            d.theteq = 100
+            a.theteq = 100
 
             Extra care should be taken when trying this with dihedral_types. Since dihedral_type is a Fourier sequence,
             ParameterSet stores DihedralType for every term in DihedralTypeList. Therefore, the example below will STILL


### PR DESCRIPTION
This PR adds the option not to create a deep copy of the ```ParameterSet``` when calling ```load_parameter```. This save substantial time as profiled here: https://github.com/choderalab/torsionfit/pull/25#issuecomment-209653537