### PR TITLE
Escape strings in gromacs .top comment

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1368,8 +1368,9 @@ class GromacsTopologyFile(Structure):
 ;     %s
 ;
 ''' % (fname, _username, _userid, _uname, now.strftime('%a. %B  %w %X %Y'),
-       os.path.split(sys.argv[0])[1], __version__, os.path.split(sys.argv[0])[1],
-       gmx.GROMACS_TOPDIR, ' '.join(sys.argv)))
+       os.path.split(sys.argv[0])[1], __version__,
+       os.path.split(sys.argv[0])[1], gmx.GROMACS_TOPDIR,
+       (' '.join(sys.argv)).encode('utf8').decode('unicode_escape')))
             dest.write('\n[ defaults ]\n')
             dest.write('; nbfunc        comb-rule       gen-pairs       '
                         'fudgeLJ fudgeQQ\n')


### PR DESCRIPTION
Fixes #729 

Might require some py2/3 compatibility tweaks