### PR TITLE
Improve atomic number prediction for XYZ files

### DIFF
--- a/parmed/tinker/tinkerfiles.py
+++ b/parmed/tinker/tinkerfiles.py
@@ -165,24 +165,29 @@ class XyzFile(Structure):
         if len(words) == 6 and not XyzFile._check_atom_record(words):
             self.box = [float(w) for w in words]
             words = fxyz.readline().split()
-        atom = Atom(atomic_number=AtomicNum[element_by_name(words[1])],
-                    name=words[1], type=words[5])
-        atom.xx, atom.xy, atom.xz = [float(w) for w in words[2:5]]
         residue = Residue('SYS')
         residue.number = 1
         residue._idx = 0
         if seq is not None:
             residue = seqstruct.residues[0]
+            atomic_number = _guess_atomic_number(words[1], residue)
+        else:
+            atomic_number = AtomicNum[element_by_name(words[1])]
+        atom = Atom(atomic_number=atomic_number, name=words[1], type=words[5])
+        atom.xx, atom.xy, atom.xz = [float(w) for w in words[2:5]]
         self.add_atom(atom, residue.name, residue.number, residue.chain,
                       residue.insertion_code, residue.segid)
         bond_ids = [[int(w) for w in words[6:]]]
         for i, line in enumerate(fxyz):
             words = line.split()
-            atom = Atom(atomic_number=AtomicNum[element_by_name(words[1])],
-                        name=words[1], type=words[5])
-            atom.xx, atom.xy, atom.xz = [float(w) for w in words[2:5]]
             if seq is not None:
                 residue = seqstruct.atoms[i+1].residue
+                atomic_number = _guess_atomic_number(words[1], residue)
+            else:
+                atomic_number = AtomicNum[element_by_name(words[1])]
+            atom = Atom(atomic_number=atomic_number, name=words[1],
+                        type=words[5])
+            atom.xx, atom.xy, atom.xz = [float(w) for w in words[2:5]]
             self.add_atom(atom, residue.name, residue.number, residue.chain,
                           residue.insertion_code, residue.segid)
             bond_ids.append([int(w) for w in words[6:]])
@@ -194,7 +199,7 @@ class XyzFile(Structure):
                     self.bonds.append(Bond(atom, self.atoms[idx-1]))
         if own_handle_xyz:
             fxyz.close()
-      
+
 class DynFile(object):
     """ Reads and processes a Tinker DYN file """
     def __init__(self, fname=None):
@@ -249,7 +254,7 @@ class DynFile(object):
                 self.velocities = [[0.0, 0.0, 0.0] for i in range(self.natom)]
                 DynFile._read_section(f, self.velocities, self.natom)
                 if f.readline().strip() != 'Current Atomic Accelerations :':
-                    raise TinkerError('Could not find accelerations in %s ' % 
+                    raise TinkerError('Could not find accelerations in %s ' %
                                       fname)
                 self.accelerations = [[0.0, 0.0, 0.0]
                                       for i in range(self.natom)]
@@ -257,7 +262,7 @@ class DynFile(object):
                 if f.readline().strip() != 'Alternate Atomic Accelerations :':
                     raise TinkerError('Could not find old accelerations in %s' %
                                       fname)
-                self.old_accelerations = [[0.0, 0.0, 0.0] 
+                self.old_accelerations = [[0.0, 0.0, 0.0]
                                           for i in range(self.natom)]
                 DynFile._read_section(f, self.old_accelerations, self.natom)
             else:
@@ -286,3 +291,15 @@ def is_float(thing):
         return True
     except ValueError:
         return False
+
+def _guess_atomic_number(name, residue):
+    """ Guesses the atomic number """
+    # Special-case single-atom residues, which are almost always ions
+    name = ''.join(c for c in name if c.isalpha())
+    if len(residue.atoms) == 1:
+        if len(name) > 1:
+            try:
+                return AtomicNum[name[0].upper() + name[1].lower()]
+            except KeyError:
+                return AtomicNum[element_by_name(name)]
+    return AtomicNum[element_by_name(name)]

--- a/parmed/tinker/tinkerfiles.py
+++ b/parmed/tinker/tinkerfiles.py
@@ -197,6 +197,12 @@ class XyzFile(Structure):
             for idx in bonds:
                 if idx > i:
                     self.bonds.append(Bond(atom, self.atoms[idx-1]))
+        if seq is None:
+            # Try to improve atomic number prediction for monoatomic species
+            # (like ions) if no sequence as loaded
+            for atom in self.atoms:
+                if len(atom.bonds) == 0: # not bonded to anybody else
+                    atom.atomic_number = _guess_atomic_number(atom.name)
         if own_handle_xyz:
             fxyz.close()
 
@@ -292,11 +298,11 @@ def is_float(thing):
     except ValueError:
         return False
 
-def _guess_atomic_number(name, residue):
+def _guess_atomic_number(name, residue=None):
     """ Guesses the atomic number """
     # Special-case single-atom residues, which are almost always ions
     name = ''.join(c for c in name if c.isalpha())
-    if len(residue.atoms) == 1:
+    if residue is None or len(residue.atoms) == 1:
         if len(name) > 1:
             try:
                 return AtomicNum[name[0].upper() + name[1].lower()]

--- a/test/test_parmed_tinker.py
+++ b/test/test_parmed_tinker.py
@@ -11,8 +11,8 @@ from parmed.utils.six.moves import zip
 get_fn = utils.get_fn
 
 class TestTinkerFiles(unittest.TestCase):
-    
-    def testParameterFile(self):
+
+    def test_parameter_file(self):
         """ Tests parsing TINKER parameter files """
         param = parameterfile.AmoebaParameterSet(get_fn('amoeba09.prm'))
         attributes = {'angle-sextic': 2.2e-08, 'direct-13-scale': 1.0,
@@ -55,7 +55,7 @@ class TestTinkerFiles(unittest.TestCase):
 
         self.assertEqual(len(param.opbends), 35)
         self.assertAlmostEqual(param.opbends['60-62-0-0'].k, 107.9)
-        
+
         self.assertEqual(len(param.torsion_torsions), 0)
 
         self.assertEqual(len(param.urey_bradleys), 1)
@@ -65,7 +65,7 @@ class TestTinkerFiles(unittest.TestCase):
         self.assertEqual(len(param.multipoles), 17)
         self.assertTrue(not any(param.multipoles['2-0-0'].potential_terms))
 
-    def testAnalout(self):
+    def test_analout(self):
         """ Tests parsing Amber-style Tinker analout files """
         analout = system.TinkerAnalout(get_fn('jac.analout'))
         self.assertEqual(len(analout.atom_list), 23558)
@@ -93,11 +93,11 @@ class TestTinkerFiles(unittest.TestCase):
         self.assertEqual(analout.multipole_list[5].moment,
                          [0.2124, 0.0, 0.0, -0.1249, 0.03622, 0.0, -0.01437,
                           0.0, 0.0, -0.02185])
-        
+
         self.assertEqual(analout.pitors_list[5].atom1.type, 9)
         self.assertEqual(len(analout.pair12_list), 16569)
-    
-    def testXyz(self):
+
+    def test_xyz(self):
         """ Tests parsing Tinker XYZ files """
         self.assertTrue(tinkerfiles.XyzFile.id_format(get_fn('nma.xyz')))
         self.assertTrue(tinkerfiles.XyzFile.id_format(get_fn('2igd_924wat.xyz')))
@@ -119,8 +119,11 @@ class TestTinkerFiles(unittest.TestCase):
             self.assertEqual(r1.chain, r2.chain)
             self.assertEqual(r1.name, r2.name)
             self.assertEqual(r1.insertion_code, r2.insertion_code)
+        # Make sure NA ions are atomic number of sodium
+        for atom in xyz.view['NA',:].atoms:
+            self.assertEqual(atom.atomic_number, pmd.periodic_table.AtomicNum['Na'])
 
-    def testDyn(self):
+    def test_dyn(self):
         """ Tests parsing Tinker DYN files """
         dyn = tinkerfiles.DynFile(get_fn('nma.dyn'))
         self.assertEqual(dyn.natom, 2466)

--- a/test/test_parmed_tinker.py
+++ b/test/test_parmed_tinker.py
@@ -112,6 +112,7 @@ class TestTinkerFiles(unittest.TestCase):
         self.assertEqual(xyz.atoms[-1].type, '248')
         xyz = pmd.load_file(get_fn('2igd_924wat.xyz'), get_fn('2igd_924wat.pdb'))
         pdb = pmd.load_file(get_fn('2igd_924wat.pdb'))
+        xyz2 = pmd.load_file(get_fn('2igd_924wat.xyz'))
         self.assertEqual(len(pdb.atoms), len(xyz.atoms))
         self.assertEqual(len(pdb.residues), len(xyz.residues))
         for r1, r2 in zip(pdb.residues, xyz.residues):
@@ -121,6 +122,10 @@ class TestTinkerFiles(unittest.TestCase):
             self.assertEqual(r1.insertion_code, r2.insertion_code)
         # Make sure NA ions are atomic number of sodium
         for atom in xyz.view['NA',:].atoms:
+            self.assertEqual(atom.atomic_number, pmd.periodic_table.AtomicNum['Na'])
+        # Now make sure that NA ions are atomic number of sodium even if we
+        # don't load a PDB file
+        for atom in xyz2.view[:,'Na+']:
             self.assertEqual(atom.atomic_number, pmd.periodic_table.AtomicNum['Na'])
 
     def test_dyn(self):


### PR DESCRIPTION
This fixes atomic number identification for ions, which are identified as single atoms with no bonds.

Closes #482 