### PR TITLE
Fix issue where nonbonded tables didn't get set following `AmberParm.__getitem__`

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -1524,7 +1524,7 @@ class AmberParm(AmberFormat, Structure):
             data['RESIDUE_CHAINID'] = [res.chain for res in self.residues]
         if 'RESIDUE_ICODE' in data:
             data['RESIDUE_ICODE'] = [r.insertion_code for r in self.residues]
-        nmxrs = max([len(res) for res in self.residues])
+        nmxrs = max([len(res) for res in self.residues]) if self.residues else 0
         data['POINTERS'][NMXRS] = nmxrs
         self.pointers['NMXRS'] = nmxrs
 

--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -403,6 +403,17 @@ class AmberParm(AmberFormat, Structure):
             other.LJ_radius[atom.nb_idx-1] = atom.atom_type.rmin
             other.LJ_depth[atom.nb_idx-1] = atom.atom_type.epsilon
         other._add_standard_flags()
+        other.remake_parm()
+        other._set_nonbonded_tables()
+        # Add back the original L-J tables to restore any NBFIXes that may have
+        # been there
+        other.parm_data['LENNARD_JONES_ACOEF'] = \
+                self.parm_data['LENNARD_JONES_ACOEF'][:]
+        other.parm_data['LENNARD_JONES_BCOEF'] = \
+                self.parm_data['LENNARD_JONES_BCOEF'][:]
+        if 'LENNARD_JONES_CCOEF' in self.parm_data:
+            other.parm_data['LENNARD_JONES_CCOEF'] = \
+                    self.parm_data['LENNARD_JONES_CCOEF'][:]
         return other
 
     #===================================================

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -615,6 +615,17 @@ class TestReadParm(unittest.TestCase):
         self.assertEqual(parm.combining_rule, 'lorentz')
         self._standard_parm_tests(parm, has1012=True)
 
+    def test_getitem_nbtables(self):
+        """ Tests that nonbond tables are set correctly following slicing """
+        parm = load_file(get_fn('ash.parm7'), get_fn('ash.rst7'))
+        new = parm[list(range(len(parm.atoms)))]
+        self.assertEqual(len(parm.parm_data['NONBONDED_PARM_INDEX']),
+                         len(new.parm_data['NONBONDED_PARM_INDEX']))
+        self.assertEqual(len(parm.parm_data['LENNARD_JONES_ACOEF']),
+                         len(new.parm_data['LENNARD_JONES_ACOEF']))
+        self.assertEqual(len(parm.parm_data['LENNARD_JONES_BCOEF']),
+                         len(new.parm_data['LENNARD_JONES_BCOEF']))
+
     def test_bad_arguments(self):
         """ Test proper error handling for bad AmberParm arguments """
         self.assertRaises(TypeError, lambda:


### PR DESCRIPTION
Fixes #670 