### PR TITLE
Fix writing PDB file with standard residue names

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -65,7 +65,7 @@ def _compare_atoms(old_atom, new_atom, resname, resid, chain, segid, inscode):
 def _standardize_resname(resname):
     """ Looks up a standardized residue name for the given resname """
     try:
-        return AminoAcidResidue.get(resname).abbr, False
+        return AminoAcidResidue.get(resname, abbronly=True).abbr, False
     except KeyError:
         try:
             return RNAResidue.get(resname).abbr, False
@@ -1589,7 +1589,7 @@ def _needs_ter_card(res):
     """
     # First see if it's in the list of standard biomolecular residues. If so,
     # and it has no tail, no TER is needed
-    std_resname = _standardize_resname(res.name)
+    std_resname = _standardize_resname(res.name)[0]
     if std_resname in StandardBiomolecularResidues:
         is_std_res = True
         if StandardBiomolecularResidues[std_resname].tail is None:

--- a/parmed/residue.py
+++ b/parmed/residue.py
@@ -101,7 +101,7 @@ class AminoAcidResidue(BiomolecularResidue):
                 self.symbol)
 
     @classmethod
-    def get(cls, key):
+    def get(cls, key, abbronly=False):
         """
         Gets the amino acid corresponding to either the residue name, 3-letter
         abbreviation or 1-letter symbol. It is case-insensitive.
@@ -110,6 +110,9 @@ class AminoAcidResidue(BiomolecularResidue):
         ----------
         key : str
             1-letter symbol, 3-letter abbreviation, or residue name
+        abbronly : bool
+            If True, only look for the 3-letter abbreviation (not the 1-letter
+            symbol)
 
         Returns
         -------
@@ -121,7 +124,7 @@ class AminoAcidResidue(BiomolecularResidue):
         KeyError if ``key`` is not a symbol, abbreviation, or case-insensitive
         name of an amino acid residue, or any of its abbreviations.
         """
-        if len(key) == 1:
+        if len(key) == 1 and not abbronly:
             return cls._all_residues_by_symbol[key.upper()]
         if len(key) == 3:
             return cls._all_residues_by_abbr[key.upper()]

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1080,6 +1080,13 @@ REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000
         self.assertEqual(formats.pdb._standardize_resname('BLA'), ('BLA', True))
         self.assertEqual(formats.pdb._standardize_resname('WAT'), ('HOH', True))
         self.assertEqual(formats.pdb._standardize_resname('TIP3'), ('HOH', True))
+        # Make sure standard residues return themselves
+        for res in residue.AminoAcidResidue.all_residues:
+            self.assertEqual(formats.pdb._standardize_resname(res.abbr), (res.abbr, False))
+        for res in residue.DNAResidue.all_residues:
+            self.assertEqual(formats.pdb._standardize_resname(res.abbr), (res.abbr, False))
+        for res in residue.RNAResidue.all_residues:
+            self.assertEqual(formats.pdb._standardize_resname(res.abbr), (res.abbr, False))
 
     def test_deprecations(self):
         fn = get_fn('blah', written=True)


### PR DESCRIPTION
Reported by @dacase:

The _standarize_resname() funtion in parmed/formats/pdb.py (in the master
branch at SDSC)  does this:

```python
def _standardize_resname(resname):
    """ Looks up a standardized residue name for the given resname """
    try:
        return AminoAcidResidue.get(resname).abbr, False
    except KeyError:
        try:
            return RNAResidue.get(resname).abbr, False
        except KeyError:
            try:
                return DNAResidue.get(resname).abbr, False
            except KeyError:
                return resname, True
```

Problem is that the AminoAcidResidue class knows that "G" is a "symbol"
for GLY.  So if the above code sees "G" as a resname, it notes that the key
length is 1, thinks resname is a symbol, and returns the glycine residue.

So write_pdb with standard_resnames=True fails when given RNA, since "G" gets
assigned to glycine before having a chance to get assigned to guanosine.