### PR TITLE
use self.angle_types instead of self.bond_types when replacing angle parameters

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -470,8 +470,8 @@ class CharmmParameterSet(ParameterSet):
                         warnings.warn('Replacing angle %r, %r with %r' %
                                       (key, self.angle_types[key], angle_type),
                                       ParameterWarning)
-                        self.bond_types[(type1, type2, type3)] = angle_type
-                        self.bond_types[(type3, type2, type1)] = angle_type
+                        self.angle_types[(type1, type2, type3)] = angle_type
+                        self.angle_types[(type3, type2, type1)] = angle_type
                 else: # key not present
                     self.angle_types[(type1, type2, type3)] = angle_type
                     self.angle_types[(type3, type2, type1)] = angle_type


### PR DESCRIPTION
When writing a CHARMM parameter file, I encountered an `AttibuteError` (see below) which I could track to lines 473 + 474 in file `parmed/charmm/parameters.py`: `angle_type` was stored in `self.bond_types` instead of `self.angle_types`.

```python
AttributeError                            Traceback (most recent call last)
<ipython-input-6-fa81f7d84e85> in <module>()
      8     print stream
      9     params.read_stream_file(stream)
---> 10     params.write(par='joined.prm')

/Users/chris/git/ParmEd/parmed/charmm/parameters.py in write(self, top, par, str)
    981             f.write('*>>>> CHARMM Parameter file generated by ParmEd <<<<\n')
    982             f.write('*\n\n')
--> 983             self._write_par_to(f)
    984             if ownhandle: f.close()
    985         if str is not None:

/Users/chris/git/ParmEd/parmed/charmm/parameters.py in _write_par_to(self, f)
   1032             written.add(key); written.add(tuple(reversed(key)))
   1033             f.write('%-6s %-6s %7.2f %10.4f\n' %
-> 1034                     (key[0], key[1], typ.k, typ.req))
   1035         f.write('\nANGLES\n')
   1036         written = set()

AttributeError: 'AngleType' object has no attribute 'req'
```
