### PR TITLE
Add improper_dihedrals_ordering parameter for Amber FF conversion

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -345,8 +345,8 @@ class OpenMMParameterSet(ParameterSet):
         # Structure has separate dihedral entries for each torsion
         if improper_dihedrals_ordering == 'default':
             dest.write(' <PeriodicTorsionForce>\n')
-        elif improper_dihedrals_ordering == 'amber':
-            dest.write(' <PeriodicTorsionForce ordering="amber">\n')
+        else:
+            dest.write(' <PeriodicTorsionForce ordering="%s">\n' % improper_dihedrals_ordering)
         diheds_done = set()
         pconv = u.degree.conversion_factor_to(u.radians)
         kconv = u.kilocalorie.conversion_factor_to(u.kilojoule)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -117,7 +117,7 @@ class OpenMMParameterSet(ParameterSet):
 
         return new_params
 
-    def write(self, dest, provenance=None, write_unused=True, separate_ljforce=False):
+    def write(self, dest, provenance=None, write_unused=True, separate_ljforce=False, improper_dihedrals_ordering='default'):
         """ Write the parameter set to an XML file for use with OpenMM
 
         Parameters
@@ -200,7 +200,7 @@ class OpenMMParameterSet(ParameterSet):
             self._write_omm_bonds(dest, skip_types)
             self._write_omm_angles(dest, skip_types)
             self._write_omm_urey_bradley(dest, skip_types)
-            self._write_omm_dihedrals(dest, skip_types)
+            self._write_omm_dihedrals(dest, skip_types, improper_dihedrals_ordering)
             self._write_omm_impropers(dest, skip_types)
 #           self._write_omm_rb_torsions(dest, skip_types)
             self._write_omm_cmaps(dest, skip_types)
@@ -338,12 +338,15 @@ class OpenMMParameterSet(ParameterSet):
                        (a1, a2, a3, angle.theteq*tconv, angle.k*kconv))
         dest.write(' </HarmonicAngleForce>\n')
 
-    def _write_omm_dihedrals(self, dest, skip_types):
+    def _write_omm_dihedrals(self, dest, skip_types, improper_dihedrals_ordering):
         if not self.dihedral_types and not self.improper_periodic_types: return
         # In ParameterSet, dihedral_types is *always* of type DihedralTypeList.
         # The from_structure method ensures that, even if the containing
         # Structure has separate dihedral entries for each torsion
-        dest.write(' <PeriodicTorsionForce>\n')
+        if improper_dihedrals_ordering == 'default':
+            dest.write(' <PeriodicTorsionForce>\n')
+        elif improper_dihedrals_ordering == 'amber':
+            dest.write(' <PeriodicTorsionForce ordering="amber">\n')
         diheds_done = set()
         pconv = u.degree.conversion_factor_to(u.radians)
         kconv = u.kilocalorie.conversion_factor_to(u.kilojoule)


### PR DESCRIPTION
Last thing necessary for the Amber FF conversion - this adds the `ordering='amber'` attribute (and @ChayaSt @jchodera will need to use it to add `ordering='charmm'` to their CHARMM ffxml) to the `PeriodicTorsionForce` element.

cc https://github.com/pandegroup/openmm/pull/1560