### PR TITLE
Fix negative index writing in PDB files

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -826,7 +826,6 @@ class PDBFile(object):
             standardize = lambda x: (x[:reslen], _is_hetatm(x))
         nmore = 0 # how many *extra* atoms have been added?
         last_number = 0
-        last_rnumber = 0
         for model, coord in enumerate(coords):
             if coords.shape[0] > 1:
                 dest.write('MODEL      %5d\n' % (model+1))
@@ -849,7 +848,6 @@ class PDBFile(object):
                         anum = _number_truncated_to_n_digits(atom.number, 5)
                         rnum = _number_truncated_to_n_digits(res.number, 4)
                     last_number = anum
-                    last_rnumber = rnum
                     # Do any necessary name munging to respect the PDB spec
                     if len(pa.name) < 4 and len(Element[pa.atomic_number]) != 2:
                         aname = ' %-3s' % pa.name

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -90,8 +90,8 @@ def _is_hetatm(resname):
 def _number_truncated_to_n_digits(num, digits):
     """ Truncates the given number to the specified number of digits """
     if num < 0:
-        return - (-num % eval('1e%d' % (digits-1)))
-    return num % eval('1e%d' % digits)
+        return int(-(-num % eval('1e%d' % (digits-1))))
+    return int(num % eval('1e%d' % digits))
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -842,8 +842,8 @@ class PDBFile(object):
                     pa, others, (x, y, z) = print_atoms(atom, coord)
                     # Figure out the serial numbers we want to print
                     if renumber:
-                        anum = (atom.idx + 1 + nmore)
-                        rnum = (res.idx + 1)
+                        anum = _number_truncated_to_n_digits(atom.idx + 1 + nmore, 5)
+                        rnum = _number_truncated_to_n_digits(res.idx + 1, 4)
                     else:
                         anum = _number_truncated_to_n_digits(atom.number, 5)
                         rnum = _number_truncated_to_n_digits(res.number, 4)

--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -845,7 +845,7 @@ class PDBFile(object):
                         anum = _number_truncated_to_n_digits(atom.idx + 1 + nmore, 5)
                         rnum = _number_truncated_to_n_digits(res.idx + 1, 4)
                     else:
-                        anum = _number_truncated_to_n_digits(atom.number, 5)
+                        anum = _number_truncated_to_n_digits(pa.number, 5)
                         rnum = _number_truncated_to_n_digits(res.number, 4)
                     last_number = anum
                     # Do any necessary name munging to respect the PDB spec
@@ -858,7 +858,7 @@ class PDBFile(object):
                         rec = hetatomrec
                     else:
                         rec = atomrec
-                    dest.write(rec % (anum , aname, pa.altloc, resname,
+                    dest.write(rec % (anum, aname, pa.altloc, resname,
                                res.chain[:1], rnum, res.insertion_code[:1],
                                x, y, z, pa.occupancy, pa.bfactor, segid,
                                Element[pa.atomic_number].upper(), ''))

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1053,6 +1053,7 @@ class TestPDBStructure(FileIOTestCase):
         self.assertTrue(diff_files(get_saved_fn('SCM_A_formatted.pdb'), f))
 
     def test_pdb_write_symmetry_data(self):
+        """ Tests writing PDB file with symmetry data """
         def assert_remark_290(parm, remark_290_lines):
             output = StringIO()
             parm.write_pdb(output)
@@ -1129,6 +1130,7 @@ REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000
             self.assertEqual(formats.pdb._standardize_resname(res.abbr), (res.abbr, False))
 
     def test_deprecations(self):
+        """ Test functions that raise deprecation warnings """
         fn = get_fn('blah', written=True)
         parm = formats.load_file(get_fn('ash.parm7'), get_fn('ash.rst7'))
         self.assertRaises(DeprecationWarning, lambda: write_PDB(parm, fn))
@@ -1615,6 +1617,7 @@ class TestCIFStructure(FileIOTestCase):
         self.assertEqual(download_CIF('1aki').space_group, 'P 21 21 21')
 
     def test_cif_space_group_written_from_structure(self):
+        """ Tests CIF file writing with space groups """
         parm = pmd.load_file(get_fn('SCM_A.pdb'))
         self.assertEqual(parm.space_group, 'P 1 21 1')
         written = get_fn('test.cif', written=True)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -20,7 +20,7 @@ import os
 import sys
 import unittest
 from utils import (get_fn, diff_files, get_saved_fn, run_all_tests,
-                   HAS_GROMACS, FileIOTestCase)
+                   HAS_GROMACS, FileIOTestCase, create_random_structure)
 import warnings
 
 def reset_stringio(io):
@@ -146,6 +146,25 @@ class TestFileLoader(FileIOTestCase):
         self.assertEqual(len(pdb.atoms), 49)
         self.assertEqual(len(pdb.residues), 1)
         self.assertEqual(pdb.residues[0].name, 'SAM')
+
+    def test_load_pdb_with_negative_resnum(self):
+        """ Tests negative residue numbers in PDB writing """
+        # Make a random structure
+        struct = read_PDB(get_fn('4lzt.pdb'))
+        for i, residue in enumerate(struct.residues):
+            residue.number = i - 2
+        for i, atom in enumerate(struct.atoms):
+            atom.number = i - 2
+        mypdb = get_fn('negative_indexes.pdb', written=True)
+        struct.save(mypdb, renumber=False)
+        struct2 = read_PDB(mypdb)
+        self.assertEqual(len(struct.atoms), len(struct2.atoms))
+        self.assertEqual(len(struct.residues), len(struct2.residues))
+        # Now make sure the numbers are still negative
+        for i, atom in enumerate(struct2.atoms):
+            self.assertEqual(atom.number, i-2)
+        for i, residue in enumerate(struct2.residues):
+            self.assertEqual(residue.number, i-2)
 
     def test_load_cif(self):
         """ Tests automatic loading of PDBx/mmCIF files """


### PR DESCRIPTION
This commit adds a test to make sure that negative indices are respected
in PDB file writing. In particular, negative residue numbers are used
somewhat frequently (especially in RNA systems), and the current code
just takes the % 10000 (for residues) and % 100000 (for atoms). Which
yields very weird behavior.

Also add a test for this.