### PR TITLE
Improve atomic number assignment in Amber prmtop file

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -549,7 +549,10 @@ class AmberParm(AmberFormat, Structure):
             atom.solvent_radius = radii[i]
             atom.screen = screen[i]
             if replace_atnum or atom.atomic_number == 0:
-                atom.atomic_number = atnum[i]
+                if atnum[i] == -1:
+                    atom.atomic_number = AtomicNum[element_by_mass(mass[i])]
+                else:
+                    atom.atomic_number = atnum[i]
             atom.atom_type = AtomType(atyp[i], None, mass[i], atnum[i])
             atom.occupancy = occu[i]
             atom.bfactor = bfac[i]


### PR DESCRIPTION
In rare occasions, the Amber prmtop file misassigns some atomic numbers by setting the ATOMIC_NUMBER to -1.  This PR identifies those cases and replaces -1 with the atomic number guessed by finding the element with the closest mass.

This fixes an issue in hydrogen mass repartitioning reported by Alexey and Adrian in an email to me.