### PR TITLE
Keep molecules when there is no structure content

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -269,7 +269,7 @@ class GromacsTopologyFile(Structure):
         """ Reads the topology file into the current instance """
         from parmed import gromacs as gmx
         params = self.parameterset = ParameterSet()
-        molecules = dict()
+        molecules = self.molecules = dict()
         bond_types = dict()
         angle_types = dict()
         ub_types = dict()


### PR DESCRIPTION
Currently, when parsing gromacs topology files, you will have access to the parameter set via the `parameterset` property on `GromacsTopologyFile` even when there is no `[molecules]` section. However, the structure object (the result of parsing sections like `[atoms]`) gets lost unless you add a `[molecules]` sections to your topology file. I think it would be nice to store the parsed structures as `molecules` property just like `parameterset`.

I understand that it's not really necessary for topology *modification*, but I personally am using ParmEd only as a parameter/topology **reader**. For instance, [VirtualChemistry](http://virtualchemistry.org/ff.php) GROMACS topologies do not have the `[molecules]` section which makes it a bit difficult to use ParmEd for extracting all the informations within the topology file.