### PR TITLE
Replace `1/6` and similar expressions with `1.0/6`

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -796,7 +796,7 @@ class AmberParm(AmberFormat, Structure):
         self.LJ_radius = []  # empty LJ_radii so it can be re-filled
         self.LJ_depth = []   # empty LJ_depths so it can be re-filled
         self.LJ_types = {}   # empty LJ_types so it can be re-filled
-        one_sixth = 1 / 6    # we need to raise some numbers to the 1/6th power
+        one_sixth = 1.0/6    # we need to raise some numbers to the 1.0/6th power
 
         pd = self.parm_data
         acoef = pd['LENNARD_JONES_ACOEF']
@@ -838,9 +838,9 @@ class AmberParm(AmberFormat, Structure):
             comb_sig = lambda sig1, sig2: sqrt(sig1 * sig2)
         pd = self.parm_data
         ntypes = self.pointers['NTYPES']
-        fac = 2**(-1/6) * 2
+        fac = 2**(-1.0/6) * 2
         LJ_sigma = [x*fac for x in self.LJ_radius]
-        fac = 2**(1/6)
+        fac = 2**(1.0/6)
         for i in range(ntypes):
             for j in range(i, ntypes):
                 index = pd['NONBONDED_PARM_INDEX'][ntypes*i+j] - 1
@@ -875,11 +875,11 @@ class AmberParm(AmberFormat, Structure):
             comb_sig = lambda sig1, sig2: 0.5 * (sig1 + sig2)
         elif self.combining_rule == 'geometric':
             comb_sig = lambda sig1, sig2: sqrt(sig1 * sig2)
-        fac = 2**(-1/6) * 2
+        fac = 2**(-1.0/6) * 2
         LJ_sigma = [x*fac for x in self.LJ_radius]
         pd = self.parm_data
         ntypes = self.parm_data['POINTERS'][NTYPES]
-        fac = 2**(1/6)
+        fac = 2**(1.0/6)
         for i in range(ntypes):
             for j in range(ntypes):
                 idx = pd['NONBONDED_PARM_INDEX'][ntypes*i+j] - 1
@@ -1784,7 +1784,7 @@ class AmberParm(AmberFormat, Structure):
             bcoef = self.parm_data['LENNARD_JONES_BCOEF']
         nbidx = self.parm_data['NONBONDED_PARM_INDEX']
         ntypes = self.parm_data['POINTERS'][NTYPES]
-        sigma_scale = 2**(-1/6) * length_conv
+        sigma_scale = 2**(-1.0/6) * length_conv
         for ii in range(nonbfrc.getNumExceptions()):
             i, j, qq, ss, ee = nonbfrc.getExceptionParameters(ii)
             if qq.value_in_unit(u.elementary_charge**2) == 0 and (
@@ -1814,8 +1814,8 @@ class AmberParm(AmberFormat, Structure):
                 epsilon = 0.0
                 sigma = 0.5
             elif idx >= 0:
-                # b / a == 2 / r^6 --> (a / b * 2)^(1/6) = rmin
-                rmin = (a / b * 2)**(1/6)
+                # b / a == 2 / r^6 --> (a / b * 2)^(1.0/6) = rmin
+                rmin = (a / b * 2)**(1.0/6)
                 epsilon = b / (2 * rmin**6) * ene_conv * one_scnb
                 sigma = rmin * sigma_scale
             nonbfrc.setExceptionParameters(ii, i, j, qq, sigma, epsilon)
@@ -1877,7 +1877,7 @@ class AmberParm(AmberFormat, Structure):
                 comb_sig = lambda sig1, sig2: 0.5 * (sig1 + sig2)
             elif self.combining_rule == 'geometric':
                 comb_sig = lambda sig1, sig2: sqrt(sig1 * sig2)
-            fac = 2**(1/6)
+            fac = 2**(1.0/6)
             for dihedral in self.dihedrals:
                 if dihedral.ignore_end: continue
                 key = tuple(sorted([dihedral.atom1, dihedral.atom4]))
@@ -1918,7 +1918,7 @@ class AmberParm(AmberFormat, Structure):
             comb_sig = lambda sig1, sig2: 0.5 * (sig1 + sig2)
         elif self.combining_rule == 'geometric':
             comb_sig = lambda sig1, sig2: sqrt(sig1 * sig2)
-        fac = 2**(1/6)
+        fac = 2**(1.0/6)
         for atom in self.atoms:
             if isinstance(atom, ExtraPoint): continue
             for batom in atom.bond_partners:

--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -291,7 +291,7 @@ class ChamberParm(AmberParm):
 
         self.LJ_14_radius = []  # empty LJ_radii so it can be re-filled
         self.LJ_14_depth = []   # empty LJ_depths so it can be re-filled
-        one_sixth = 1.0 / 6.0 # we need to raise some numbers to the 1/6th power
+        one_sixth = 1.0 / 6.0 # we need to raise some numbers to the 1.0/6th power
 
         for i in range(ntypes):
             lj_index = self.parm_data["NONBONDED_PARM_INDEX"][ntypes*i+i] - 1

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -381,10 +381,10 @@ class GromacsTopologyFile(Structure):
                     sig, eps = (float(x) for x in words[3:5])
                     sig *= 10 # Convert to Angstroms
                     eps *= u.kilojoule.conversion_factor_to(u.kilocalorie)
-                    params.nbfix_types[(a1, a2)] = (eps, sig*2**(1/6))
-                    params.nbfix_types[(a2, a1)] = (eps, sig*2**(1/6))
-                    params.atom_types[a1].add_nbfix(a2, sig*2**(1/6), eps)
-                    params.atom_types[a2].add_nbfix(a1, sig*2**(1/6), eps)
+                    params.nbfix_types[(a1, a2)] = (eps, sig*2**(1.0/6))
+                    params.nbfix_types[(a2, a1)] = (eps, sig*2**(1.0/6))
+                    params.atom_types[a1].add_nbfix(a2, sig*2**(1.0/6), eps)
+                    params.atom_types[a2].add_nbfix(a1, sig*2**(1.0/6), eps)
                 elif current_section == 'bondtypes':
                     a, b, t = self._parse_bondtypes(line)
                     params.bond_types[(a, b)] = t
@@ -523,7 +523,7 @@ class GromacsTopologyFile(Structure):
         nbe.funct = funct
         nbet = None
         if funct == 1 and len(words) >= 5:
-            sig = float(words[3]) * 2**(1/6)
+            sig = float(words[3]) * 2**(1.0/6)
             eps = float(words[4])
             if (sig, eps) in exc_types:
                 nbe.type = exc_types[(sig, eps)]
@@ -753,7 +753,7 @@ class GromacsTopologyFile(Structure):
         eps = float(words[sigidx+1]) * u.kilojoules_per_mole
         typ = AtomType(attype, None, mass, atnum,
                        bond_type=bond_type, charge=chg)
-        typ.set_lj_params(eps, sig*2**(1/6)/2)
+        typ.set_lj_params(eps, sig*2**(1.0/6)/2)
         return attype, typ
 
     def _parse_bondtypes(self, line):
@@ -857,7 +857,7 @@ class GromacsTopologyFile(Structure):
         a1, a2 = words[:2]
 #       funct = int(words[2]) # ... unused
         cs6, cs12 = (float(x) for x in words[3:5])
-        cs6 *= u.nanometers * 2**(1/6)
+        cs6 *= u.nanometers * 2**(1.0/6)
         cs12 *= u.kilojoules_per_mole
         return a1, a2, NonbondedExceptionType(cs6, cs12, self.defaults.fudgeQQ)
 
@@ -975,7 +975,7 @@ class GromacsTopologyFile(Structure):
                     eps = math.sqrt(pair.atom1.epsilon * pair.atom2.epsilon)
                     sig = 0.5 * (pair.atom1.sigma + pair.atom2.sigma)
                 eps *= self.defaults.fudgeLJ
-                pairtype = NonbondedExceptionType(sig*2**(1/6), eps,
+                pairtype = NonbondedExceptionType(sig*2**(1.0/6), eps,
                             self.defaults.fudgeQQ, list=self.adjust_types)
                 self.adjust_types.append(pairtype)
                 pair.type = pairtype

--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -382,7 +382,7 @@ def _process_nonbonded(struct, force):
             typemap[key] = atom_type = AtomType(atype_name, None, atom.mass,
                                                 atom.atomic_number)
         atom.charge = chg.value_in_unit(u.elementary_charge)
-        rmin = sig.value_in_unit(u.angstroms) * 2**(1/6) / 2 # to rmin/2
+        rmin = sig.value_in_unit(u.angstroms) * 2**(1.0/6) / 2 # to rmin/2
         eps = eps.value_in_unit(u.kilocalories_per_mole)
         atom_type.set_lj_params(eps, rmin)
         atom.atom_type = atom_type
@@ -417,7 +417,7 @@ def _process_nonbonded(struct, force):
                 raise TypeError('Cannot scale charge product of 0 to match '
                                 '%s' % q)
             chgscale = 1
-        nbtype = NonbondedExceptionType(sig*2**(1/6), eps, chgscale)
+        nbtype = NonbondedExceptionType(sig*2**(1.0/6), eps, chgscale)
         struct.adjusts.append(NonbondedException(ai, aj, type=nbtype))
         struct.adjust_types.append(nbtype)
     struct.adjust_types.claim()

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -2552,7 +2552,7 @@ class Structure(object):
                              nonbondedMethod)
         force.setReactionFieldDielectric(reactionFieldDielectric)
         # Now add the particles
-        sigma_scale = length_conv * 2 * 2**(-1/6)
+        sigma_scale = length_conv * 2 * 2**(-1.0/6)
         for atom in self.atoms:
             force.addParticle(atom.charge, atom.sigma*length_conv,
                               abs(atom.epsilon*ene_conv))
@@ -2581,7 +2581,7 @@ class Structure(object):
         # Add the exceptions from the dihedral list IFF no explicit exceptions
         # (or *adjusts*) have been specified. If dihedral.ignore_end is False, a
         # 1-4 with the appropriate scaling factor is used as the exception.
-        sigma_scale = 2**(-1/6) * length_conv
+        sigma_scale = 2**(-1.0/6) * length_conv
         if self.combining_rule == 'lorentz':
             comb_sig = lambda sig1, sig2: 0.5 * (sig1 + sig2)
         elif self.combining_rule == 'geometric':

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -2217,7 +2217,7 @@ class printLJMatrix(Action):
                 if bcoef == 0 or acoef == 0:
                     rij = eij = 0.0
                 else:
-                    rij = (2 * acoef / bcoef) ** (1 / 6)
+                    rij = (2 * acoef / bcoef) ** (1.0/6)
                     eij = (bcoef * bcoef / (4 * acoef))
                 if has_1264:
                     ret_str.append('%%%ds %%%ds %%15.6f %%15.6f %%15.6f %%10.6f %%10.6f\n' %

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -626,11 +626,11 @@ class Atom(_ListItem):
     @property
     def sigma(self):
         """ Lennard-Jones sigma parameter -- directly related to Rmin """
-        return self.rmin * 2**(-1/6) * 2
+        return self.rmin * 2**(-1.0/6) * 2
 
     @sigma.setter
     def sigma(self, value):
-        self._rmin = value * 2**(1/6) / 2
+        self._rmin = value * 2**(1.0/6) / 2
 
     @property
     def epsilon(self):
@@ -669,12 +669,12 @@ class Atom(_ListItem):
             if (self.atom_type is UnassignedAtomType or
                     self.atom_type.rmin_14 is None):
                 return self.sigma
-            return self.atom_type.rmin_14 * 2**(-1/6) * 2
-        return self._rmin14 * 2**(-1/6) * 2
+            return self.atom_type.rmin_14 * 2**(-1.0/6) * 2
+        return self._rmin14 * 2**(-1.0/6) * 2
 
     @sigma_14.setter
     def sigma_14(self, value):
-        self._rmin14 = value * 2**(1/6) / 2
+        self._rmin14 = value * 2**(1.0/6) / 2
 
     @property
     def epsilon_14(self):
@@ -4404,11 +4404,11 @@ class NonbondedExceptionType(_ParameterType, _ListItem):
 
     @property
     def sigma(self):
-        return self.rmin * 2**(-1/6)
+        return self.rmin * 2**(-1.0/6)
 
     @sigma.setter
     def sigma(self, value):
-        self.rmin = value * 2**(1/6)
+        self.rmin = value * 2**(1.0/6)
 
     def __repr__(self):
         return '<%s; rmin=%.4f, epsilon=%.4f, chgscale=%.4f>' % (
@@ -4509,7 +4509,7 @@ class AtomType(object):
         If set, it is the Lennard-Jones Rmin/2 parameter of this atom type in
         1-4 nonbonded interactions
     sigma : ``float``
-        This is the sigma parameter, which is just equal to Rmin*2^(1/6)
+        This is the sigma parameter, which is just equal to Rmin*2^(1.0/6)
     nbfix : ``dict(str:tuple)``
         A hash that maps atom type names of other atom types with which _this_
         atom type has a defined NBFIX with a tuple containing the terms
@@ -4661,21 +4661,21 @@ class AtomType(object):
 
     @property
     def sigma(self):
-        """ Sigma is Rmin / 2^(1/6) """
-        return self.rmin * 2**(-1/6) * 2
+        """ Sigma is Rmin / 2^(1.0/6) """
+        return self.rmin * 2**(-1.0/6) * 2
 
     @sigma.setter
     def sigma(self, value):
-        self.rmin = value * 2**(1/6) / 2
+        self.rmin = value * 2**(1.0/6) / 2
 
     @property
     def sigma_14(self):
-        """ Sigma is Rmin / 2^(1/6) """
-        return self.rmin_14 * 2**(-1/6) * 2
+        """ Sigma is Rmin / 2^(1.0/6) """
+        return self.rmin_14 * 2**(-1.0/6) * 2
 
     @sigma_14.setter
     def sigma_14(self, value):
-        self.rmin_14 = value * 2**(1/6) / 2
+        self.rmin_14 = value * 2**(1.0/6) / 2
 
     def __str__(self):
         return self.name

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -255,7 +255,7 @@ class TestTopologyObjects(unittest.TestCase):
         lja1.atom_type.set_lj_params(1.0, 2.0, 1.1, 2.1)
         self.assertEqual(lja1.epsilon, 1.0)
         self.assertEqual(lja1.rmin, 2.0)
-        self.assertEqual(lja1.sigma, 2.0*2**(-1/6)*2)
+        self.assertEqual(lja1.sigma, 2.0*2**(-1.0/6)*2)
         lja2 = Atom(atomic_number=6, name='C2', type='CT', charge=0.1,
                     mass=12.01, nb_idx=1, solvent_radius=1.8, tree='M')
         lja2.sigma = 1.0
@@ -263,13 +263,13 @@ class TestTopologyObjects(unittest.TestCase):
         self.assertEqual(lja2.sigma_14, 1.0)
         lja2.sigma_14 = 1.5
         self.assertEqual(lja2.sigma_14, 1.5)
-        self.assertEqual(lja2.rmin_14, 1.5*2**(1/6)/2)
-        self.assertAlmostEqual(lja2.rmin, 2**(1/6)/2)
+        self.assertEqual(lja2.rmin_14, 1.5*2**(1.0/6)/2)
+        self.assertAlmostEqual(lja2.rmin, 2**(1.0/6)/2)
         lja3 = Atom(atomic_number=6, name='C3', type='CT', charge=0.0,
                     mass=12.01, nb_idx=1, solvent_radius=1.8, tree='M')
         lja3.atom_type = AtomType('CX', 2, 12.01, 6)
         lja3.atom_type.set_lj_params(2.0, 3.0)
-        self.assertEqual(lja3.sigma_14, 3*2**(-1/6)*2)
+        self.assertEqual(lja3.sigma_14, 3*2**(-1.0/6)*2)
 #       lja4 = Atom(atomic_number=6, name='C4', type='CT', charge=-0.1,
 #                   mass=12.01, nb_idx=1, solvent_radius=1.8, tree='M')
 #       lja5 = Atom(atomic_number=6, name='C2', type='CT', charge=0.1,
@@ -736,11 +736,11 @@ class TestTopologyObjects(unittest.TestCase):
         self.assertEqual(atype.rmin, 1.2)
         self.assertEqual(atype.epsilon_14, 1.0)
         self.assertEqual(atype.rmin_14, 1.2)
-        self.assertEqual(atype.sigma, 1.2*2**(-1/6)*2)
+        self.assertEqual(atype.sigma, 1.2*2**(-1.0/6)*2)
         self.assertEqual(atype.sigma_14, atype.sigma)
         # Now try setting sigma and make sure it also changes rmin
         atype.sigma = 1.2
-        self.assertEqual(atype.rmin, 1.2*2**(1/6)/2)
+        self.assertEqual(atype.rmin, 1.2*2**(1.0/6)/2)
         atom.atom_type = atype
         self.assertEqual(atom.epsilon, atype.epsilon)
         self.assertEqual(atom.sigma, atype.sigma)
@@ -1773,11 +1773,11 @@ class TestTopologyObjects(unittest.TestCase):
         # Now add the type
         nbet = NonbondedExceptionType(1.0, 2.0, chgscale=3.0)
         nbet2 = NonbondedExceptionType(1.1, 2.0, chgscale=3.0)
-        self.assertEqual(nbet.sigma, 2**(-1/6))
+        self.assertEqual(nbet.sigma, 2**(-1.0/6))
         self.assertEqual(nbet, nbet)
         self.assertNotEqual(nbet, nbet2)
         nbet2.sigma = 1.0
-        self.assertEqual(nbet2.rmin*2**(-1/6), nbet2.sigma)
+        self.assertEqual(nbet2.rmin*2**(-1.0/6), nbet2.sigma)
         nbe.type = nbet
         self.assertEqual(repr(nbe), '<NonbondedException; %r and %r, type=%r>' %
                          (a1, a2, nbet))


### PR DESCRIPTION
There are quite a few instances of the expression `1/6` being used for the value of one sixth, especially when raising to the 1/6th power such as when converting between sigma and r_min. Being integer division, `1/6` evaluates to 0. Worse still, `2**(1/6)` evaluates to 1 rather than 1.12246... so that you could end up with force parameters that kind of look right but aren't. It is possible that the error was not detected by tests because some test files contained the same mistake.

I made the replacements through brute-force use of sed, searching for `1/6` and `1 / 6`. I can't guarantee I didn't miss any similar unintentional integer divisions.