### PR TITLE
Fix OFF writing for residues with many connections

### DIFF
--- a/parmed/amber/offlib.py
+++ b/parmed/amber/offlib.py
@@ -531,7 +531,7 @@ class AmberOFFLibrary(object):
             conn = [c, c+len(r)-1, 0, 0, 0, 0]
             if r.head is not None: conn[0] = r.head.idx + 1
             if r.tail is not None: conn[1] = r.tail.idx + 1
-            for i, at in enumerate(r.connections):
+            for i, at in enumerate(r.connections[:4]):
                 conn[i+2] = at.idx + 1
             dest.write(' %d %d %d %d %d %d\n' % tuple(conn))
             c += len(r)


### PR DESCRIPTION
The connection list in OFF files is only 6 characters, and the 1st two elements
are reserved for the head and tail atoms. In very rare cases where there are too
many connections, this may throw an IndexError. This fixes the IndexError by not
writing the atoms that don't "fit" in the line.