### PR TITLE
Read velocities from amber files if available

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -217,7 +217,7 @@ class AmberParm(AmberFormat, Structure):
             if not hasattr(f, 'coordinates') or f.coordinates is None:
                 raise TypeError('%s does not have coordinates' % xyz)
             self.coordinates = f.coordinates
-            if hasattr(f, 'velocities') and f.coordinates is not None:
+            if hasattr(f, 'velocities') and f.velocities is not None:
                 self.velocities = f.velocities
             if hasattr(f, 'box') and f.box is not None and box is None:
                 self.box = f.box

--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -217,6 +217,8 @@ class AmberParm(AmberFormat, Structure):
             if not hasattr(f, 'coordinates') or f.coordinates is None:
                 raise TypeError('%s does not have coordinates' % xyz)
             self.coordinates = f.coordinates
+            if hasattr(f, 'velocities') and f.coordinates is not None:
+                self.velocities = f.velocities
             if hasattr(f, 'box') and f.box is not None and box is None:
                 self.box = f.box
         else:


### PR DESCRIPTION
I encountered this while playing with one of the InterMol amber [input files](https://github.com/shirtsgroup/InterMol/blob/master/intermol/tests/amber/stress_tests/solv/solv.rst7). This fix appears to work for my use case but I am not very familiar with the amber portions of ParmEd. Will this interfere with anything else?