### PR TITLE
add visualization

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -34,7 +34,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv boost==1.59.0 -c omnia
         # uninstall parmed from ambermd
         conda uninstall -y parmed -n myenv
-        conda install nglview -y -c bioconda
+        conda install -y -n myenv nglview -c bioconda
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -34,6 +34,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv boost==1.59.0 -c omnia
         # uninstall parmed from ambermd
         conda uninstall -y parmed -n myenv
+        conda install nglview -c bioconda
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -34,7 +34,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv boost==1.59.0 -c omnia
         # uninstall parmed from ambermd
         conda uninstall -y parmed -n myenv
-        conda install nglview -c bioconda
+        conda install nglview -y -c bioconda
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1007,6 +1007,8 @@ class Structure(object):
         ----------
         args and kwargs : positional and keyword arguments given to nglview, optional
         """
+        if self.coordinates is None:
+            raise ValueError('coordinates must not be None')
         from nglview import show_parmed
         return show_parmed(self, *args, **kwargs)
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -995,6 +995,7 @@ class Structure(object):
 
     def visualize(self, *args, **kwargs):
         """Use nglview for visualization. This only works with Jupyter notebook
+        and require to install `nglview`
 
         Examples
         --------

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -993,6 +993,24 @@ class Structure(object):
 
     #===================================================
 
+    def visualize(self, *args, **kwargs):
+        """Use nglview for visualization. This only works with Jupyter notebook
+
+        Examples
+        --------
+        >>> import parmed as pmd
+        >>> parm = pmd.download_PDB('1tsu')
+        >>> parm.visualize()
+
+        Parameters
+        ----------
+        args and kwargs : positional and keyword arguments given to nglview, optional
+        """
+        from nglview import show_parmed
+        return show_parmed(self, *args, **kwargs)
+
+    #===================================================
+
     def __getitem__(self, selection):
         """
         Allows extracting a single atom from the structure or a slice of atoms

--- a/test/test_parmed_visualization.py
+++ b/test/test_parmed_visualization.py
@@ -50,3 +50,6 @@ class TestVisualization(unittest.TestCase):
         parm = pmd.load_file(get_fn('2koc.pdb'))
         view = parm.visualize()
         self.assertIsInstance(view, nglview.NGLWidget)
+        # test None
+        parm.coordinates = None
+        self.assertRaises(ValueError, parm.visualize)

--- a/test/test_parmed_visualization.py
+++ b/test/test_parmed_visualization.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+import sys
+import parmed as pmd
+import unittest
+
+from utils import get_fn
+
+try:
+    from ipywidgets import Widget
+    from ipykernel.comm import Comm
+    import nglview
+    has_nglview = True
+
+    #------------------------------------------------------
+    # Utility stuff from ipywidgets tests: create DummyComm
+    # we dont need Jupyter notebook for testing
+    #------------------------------------------------------
+    class DummyComm(Comm):
+        comm_id = 'a-b-c-d'
+    
+        def open(self, *args, **kwargs):
+            pass
+    
+        def send(self, *args, **kwargs):
+            pass
+    
+        def close(self, *args, **kwargs):
+            pass
+    
+    _widget_attrs = {}
+    displayed = []
+    undefined = object()
+
+    _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
+    Widget._comm_default = lambda self: DummyComm()
+    _widget_attrs['_ipython_display_'] = Widget._ipython_display_
+    def raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError()
+    Widget._ipython_display_ = raise_not_implemented
+except ImportError:
+    has_nglview = False
+    nglview = Comm = DummyComm = _widget_attrs = displayed = undefined = Widget  = None
+
+@unittest.skipUnless(has_nglview, "Only test if having nglview")
+class TestVisualization(unittest.TestCase):
+    """ Test visualization """
+
+    def test_visualization(self):
+        """ Test visualization with nglview """
+        parm = pmd.load_file(get_fn('2koc.pdb'))
+        view = parm.visualize()
+        self.assertIsInstance(view, nglview.NGLWidget)


### PR DESCRIPTION
I think it's convenient to add this. What do you think? 

```python
parm.visualize()
parm[':1-20'].visualize()
```

![parmed](https://cloud.githubusercontent.com/assets/4451957/18035690/80bd97ca-6d28-11e6-8678-7c75cb875cad.png)

There is no test yet since I am not sure if you are ok with this PR.

Another advantage is amber user can use `parmed` to visualize netcdf trajectory (and others) on window.