### PR TITLE
Add TER card writing and HETATM writing where appropriate in PDB files

### DIFF
--- a/parmed/formats/pqr.py
+++ b/parmed/formats/pqr.py
@@ -7,7 +7,7 @@ from contextlib import closing
 import numpy as np
 from parmed.exceptions import PDBError, PDBWarning
 from parmed.formats.registry import FileFormatType
-from parmed.formats.pdb import _standardize_resname, PDBFile
+from parmed.formats.pdb import _standardize_resname, PDBFile, _is_hetatm
 from parmed.periodic_table import AtomicNum, Mass, Element, element_by_name
 from parmed.structure import Structure
 from parmed.topologyobjects import Atom, ExtraPoint
@@ -257,6 +257,7 @@ class PQRFile(object):
             own_handle = True
         atomrec = ('ATOM  %5d %-3s  %-3s %1s %3d    %7.3f %7.3f %7.3f %8.4f '
                    '%8.4f\n')
+        hetatomrec = atomrec.replace('ATOM  ', 'HETATM')
         if struct.box is not None:
             dest.write('CRYST1 %8.3f %8.3f %8.3f %6.2f %6.2f %6.2f\n' % (
                     struct.box[0], struct.box[1], struct.box[2], struct.box[3],
@@ -274,7 +275,7 @@ class PQRFile(object):
         if standard_resnames:
             standardize = lambda x: _standardize_resname(x)
         else:
-            standardize = lambda x: x
+            standardize = lambda x: (x, _is_hetatm(x))
         last_number = 0
         last_rnumber = 0
         for model, coord in enumerate(coords):
@@ -302,10 +303,14 @@ class PQRFile(object):
                     else:
                         aname = atom.name
                     xyz = coord[atom.idx]
-                    dest.write(atomrec % (anum, aname, standardize(res.name),
-                                          res.chain, rnum, xyz[0], xyz[1],
-                                          xyz[2], atom.charge,
-                                          atom.solvent_radius))
+                    resname, hetatm = standardize(res.name)
+                    if hetatm:
+                        rec = hetatomrec
+                    else:
+                        rec = atomrec
+                    dest.write(rec % (anum, aname, resname, res.chain, rnum,
+                                      xyz[0], xyz[1], xyz[2], atom.charge,
+                                      atom.solvent_radius))
             if coords.shape[0] > 1:
                 dest.write('ENDMDL\n')
 

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -984,11 +984,11 @@ class TestPDBStructure(FileIOTestCase):
 
     def test_private_functions(self):
         """ Tests the private helper functions in parmed/formats/pdb.py """
-        self.assertEqual(formats.pdb._standardize_resname('ASH'), 'ASP')
-        self.assertEqual(formats.pdb._standardize_resname('CYX'), 'CYS')
-        self.assertEqual(formats.pdb._standardize_resname('RA'), 'A')
-        self.assertEqual(formats.pdb._standardize_resname('DG'), 'DG')
-        self.assertEqual(formats.pdb._standardize_resname('BLA'), 'BLA')
+        self.assertEqual(formats.pdb._standardize_resname('ASH'), ('ASP', False))
+        self.assertEqual(formats.pdb._standardize_resname('CYX'), ('CYS', False))
+        self.assertEqual(formats.pdb._standardize_resname('RA'), ('A', False))
+        self.assertEqual(formats.pdb._standardize_resname('DG'), ('DG', False))
+        self.assertEqual(formats.pdb._standardize_resname('BLA'), ('BLA', True))
 
     def test_deprecations(self):
         fn = get_fn('blah', written=True)


### PR DESCRIPTION
(and CIF files for the HETATM cards).

This improves compatibility of ParmEd-generated PDB files with both Amber *and*
Tinker, which requires residues like HOH/WAT and ions to be HETATM instead of
ATOM.

Closes #355 