### PR TITLE
Have the chamber action change water names to WAT and O 

### DIFF
--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3854,7 +3854,7 @@ class chamber(Action):
         elif self.box is not None:
             retstr += ' Box info %s.' % (self.box)
         retstr += ' GB Radius set %s.' % self.radii
-        if nosettle:
+        if self.nosettle:
             retstr += ' Not changing water names.'
         return retstr
 

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3717,7 +3717,8 @@ class chamber(Action):
         - -radii      Implicit solvent solvation radii. <radiusset> can be
                       amber6, bondi, mbondi, mbondi2, mbondi3
                       Same effect as the changeRadii command. Default is mbondi.
-        - nocondense  This no longer has any effect and is ignored.
+        - nosettle    This avoids changing the names of the water residue and
+                      oxygen atoms from TIP3 and OH2 to WAT and O
 
     If the PDB file has a CRYST1 record, the box information will be set from
     there. Any box info given on the command-line will override the box found in
@@ -3725,7 +3726,7 @@ class chamber(Action):
     """
     usage = ('-top <RTF> -param <PAR> [-str <STR>] -psf <PSF> [-crd <CRD>] '
              '[-nocmap] [-box a,b,c[,alpha,beta,gamma]|bounding] [-radii '
-             '<radiusset>]')
+             '<radiusset>] [nosettle]')
     needs_parm = False
 
     def init(self, arg_list):
@@ -3828,6 +3829,7 @@ class chamber(Action):
             raise InputError('Illegal radius set %s -- must be one of '
                              '%s' % (self.radii, ', '.join(GB_RADII)))
         arg_list.has_key('nocondense')
+        self.nosettle = arg_list.has_key('nosettle')
 
     def __str__(self):
         retstr = 'Creating chamber topology file from PSF %s, ' % self.psf
@@ -3852,6 +3854,8 @@ class chamber(Action):
         elif self.box is not None:
             retstr += ' Box info %s.' % (self.box)
         retstr += ' GB Radius set %s.' % self.radii
+        if nosettle:
+            retstr += ' Not changing water names.'
         return retstr
 
     def execute(self):
@@ -3945,6 +3949,15 @@ class chamber(Action):
         changeRadii(parm, self.radii).execute()
         self.parm_list.add_parm(parm)
         self.parm = parm
+        if not self.nosettle:
+            # Change water residue names from TIP3 to WAT and OH2 to O
+            for res, nam in zip(parm.residues, parm.parm_data['RESIDUE_LABEL']):
+                if nam != 'TIP3':
+                    continue
+                res.name = parm.parm_data['RESIDUE_LABEL'][res.idx] = 'WAT'
+                for atom in res:
+                    if atom.name == 'OH2':
+                        atom.name = parm.parm_data['ATOM_NAME'][atom.idx] = 'O'
 
 #+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -346,6 +346,15 @@ class TestNonParmActions(FileIOTestCase):
         parm = a.parm
         for x, y in zip(parm.parm_data['BOX_DIMENSIONS'], [90] + [33]*3):
             self.assertEqual(x, y)
+        has_wat = False
+        for res in parm.residues:
+            self.assertNotEqual(res.name, 'TIP3')
+            if res.name == 'WAT':
+                has_wat = True
+                names = [a.name for a in res]
+                self.assertNotIn('OH2', names)
+                self.assertIn('O', names)
+        self.assertTrue(has_wat)
 
     @unittest.skipUnless(HAS_GROMACS, "Cannot run GROMACS tests without GROMACS")
     def test_gromber(self):


### PR DESCRIPTION
This is necessary to get SETTLE to work on Amber with the default values of
WATNAM and OWTNM. (these can always be changed to TIP3 and OH2 to get SETTLE to
work regardless).

Addresses suggestion by @dacase