### PR TITLE
Add option to name types based on OpenMM Atom.id

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -28,7 +28,7 @@ else # Otherwise, CPython... go through conda
     if [ -z "$MINIMAL_PACKAGES" ]; then
         conda create -y -n myenv python=$PYTHON_VERSION \
             numpy scipy pandas nose openmm coverage nose-timer \
-            python-coveralls ambermini netCDF4
+            python-coveralls ambermini=16.16 netCDF4
         conda update -y -n myenv --all
         conda install -y -n myenv pyflakes=1.0.0
         conda install -y -n myenv rdkit==2015.09.1 -c omnia

--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -44,6 +44,9 @@ def load_topology(topology, system=None, xyz=None, box=None, use_atom_id_as_type
         information unless ``box`` (below) is also specified
     box : array of 6 floats
         Unit cell dimensions
+    use_atom_id_as_typename : bool, default=False
+        If True, use the OpenMM Atom.id attribute to name the created ParmEd
+        AtomType names.
 
     Returns
     -------

--- a/test/test_format_conversions.py
+++ b/test/test_format_conversions.py
@@ -2,18 +2,20 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import unittest
+import warnings
+
 import numpy as np
+
 from parmed import load_file, gromacs, amber, openmm, charmm
 from parmed.exceptions import GromacsWarning
 from parmed.gromacs._gromacsfile import GromacsFile
 from parmed.utils.six.moves import zip, range
 from parmed import unit as u, topologyobjects as to
 from parmed.tools import addLJType
-import unittest
 from utils import (get_fn, get_saved_fn, diff_files, TestCaseRelative,
                    FileIOTestCase, HAS_GROMACS, CPU, has_openmm as HAS_OPENMM,
-                   mm, app, equal_atoms)
-import warnings
+                   mm, app, equal_atoms, EnergyTestCase)
 
 class TestAmberToGromacs(FileIOTestCase, TestCaseRelative):
     """ Tests converting Amber prmtop files to Gromacs topologies """
@@ -56,7 +58,7 @@ class TestAmberToGromacs(FileIOTestCase, TestCaseRelative):
         np.testing.assert_allclose(top.box, parm.box)
 
 @unittest.skipUnless(HAS_GROMACS, "Cannot run GROMACS tests without GROMACS")
-class TestGromacsToAmber(FileIOTestCase, TestCaseRelative):
+class TestGromacsToAmber(FileIOTestCase, TestCaseRelative, EnergyTestCase):
     """ Tests converting Gromacs top/gro files to Amber """
 
     def test_simple(self):
@@ -212,7 +214,7 @@ class TestGromacsToAmber(FileIOTestCase, TestCaseRelative):
         cong.setPositions(top.positions)
         cona.setPositions(top.positions)
 
-        self._check_energies(top, cong, parm, cona)
+        self.check_energies(top, cong, parm, cona)
 
         # Make an NBFIX
         self.assertFalse(parm.has_NBFIX())
@@ -238,7 +240,7 @@ class TestGromacsToAmber(FileIOTestCase, TestCaseRelative):
         cong.setPositions(gro.positions)
         cona.setPositions(gro.positions)
 
-        self._check_energies(top, cong, parm, cona)
+        self.check_energies(top, cong, parm, cona)
 
     @unittest.skipUnless(HAS_OPENMM, "Cannot test without OpenMM")
     def test_energy_complicated(self):
@@ -259,24 +261,10 @@ class TestGromacsToAmber(FileIOTestCase, TestCaseRelative):
         cong.setPositions(gro.positions)
         cona.setPositions(gro.positions)
 
-        self._check_energies(top, cong, parm, cona)
+        self.check_energies(top, cong, parm, cona)
 
         warnings.filterwarnings('always', category=GromacsWarning)
 
-
-    def _check_energies(self, parm1, con1, parm2, con2):
-        ene1 = openmm.utils.energy_decomposition(parm1, con1)
-        ene2 = openmm.utils.energy_decomposition(parm2, con2)
-
-        all_terms = set(ene1.keys()) | set(ene2.keys())
-
-        for term in all_terms:
-            if term not in ene1:
-                self.assertAlmostEqual(ene2[term], 0)
-            elif term not in ene2:
-                self.assertAlmostEqual(ene1[term], 0)
-            else:
-                self.assertRelativeEqual(ene2[term], ene1[term], places=5)
 
 class TestAmberToCharmm(FileIOTestCase, TestCaseRelative):
     """ Tests converting Amber files to CHARMM """
@@ -327,7 +315,7 @@ class TestAmberToCharmm(FileIOTestCase, TestCaseRelative):
         self.assertEqual(nnormal+nimp, len(psf.dihedrals))
 
 @unittest.skipUnless(HAS_OPENMM, "Cannot test without OpenMM")
-class TestOpenMMToAmber(FileIOTestCase, TestCaseRelative):
+class TestOpenMMToAmber(FileIOTestCase, TestCaseRelative, EnergyTestCase):
     """
     Tests that OpenMM system/topology combo can be translated to other formats
     """
@@ -347,24 +335,11 @@ class TestOpenMMToAmber(FileIOTestCase, TestCaseRelative):
         con1.setPositions(parm.positions)
         con2.setPositions(parm.positions)
 
-        self._check_energies(parm, con1, parm2, con2)
+        self.check_energies(parm, con1, parm2, con2)
 
-    def _check_energies(self, parm1, con1, parm2, con2):
-        ene1 = openmm.utils.energy_decomposition(parm1, con1)
-        ene2 = openmm.utils.energy_decomposition(parm2, con2)
-
-        all_terms = set(ene1.keys()) | set(ene2.keys())
-
-        for term in all_terms:
-            if term not in ene1:
-                self.assertAlmostEqual(ene2[term], 0)
-            elif term not in ene2:
-                self.assertAlmostEqual(ene1[term], 0)
-            else:
-                self.assertRelativeEqual(ene2[term], ene1[term], places=5)
 
 @unittest.skipUnless(HAS_OPENMM, "Cannot test without OpenMM")
-class TestOpenMMToGromacs(FileIOTestCase, TestCaseRelative):
+class TestOpenMMToGromacs(FileIOTestCase, TestCaseRelative, EnergyTestCase):
     """
     Tests that OpenMM system/topology combo can be translated to other formats
     """
@@ -384,19 +359,4 @@ class TestOpenMMToGromacs(FileIOTestCase, TestCaseRelative):
         con1.setPositions(parm.positions)
         con2.setPositions(parm.positions)
 
-        self._check_energies(parm, con1, parm2, con2)
-
-    def _check_energies(self, parm1, con1, parm2, con2):
-        ene1 = openmm.utils.energy_decomposition(parm1, con1)
-        ene2 = openmm.utils.energy_decomposition(parm2, con2)
-
-        all_terms = set(ene1.keys()) | set(ene2.keys())
-
-        for term in all_terms:
-            if term not in ene1:
-                self.assertAlmostEqual(ene2[term], 0)
-            elif term not in ene2:
-                self.assertAlmostEqual(ene1[term], 0)
-            else:
-                self.assertRelativeEqual(ene2[term], ene1[term], places=5)
-
+        self.check_energies(parm, con1, parm2, con2)

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -88,7 +88,7 @@ class TestOpenMM(FileIOTestCase):
         self.assertEqual(len(parm.bonds), len(structure.bonds))
 
     def test_load_topology_use_atom_id_as_typename(self):
-        """ Tests loading an OpenMM Topology and System instance """
+        """ Tests loading an OpenMM Topology and using Atom.id to name types """
         import warnings
         ommparm = app.AmberPrmtopFile(get_fn('complex.prmtop'))
         parm = load_file(get_fn('complex.prmtop'))

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -98,8 +98,7 @@ class TestOpenMM(FileIOTestCase, TestCaseRelative, EnergyTestCase):
         for pmd_atom, omm_atom in zip(parm.atoms, ommparm.topology.atoms()):
             omm_atom.id = pmd_atom.type
         structure = openmm.load_topology(ommparm.topology, system,
-                                         xyz=parm.positions,
-                                         use_atom_id_as_typename=True)
+                                         xyz=parm.positions)
 
         self.assertEqual(len(parm.atoms), len(structure.atoms))
         self.assertEqual([a.type for a in parm.atoms],

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -87,6 +87,25 @@ class TestOpenMM(FileIOTestCase):
         self.assertEqual(len(parm.residues), len(structure.residues))
         self.assertEqual(len(parm.bonds), len(structure.bonds))
 
+    def test_load_topology_use_atom_id_as_typename(self):
+        """ Tests loading an OpenMM Topology and System instance """
+        import warnings
+        ommparm = app.AmberPrmtopFile(get_fn('complex.prmtop'))
+        parm = load_file(get_fn('complex.prmtop'))
+        system = ommparm.createSystem(implicitSolvent=app.OBC1)
+
+        for pmd_atom, omm_atom in zip(parm.atoms, ommparm.topology.atoms()):
+            omm_atom.id = pmd_atom.type
+
+        structure = openmm.load_topology(ommparm.topology, system, use_atom_id_as_typename=True)
+
+        self.assertEqual(len(parm.atoms), len(structure.atoms))
+        self.assertEqual([a.type for a in parm.atoms],
+                         [a.type for a in structure.atoms])
+        self.assertEqual(len(parm.residues), len(structure.residues))
+        self.assertEqual(len(parm.bonds), len(structure.bonds))
+
+
     def test_load_topology_extra_bonds(self):
         """ Test loading extra bonds not in Topology """
         parm = load_file(get_fn('ash.parm7'))

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,14 +2,17 @@
 Useful functions for the test cases
 """
 import os
-import numpy as np
+from os.path import join, split, abspath
 import random
 import unittest
 import warnings
-from os.path import join, split, abspath
-from parmed import gromacs
+
+import numpy as np
+
+from parmed import gromacs, openmm
 from parmed.utils.six import string_types
 from parmed.utils.six.moves import zip
+
 warnings.filterwarnings('error', category=DeprecationWarning, module='parmed')
 
 try:
@@ -71,6 +74,22 @@ class TestCaseRelative(unittest.TestCase):
                 raise self.failureException(
                             '%s != %s with relative tolerance %g (%f)' %
                             (val1, val2, delta, ratio))
+
+class EnergyTestCase(unittest.TestCase):
+
+    def check_energies(self, parm1, con1, parm2, con2):
+        ene1 = openmm.utils.energy_decomposition(parm1, con1)
+        ene2 = openmm.utils.energy_decomposition(parm2, con2)
+
+        all_terms = set(ene1.keys()) | set(ene2.keys())
+
+        for term in all_terms:
+            if term not in ene1:
+                self.assertAlmostEqual(ene2[term], 0)
+            elif term not in ene2:
+                self.assertAlmostEqual(ene1[term], 0)
+            else:
+                self.assertRelativeEqual(ene2[term], ene1[term], places=5)
 
 class FileIOTestCase(unittest.TestCase):
 


### PR DESCRIPTION
When loading an OpenMM `Topology` into `Structure`, `AtomType` names are
autogenerated and types with equivalent LJ params are combined. This
PR adds an option to instead take the `AtomType`'s name from the optional
Openmm `Atom.id` attribute instead.

This change should not affect any previous behavior.