### PR TITLE
Fix erroneous warnings with ANISOU records

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -25,7 +25,7 @@ import warnings
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-def _compare_atoms(old_atom, new_atom, resname, resid, chain, segid):
+def _compare_atoms(old_atom, new_atom, resname, resid, chain, segid, inscode):
     """
     Compares two atom instances, along with the residue name, number, and chain
     identifier, to determine if two atoms are actually the *same* atom, but
@@ -45,6 +45,8 @@ def _compare_atoms(old_atom, new_atom, resname, resid, chain, segid):
         The chain identifier that the new atom would belong to
     segid : ``str``
         The segment identifier for the molecule
+    inscode : ``str``
+        The insertion code for the residue
 
     Returns
     -------
@@ -55,6 +57,7 @@ def _compare_atoms(old_atom, new_atom, resname, resid, chain, segid):
     if old_atom.residue.number != resid: return False
     if old_atom.residue.chain != chain.strip(): return False
     if old_atom.residue.segid != segid.strip(): return False
+    if old_atom.residue.insertion_code != inscode.strip(): return False
     return True
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -443,8 +446,8 @@ class PDBFile(object):
                                 charge=chg, mass=mass, occupancy=occupancy,
                                 bfactor=bfactor, altloc=altloc, number=atnum)
                     atom.xx, atom.xy, atom.xz = float(x), float(y), float(z)
-                    if (_compare_atoms(last_atom, atom, resname,
-                                       resid, chain, segid) and altloc):
+                    if (_compare_atoms(last_atom, atom, resname, resid, chain,
+                                       segid, inscode) and altloc):
                         atom.residue = last_atom.residue
                         last_atom.other_locations[altloc] = atom
                         altloc_ids.add(atom.number)
@@ -483,7 +486,7 @@ class PDBFile(object):
                         warnings.warn('Problem parsing residue number from '
                                       'ANISOU record', PDBWarning)
                         continue # Skip the rest of this record
-                    icode = line[27].strip()
+                    icode = line[26].strip()
                     try:
                         u11 = int(line[28:35])
                         u22 = int(line[35:42])
@@ -1221,7 +1224,7 @@ class CIFFile(object):
                                 altloc=altloc, number=atnum)
                 atom.xx, atom.xy, atom.xz = x, y, z
                 if (_compare_atoms(last_atom, atom, resname, resnum,
-                                   chain, '')
+                                   chain, '', inscode)
                         and altloc):
                     atom.residue = last_atom.residue
                     last_atom.other_locations[altloc] = atom

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -284,6 +284,10 @@ class TestPDBStructure(FileIOTestCase):
         warnings.filterwarnings('always', category=exceptions.PDBWarning)
         FileIOTestCase.tearDown(self)
 
+    def test_pdb_anisou_inscode(self):
+        """ Tests that PDB files with ANISOU records on inscodes work """
+        download_PDB('1gdu')
+
     def test_pdb_format_detection(self):
         """ Tests PDB file detection from contents """
         fn = get_fn('test.pdb', written=True)
@@ -1006,27 +1010,27 @@ class TestPDBStructure(FileIOTestCase):
         pdbfile = get_fn('4lzt.pdb')
         parm = pmd.load_file(pdbfile)
         remark_290_lines = """
-REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
-REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
-REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000
 """
         assert_remark_290(parm, remark_290_lines)
 
         # 2idg
         parm = pmd.download_PDB('2igd')
         remark_290_lines = """
-REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
-REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
-REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
-REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       17.52500            
-REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
-REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       21.18500            
-REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
-REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       20.25000            
-REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       21.18500            
-REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       17.52500            
-REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       20.25000            
-REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000    
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       17.52500
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       21.18500
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       20.25000
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       21.18500
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       17.52500
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       20.25000
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000
 """
         assert_remark_290(parm, remark_290_lines)
 


### PR DESCRIPTION
The mistake was very dumb.  I was parsing the insertion code from ANISOU records in the 28th character field instead of the 27th.

This might also fix another bug when two residues with different insertion codes come right after each other but are the same kind of residue.