### PR TITLE
Remember bond order where applicable

### DIFF
--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -127,7 +127,7 @@ class ResidueTemplate(object):
         self.atoms.append(atom)
         self._map[atom.name] = atom
 
-    def add_bond(self, atom1, atom2):
+    def add_bond(self, atom1, atom2, order=1.0):
         """ Adds a bond between the two provided atoms in the residue
 
         Parameters
@@ -140,6 +140,14 @@ class ResidueTemplate(object):
             The other atom in the bond. It must be in the ``atoms`` list of this
             ResidueTemplate. It can also be the atom index (index from 0) of the
             atom in the bond.
+        order : float
+            The bond order of this bond. Bonds are classified as follows:
+                1.0 -- single bond
+                2.0 -- double bond
+                3.0 -- triple bond
+                1.5 -- aromatic bond
+                1.25 -- amide bond
+            Default is 1.0
 
         Raises
         ------
@@ -163,7 +171,7 @@ class ResidueTemplate(object):
             raise RuntimeError('Both atoms must belong to template.atoms')
         # Do not add the same bond twice
         if atom1 not in atom2.bond_partners:
-            self.bonds.append(Bond(atom1, atom2))
+            self.bonds.append(Bond(atom1, atom2, order=order))
 
     @classmethod
     def from_residue(cls, residue):

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -1654,8 +1654,16 @@ class Bond(object):
         The first atom involved in the bond
     atom2 : :class:`Atom`
         The other atom involved in the bond
-    type : :class:`BondType`
-        The bond type that defines the parameters for this bond
+    type : :class:`BondType` or None, optional
+        The bond type that defines the parameters for this bond. Default is None
+    order : float, optional
+        The bond order of this bond. Bonds are classified as follows:
+            1.0 -- single bond
+            2.0 -- double bond
+            3.0 -- triple bond
+            1.5 -- aromatic bond
+            1.25 -- amide bond
+        Default is 1.0
 
     Notes
     -----
@@ -1673,7 +1681,7 @@ class Bond(object):
     True
     """
 
-    def __init__(self, atom1, atom2, type=None):
+    def __init__(self, atom1, atom2, type=None, order=1.0):
         """ Bond constructor """
         # Make sure we're not bonding me to myself
         if atom1 is atom2:
@@ -1687,6 +1695,8 @@ class Bond(object):
         atom1.bond_to(atom2)
         self.type = type
         self.funct = 1
+        self._order = None
+        self.order = order
 
     def __contains__(self, thing):
         """ Quick and easy way to see if an Atom is in this Bond """
@@ -1704,6 +1714,19 @@ class Bond(object):
         _delete_from_list(self.atom2._bond_partners, self.atom1)
 
         self.atom1 = self.atom2 = self.type = None
+
+    @property
+    def order(self):
+        """ Bond order. See description in :class:`Bond` argument list """
+        return self._order
+
+    @order.setter
+    def order(self, value):
+        """
+        Order of the bond. Must be a float, or ValueError or TypeError will be
+        raised
+        """
+        self._order = float(value)
 
     def __repr__(self):
         return '<%s %r--%r; type=%r>' % (type(self).__name__,

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1919,6 +1919,24 @@ class TestMol2File(FileIOTestCase):
         self.assertEqual(len(mol2.atoms), 89)
         self.assertEqual(len(mol2.bonds), 89)
 
+    def test_mol2_bond_order(self):
+        """ Tests that mol2 file parsing remembers bond order/type """
+        mol2 = formats.Mol2File.parse(get_fn('multimol.mol2'))[0]
+        fn = get_fn('test.mol2', written=True)
+        mol2.save(fn)
+        with open(fn, 'r') as f:
+            for line in f:
+                if line.startswith('@<TRIPOS>BOND'):
+                    break
+            # Collect all bond orders
+            bos = set()
+            for line in f:
+                if line.startswith('@<TRIPOS>'):
+                    break
+                bos.add(line.split()[3])
+        # This structure has bond orders 1, 2, am, and ar
+        self.assertEqual(bos, {'1', '2', 'am', 'ar'})
+
     @unittest.skipUnless(HAS_GROMACS, 'Cannot test without gromacs')
     def test_mol3_disulfide(self):
         """ Tests writing mol3 file w/ disulfide (for RESIDUECONNECT) """

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1936,6 +1936,9 @@ class TestMol2File(FileIOTestCase):
                 bos.add(line.split()[3])
         # This structure has bond orders 1, 2, am, and ar
         self.assertEqual(bos, {'1', '2', 'am', 'ar'})
+        mol2_2 = formats.Mol2File.parse(fn)
+        for b1, b2 in zip(mol2.bonds, mol2_2.bonds):
+            self.assertEqual(b1.order, b2.order)
 
     @unittest.skipUnless(HAS_GROMACS, 'Cannot test without gromacs')
     def test_mol3_disulfide(self):


### PR DESCRIPTION
This adds a new attribute "order" to the `Bond` class to remember the bond order.  So far, it's only specified in mol2 files, so this only affects saving mol2 files from residue templates or structures that have been created by parsing a mol2 file.

Whenever bond information is present *without* specifying an order (i.e., every file type *except* mol2 files), a bond order of 1.0 is assumed.

Still needs documentation.  This adds a test, though.

Fixes #691 