### PR TITLE
Add useful information to log file

### DIFF
--- a/parmed/__init__.py
+++ b/parmed/__init__.py
@@ -6,7 +6,7 @@ between standard and amber file formats, manipulate structures, etc.
 # Version format should be "major.minor.patch". For beta releases, attach
 # "-beta#" to the end. The beta number will be turned into another number in the
 # version tuple
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 __author__ = 'Jason Swails'
 
 __all__ = ['exceptions', 'periodic_table', 'residue', 'unit', 'utils',

--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -458,37 +458,42 @@ class CharmmPsfFile(Structure):
         parmset : :class:`CharmmParameterSet`
             List of all parameters
 
-        copy_parameters : bool
-            if False, parmset will not be copied.
+        copy_parameters : bool, optional, default=True
+            If False, parmset will not be copied.
 
             WARNING:
             -------
-            Not copying parmset will cause ParameterSet and Structure to share references to types.
-            If you modify the original parameter set, the references in Structure list_types will be silently modified.
-            However, if you change any reference in the parameter set, then that reference will no longer be shared with
-            structure.
+            Not copying parmset will cause ParameterSet and Structure to share
+            references to types.  If you modify the original parameter set, the
+            references in Structure list_types will be silently modified.
+            However, if you change any reference in the parameter set, then that
+            reference will no longer be shared with structure.
 
-            Example where the reference in ParameterSet is changed. This will NOT modify the parameters in the psf.
+            Example where the reference in ParameterSet is changed. The
+            following will NOT modify the parameters in the psf::
 
-            psf.load_parameters(parmset, copy_parameters=False)
-            parmset.angle_types[('a1', 'a2', a3')] = AngleType(1, 2)
+                psf.load_parameters(parmset, copy_parameters=False)
+                parmset.angle_types[('a1', 'a2', a3')] = AngleType(1, 2)
 
-            This WILL change the parameter in the psf because the reference has not been changed in ParameterSet
+            The following WILL change the parameter in the psf because the
+            reference has not been changed in ``ParameterSet``::
 
-            psf.load_parameters(parmset, copy_parameters=False)
+                psf.load_parameters(parmset, copy_parameters=False)
+                a = parmset.angle_types[('a1', 'a2', 'a3')]
+                a.k = 10
+                a.theteq = 100
 
-            a = parmset.angle_types[('a1', 'a2', 'a3')]
-            a.k = 10
-            a.theteq = 100
+            Extra care should be taken when trying this with dihedral_types.
+            Since dihedral_type is a Fourier sequence, ParameterSet stores
+            DihedralType for every term in DihedralTypeList. Therefore, the
+            example below will STILL modify the type in the :class:`Structure`
+            list_types::
 
-            Extra care should be taken when trying this with dihedral_types. Since dihedral_type is a Fourier sequence,
-            ParameterSet stores DihedralType for every term in DihedralTypeList. Therefore, the example below will STILL
-            modify the type in the Structure list_types.
+                parmset.dihedral_types[('a', 'b', 'c', 'd')][0] = DihedralType(1, 2, 3)
 
-            parmset.dihedral_types[('a', 'b', 'c', 'd')][0] = DihedralType(1, 2, 3)
-
-            This assigns a new instance of DihedralType to an existing DihedralTypeList that ParameterSet and Structure
-            are tracking and the shared reference is NOT changed.
+            This assigns a new instance of DihedralType to an existing
+            DihedralTypeList that ParameterSet and Structure are tracking and
+            the shared reference is NOT changed.
 
             Use with caution!
 


### PR DESCRIPTION
Closes #676 

Here's an example of the new behavior.  Using the following command-line:

```
parmed -p tip4p.parm7 -c tip4p.rst7 -p propane.pdb -p tripos9.mol2
```

Gives the following start to the log file:

```
# Log started on 04/14/2016 [mm/dd/yyyy] at 21:26:53
# Command line arguments: -p tip4p.parm7 -c tip4p.rst7 -p propane.pdb -p tripos9.mol2
# Loaded topologies: tip4p.parm7, propane.pdb, tripos9.mol2
```