### PR TITLE
change overload to override in the ffxml tag

### DIFF
--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -70,11 +70,11 @@ class ResidueTemplate(object):
         atom of this residue when this residue is the last in a chain
     groups : list of list(:class:`Atom`)
         If set, each group is a list of Atom instances making up each group
-    overload_level : integer
+    override_level : integer
         For use with OpenMM ResidueTemplates. If OpenMM ForceField is given multiple
         identically-matching residue templates with the same names it choses
-        (overloads with) the one with the highest overload_level
-        (overloadLevel in OpenMM). Default is 0.
+        (overrides with) the one with the highest override_level
+        (overrideLevel in OpenMM). Default is 0.
     """
 
     def __init__(self, name=''):
@@ -89,7 +89,7 @@ class ResidueTemplate(object):
         self.first_patch = None
         self.last_patch = None
         self.groups = []
-        self.overload_level = 0
+        self.override_level = 0
 
     def __repr__(self):
         if self.head is not None:

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -272,11 +272,11 @@ class OpenMMParameterSet(ParameterSet):
             templhash = OpenMMParameterSet._templhasher(residue)
             if templhash in written_residues: continue
             written_residues.add(templhash)
-            if residue.overload_level == 0:
+            if residue.override_level == 0:
                 dest.write('  <Residue name="%s">\n' % residue.name)
             else:
                 dest.write('  <Residue name="%s" override="%d">\n' % (residue.name,
-                           residue.overload_level))
+                           residue.override_level))
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %
                            (atom.name, atom.type, atom.charge))

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -275,7 +275,7 @@ class OpenMMParameterSet(ParameterSet):
             if residue.overload_level == 0:
                 dest.write('  <Residue name="%s">\n' % residue.name)
             else:
-                dest.write('  <Residue name="%s" overload="%d">\n' % (residue.name,
+                dest.write('  <Residue name="%s" override="%d">\n' % (residue.name,
                            residue.overload_level))
             for atom in residue.atoms:
                 dest.write('   <Atom name="%s" type="%s" charge="%s"/>\n' %

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -559,8 +559,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 16)
 
-    def test_overload_level(self):
-        """Test correct support for the overload_level attribute of
+    def test_override_level(self):
+        """Test correct support for the override_level attribute of
            ResidueTemplates and correct writing to XML tag"""
         params = openmm.OpenMMParameterSet.from_parameterset(
                  pmd.amber.AmberParameterSet(get_fn('atomic_ions.lib'))
@@ -568,7 +568,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         new_residues = OrderedDict()
         new_residues['K'] = params.residues['K']
         new_residues['NA'] = params.residues['NA']
-        new_residues['K'].overload_level = 1
+        new_residues['K'].override_level = 1
         params.residues = new_residues
         ffxml = StringIO()
         params.write(ffxml)

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -574,7 +574,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         params.write(ffxml)
         ffxml.seek(0)
         output_lines = ffxml.readlines()
-        control_line1 = '  <Residue name="K" overload="1">\n'
+        control_line1 = '  <Residue name="K" override="1">\n'
         control_line2 = '  <Residue name="NA">\n'
         self.assertEqual(output_lines[5], control_line1)
         self.assertEqual(output_lines[8], control_line2)


### PR DESCRIPTION
Small change here, due to analogical change in OpenMM (https://github.com/pandegroup/openmm/commit/6ce433934296d05dfb08557c98746c073373d67b , also see https://github.com/choderalab/openmm/issues/17). 

Should I also change the `residue.overload_level` to be `residue.override_level` ? 