### PR TITLE
add space_group to cif

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -1419,6 +1419,11 @@ class CIFFile(object):
             cell.appendAttribute('angle_gamma')
             cell.append(struct.box[:])
             cont.append(cell)
+        # symmetry
+        sym = containers.DataCategory('symmetry')
+        sym.appendAttribute('space_group_name_H-M')
+        sym.append(struct.space_group)
+        cont.append(sym)
         if coordinates is not None:
             coords = np.array(coordinates, copy=False, subok=True)
             try:

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -1422,7 +1422,7 @@ class CIFFile(object):
         # symmetry
         sym = containers.DataCategory('symmetry')
         sym.appendAttribute('space_group_name_H-M')
-        sym.append(struct.space_group)
+        sym.append([struct.space_group])
         cont.append(sym)
         if coordinates is not None:
             coords = np.array(coordinates, copy=False, subok=True)

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -1321,9 +1321,6 @@ class CIFFile(object):
                             atom.anisou = None
                         warnings.warn('Problem processing anisotropic '
                                       'B-factors. Skipping', PDBWarning)
-            symmetry_obj = cont.getObj('symmetry')
-            if symmetry_obj is not None:
-                struct.space_group = symmetry_obj.getRow(0)[1]
             if xyz:
                 if len(xyz) != len(struct.atoms) * 3:
                     raise ValueError('Corrupt CIF; all models must have the '

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -1259,13 +1259,16 @@ class CIFFile(object):
                 alphaid = cell.getAttributeIndex('angle_alpha')
                 betaid = cell.getAttributeIndex('angle_beta')
                 gammaid = cell.getAttributeIndex('angle_gamma')
-                spaceid = cell.getAttributeIndex('space_group_name_H-M')
                 row = cell.getRow(0)
                 struct.box = np.array(
                         [float(row[aid]), float(row[bid]), float(row[cid]),
                          float(row[alphaid]), float(row[betaid]),
                          float(row[gammaid])]
                 )
+            symmetry = cont.getObj('symmetry')
+            if symmetry is not None:
+                spaceid = symmetry.getAttributeIndex('space_group_name_H-M')
+                row = symmetry.getRow(0)
                 if spaceid != -1:
                     struct.space_group = row[spaceid]
             # Check for anisotropic B-factors

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1585,6 +1585,14 @@ class TestCIFStructure(FileIOTestCase):
         """ Tests that symmetry is parsed from mmCIF files correctly """
         self.assertEqual(download_CIF('1aki').space_group, 'P 21 21 21')
 
+    def test_cif_space_group_written_from_structure(self):
+        parm = pmd.load_file(get_fn('SCM_A.pdb'))
+        self.assertEqual(parm.space_group, 'P 1 21 1')
+        written = get_fn('test.cif', written=True)
+        parm.write_cif(written)
+        parm2 = pmd.load_file(written)
+        self.assertEqual(parm2.space_group, 'P 1 21 1')
+
     def test_cif_models(self):
         """ Test CIF parsing/writing NMR structure with 20 models (2koc) """
         cif = download_CIF('2koc')

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1581,6 +1581,10 @@ class TestCIFStructure(FileIOTestCase):
         self.assertRaises(ValueError, lambda: download_CIF('illegal'))
         self.assertRaises(IOError, lambda: download_CIF('#@#%'))
 
+    def test_cif_symmetry(self):
+        """ Tests that symmetry is parsed from mmCIF files correctly """
+        self.assertEqual(download_CIF('1aki').space_group, 'P 21 21 21')
+
     def test_cif_models(self):
         """ Test CIF parsing/writing NMR structure with 20 models (2koc) """
         cif = download_CIF('2koc')


### PR DESCRIPTION
The code does not work yet. Can you help? :D 

```python
import parmed as pmd

parm = pmd.load_file('SCM_A.pdb')
print(parm.space_group)

parm.save('test.cif', overwrite=True)
print(pmd.load_file('test.cif').space_group)
```

output
```
P 1 21 1
P 1
```