### PR TITLE
Fix mask parsing errors when there is leading or trailing whitespace.

### DIFF
--- a/parmed/amber/mask.py
+++ b/parmed/amber/mask.py
@@ -11,7 +11,7 @@ from parmed.utils.six.moves import range
 #+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 class AmberMask(object):
-    """ 
+    """
     What is hopefully a fully-fledged Amber mask parser implemented in Python.
 
     Parameters
@@ -26,8 +26,8 @@ class AmberMask(object):
 
     def __init__(self, parm, mask):
         self.parm = parm
-        self.mask = mask
-      
+        self.mask = mask.strip()
+
     #======================================================
 
     def __str__(self):
@@ -37,7 +37,7 @@ class AmberMask(object):
 
     def Selected(self, invert=False):
         """ Generator that returns the indexes of selected atoms
-        
+
         Parameters
         ----------
         invert : bool, optional
@@ -123,7 +123,7 @@ class AmberMask(object):
         while i < len(self.mask):
             p = self.mask[i]
             # skip whitespace
-            if p.isspace(): 
+            if p.isspace():
                 i += 1
                 continue
             # If p is an operator, is the last character, or is a ()...
@@ -210,11 +210,11 @@ class AmberMask(object):
                 if flag == 1:
                     n += 1
             i += 1
-      
+
         return infix + '_' # terminating _ for next step
 
     #======================================================
-   
+
     def _isOperator(self, char):
         """ Determines if a character is an operator """
         return len(char) == 1 and char in '!&|<>'
@@ -224,7 +224,7 @@ class AmberMask(object):
     def _isOperand(self, char):
         """ Determines if a character is an operand """
         return len(char) == 1 and (char in "\\*/%-?,'.=+" or char.isalnum())
-   
+
     #======================================================
 
     def _torpn(self, infix, prnlev):
@@ -344,7 +344,7 @@ class AmberMask(object):
         return pmask
 
     #======================================================
-   
+
     def _neg(self, pmask1):
         """ Negates a given mask """
         return pmask1.Not()
@@ -421,7 +421,7 @@ class AmberMask(object):
                 buffer += p
                 buffer_p += 1
                 if p == '*' and ptoken[pos-1] != '\\':
-                    if buffer_p == 1 and (pos == len(ptoken) - 1 or 
+                    if buffer_p == 1 and (pos == len(ptoken) - 1 or
                                           ptoken[pos+1] == ','):
                         reslist = ALL
                     elif reslist == NUMLIST:
@@ -493,7 +493,7 @@ class AmberMask(object):
             if p.isdigit():
                 buffer += p
             if p == ',' or pos == len(instring) - 1:
-                if dash == 0: 
+                if dash == 0:
                     at1 = int(buffer)
                     self._atnum_select(at1, at1, mask)
                 else:
@@ -557,7 +557,7 @@ class AmberMask(object):
             if p.isdigit():
                 buffer += p
             if p == ',' or pos == len(instring) - 1:
-                if dash == 0: 
+                if dash == 0:
                     at1 = int(buffer)
                     self._resnum_select(at1, at1, mask)
                 else:
@@ -596,13 +596,13 @@ class AmberMask(object):
             pos += 1
 
     #======================================================
-   
+
     def _atnum_select(self, at1, at2, mask):
         """ Fills a _mask array between atom numbers at1 and at2 """
         for i in range(at1-1, at2): mask[i] = 1
 
     #======================================================
-   
+
     def _resnum_select(self, res1, res2, mask):
         """ Fills a _mask array between residues res1 and res2 """
         for i, atom in enumerate(self.parm.atoms):
@@ -610,7 +610,7 @@ class AmberMask(object):
             if res >= res1 and res <= res2: mask[i] = 1
 
     #======================================================
-   
+
     def _atname_select(self, atname, mask, key='name'):
         """ Fills a _mask array with all atom names of a given name """
         if atname.isdigit():
@@ -629,7 +629,7 @@ class AmberMask(object):
                 mask[i] = mask[i] | int(_nameMatch(atname, getattr(atom, key)))
 
     #======================================================
-   
+
     def _resname_select(self, resname, mask):
         """ Fills a _mask array with all residue names of a given name """
         for i, atm in enumerate(self.parm.atoms):
@@ -637,9 +637,9 @@ class AmberMask(object):
                 mask[i] = 1
             elif resname.isdigit():
                 mask[i] = mask[i] | int(int(resname) == atm.residue.idx + 1)
-            
+
     #======================================================
-   
+
     def _binop(self, op, pmask1, pmask2):
         """ Does a binary operation on a pair of masks """
         if op == '&':
@@ -667,8 +667,8 @@ def _nameMatch(atnam1, atnam2):
     """
     Determines if atnam1 matches atnam2, where atnam1 can have * as a wildcard
     and spaces are ignored. atnam2 should come from the prmtop. We'll use regex
-    to do this. 
-   
+    to do this.
+
     We will replace * with a regex that will match any alphanumeric character
     0 or more times: * --> \\w*
 
@@ -715,7 +715,7 @@ class _mask(list):
         raise MaskError('_mask is a fixed-length array!')
 
     def And(self, other):
-        if self.natom != other.natom: 
+        if self.natom != other.natom:
             raise MaskError("_mask: and() requires another mask of equal size!")
         new_mask = _mask(self.natom)
         for i in range(len(self)):
@@ -729,7 +729,7 @@ class _mask(list):
         for i in range(len(self)):
             new_mask[i] = int(self[i] or other[i])
         return new_mask
-   
+
     def Not(self):
         new_mask = _mask(self.natom)
         for i in range(self.natom):

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -1483,7 +1483,9 @@ class printBonds(Action):
     """
     Prints all of the bonds (with their details) for the given atoms in the
     mask. If a second mask is given, only bonds in which one atom appears in
-    *each* list will be printed.
+    *each* list will be printed. If coordinates and parameter types are present,
+    also print the actual distance (in Angstroms) and energy (in kcal/mol) for
+    each printed bond.
     """
     usage = '[<mask> [<mask>] ]'
     def init(self, arg_list):
@@ -1540,7 +1542,10 @@ class printAngles(Action):
     mask. If a second mask is given, only atoms whose central atom is in the
     second mask and another atom is in the first mask is printed. If a third
     mask is given, the central atom must be in the second mask and the other two
-    atoms must appear in the first *and* third masks (in any order)
+    atoms must appear in the first *and* third masks (in any order).
+
+    If coordinates and parameter types are present, the value of the angle (in
+    degrees) and its energy (in kcal/mol) are reported for each printed angle.
     """
     usage = '[<mask> [<mask> [<mask>] ] ]'
     def init(self, arg_list):
@@ -1639,6 +1644,10 @@ class printDihedrals(Action):
     mask are printed. Ordering is important here, so the first atom must be in
     the first mask, the second atom in the second, etc. The order can be
     precisely reversed, but no other ordering is recognized.
+
+    If coordinates and parameter types are present, the value of the torsion
+    angle (in degrees) and the energy of each dihedral (in kcal/mol) are
+    reported for each printed dihedral.
     """
     usage = '[<mask> [<mask> [<mask> [<mask>] ] ] ]'
     def init(self, arg_list):

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -1679,6 +1679,7 @@ class TestAmberMask(unittest.TestCase):
         mask_wldcrd6 = mask.AmberMask(parm, '@*')
         mask_wldcrd7 = mask.AmberMask(parm, '@CA|@*')
         mult_op = mask.AmberMask(parm, '(!:1&@CA)|!:2')
+        mask_res12 = mask.AmberMask(parm, ':1 | :2 ')
 
         # Check all of the masks
         self.assertEqual(sum(mask_res1.Selection(prnlev=9)), 13)
@@ -1818,6 +1819,8 @@ class TestAmberMask(unittest.TestCase):
                     self.assertEqual(val, 0)
             else:
                 self.assertEqual(val, 1)
+
+        self.assertEqual({parm.atoms[i].residue.idx for i in mask_res12.Selected()}, {0, 1})
 
     def test_illegal_masks(self):
         """ Test bad mask strings """


### PR DESCRIPTION
- Add documentation to printBonds|Angles|Dihedrals giving details about
the units that are used for the measurements
- Add a test for the fix