### PR TITLE
from pyrosetta import Pose

### DIFF
--- a/parmed/rosetta/pose.py
+++ b/parmed/rosetta/pose.py
@@ -12,7 +12,7 @@ from parmed.topologyobjects import Atom, ExtraPoint, Bond
 from parmed.utils.six.moves import range
 
 try:
-    from rosetta import Pose, AtomID
+    from pyrosetta import Pose, AtomID
 except ImportError:
     Pose = AtomID = None
 

--- a/test/test_parmed_rosetta.py
+++ b/test/test_parmed_rosetta.py
@@ -8,7 +8,7 @@ try:
 except:
     PDBFile = None
 try:
-    from rosetta import init, pose_from_sequence
+    from pyrosetta import init, pose_from_sequence
 except ImportError:
     init = pose_from_sequence = None
 


### PR DESCRIPTION
```bash
UserWarning: Import of 'rosetta' as a top-level module is deprecated
```
(Actually "from rosetta import Pose, init" does not work anymore)

I am using 2016 version  (pyrosetta-4.0) (for testing nglview):
![pose](https://user-images.githubusercontent.com/4451957/28605754-5fa216e6-71a1-11e7-9884-c9b4b5808da6.png)
