### PR TITLE
Switch to using netCDF4 to write NetCDF files if it's available

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -27,7 +27,7 @@ else # Otherwise, CPython... go through conda
     if [ -z "$MINIMAL_PACKAGES" ]; then
         conda create -y -n myenv python=$PYTHON_VERSION \
             numpy scipy pandas nose openmm coverage nose-timer \
-            python-coveralls ambermini pysander rdkit
+            python-coveralls ambermini pysander rdkit netCDF4
         conda update -y -n myenv --all
         conda install -y -n myenv pyflakes=1.0.0
     else

--- a/test/test_parmed_netcdf.py
+++ b/test/test_parmed_netcdf.py
@@ -16,7 +16,7 @@ from utils import get_fn, FileIOTestCase, TestCaseRelative
 @skipIf(PYPY, 'NetCDF parsing does not yet work with pypy')
 class TestNetCDF(FileIOTestCase, TestCaseRelative):
     """ Test NetCDF Functionality """
-    
+
     def testNetCDF(self):
         """ Test scipy NetCDF parsing """
         traj = NetCDFTraj.open_old(get_fn('tz2.truncoct.nc'))
@@ -238,7 +238,7 @@ class TestNetCDF(FileIOTestCase, TestCaseRelative):
         self.assertAlmostEqual(rst.cell_angles[0], 109.471219)
         self.assertAlmostEqual(rst.cell_angles[1], 109.471219)
         self.assertAlmostEqual(rst.cell_angles[2], 109.471219)
-        self.assertTrue(all([round(x-y, 7) == 0 
+        self.assertTrue(all([round(x-y, 7) == 0
                              for x, y in zip(rst.cell_lengths, rst.box[:3])]))
-        self.assertTrue(all([round(x-y, 7) == 0 
+        self.assertTrue(all([round(x-y, 7) == 0
                              for x, y in zip(rst.cell_angles, rst.box[3:])]))


### PR DESCRIPTION
This is done because writing netCDF4 files is *way* faster than in pure Python
with scipy's version. This will fix the horrific performance issues seen with
the NetCDFReporter when running OpenMM GPU simulations.

Fixes #619 