### PR TITLE
Improved CHARMM patch reading and support for OpenMM ffxml patch writing

### DIFF
--- a/devtools/ci/travis/install.sh
+++ b/devtools/ci/travis/install.sh
@@ -34,6 +34,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv boost==1.59.0 -c omnia
         conda install -y -n myenv nglview -c bioconda
         conda install -y -n myenv ambertools=17.0 -c http://ambermd.org/downloads/ambertools/conda/
+        conda install -y -n myenv -c conda-forge networkx
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -891,14 +891,6 @@ class CharmmParameterSet(ParameterSet):
         except StopIteration:
             pass
 
-        # Sanity check time: Make sure no patch names have already been defined as residues, and vice versa
-        new_patches_that_are_existing_residues = set(patches.keys()).intersection(self.residues.keys())
-        if len(new_patches_that_are_existing_residues) > 0:
-            raise ValueError('CHARMM tried to define these patches that are already defined as residues: %s' % new_patches_that_are_existing_residues)
-        new_residues_that_are_existing_patches = set(residues.keys()).intersection(self.patches.keys())
-        if len(new_residues_that_are_existing_patches) > 0:
-            raise ValueError('CHARMM tried to define these residues that are already defined as patches: %s' % new_residues_that_are_existing_patches)
-
         # Go through the patches and add the appropriate one
         self.patches.update(patches)
         for resname, res in iteritems(residues):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -857,10 +857,6 @@ class CharmmParameterSet(ParameterSet):
                                     hpatches[resname] = val
                                 elif tok.upper().startswith('LAST'):
                                     tpatches[resname] = val
-                        elif line[:5].upper() == 'DELETE':
-                            words = line.split()
-                            name = words[2].upper()
-                            res.delete.append(name)
                         elif line[:4].upper() in ('IMPR', 'IMPH'):
                             it = iter(w.upper() for w in line.split()[1:])
                             for a1, a2, a3, a4 in zip(it, it, it, it):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -812,9 +812,16 @@ class CharmmParameterSet(ParameterSet):
                             group.append(atom)
                             res.add_atom(atom)
                         elif line[:6].upper() == 'DELETE':
-                            words = line.split()
                             name = words[2].upper()
-                            res.delete.append(name)
+                            entity_type = words[1].upper()
+                            if entity_type == 'ATOM':
+                                res.delete_atoms.append(name)
+                            elif entity_type == 'IMPR':
+                                res.delete_impropers.append(words[2:5])
+                            else:
+                                msg = 'ParmEd cannot handle DELETE BOND, ANGL, DIHE, IMPR, DONO, or ACCE\n'
+                                msg += 'line was: %s' % line                                
+                                raise Exception(msg)
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
                             for a1, a2 in zip(it, it):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -89,7 +89,6 @@ class CharmmParameterSet(ParameterSet):
         # Instantiate the list types
         super(CharmmParameterSet, self).__init__()
         self.parametersets = []
-        self.patches = dict()
         self._declared_nbrules = False
 
         # Load all of the files
@@ -903,10 +902,6 @@ class CharmmParameterSet(ParameterSet):
                     res.first_patch = self.patches[patch_name]
                 except KeyError:
                     warnings.warn('Patch %s not found' % patch_name)
-                    # DEBUG
-                    print('patches.keys()')
-                    print(patches.keys())
-                    print(patch_name in patches.keys())
 
             patch_name = tpatches[resname]
             if patch_name is not None:

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -891,6 +891,14 @@ class CharmmParameterSet(ParameterSet):
         except StopIteration:
             pass
 
+        # Sanity check time: Make sure no patch names have already been defined as residues, and vice versa
+        new_patches_that_are_existing_residues = set(patches.keys()).intersection(self.residues.keys())
+        if len(new_patches_that_are_existing_residues) > 0:
+            raise ValueError('CHARMM tried to define these patches that are already defined as residues: %s' % new_patches_that_are_existing_residues)
+        new_residues_that_are_existing_patches = set(residues.keys()).intersection(self.patches.keys())
+        if len(new_residues_that_are_existing_patches) > 0:
+            raise ValueError('CHARMM tried to define these residues that are already defined as patches: %s' % new_residues_that_are_existing_patches)
+
         # Go through the patches and add the appropriate one
         self.patches.update(patches)
         for resname, res in iteritems(residues):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -729,6 +729,7 @@ class CharmmParameterSet(ParameterSet):
             f = tfile
         hpatch = tpatch = None # default Head and Tail patches
         residues = dict()
+        patches = dict()
         hpatches = dict()
         tpatches = dict()
         line = next(f)
@@ -820,7 +821,7 @@ class CharmmParameterSet(ParameterSet):
                                 res.delete_impropers.append(words[2:5])
                             else:
                                 msg = 'ParmEd cannot handle DELETE BOND, ANGL, DIHE, IMPR, DONO, or ACCE\n'
-                                msg += 'line was: %s' % line                                
+                                msg += 'line was: %s' % line
                                 raise Exception(msg)
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
@@ -879,7 +880,7 @@ class CharmmParameterSet(ParameterSet):
                     if restype == 'RESI':
                         residues[resname] = res
                     elif restype == 'PRES':
-                        self.patches[resname] = res
+                        patches[resname] = res
                     else:
                         assert False, 'restype != RESI or PRES'
                     # We parsed a line we need to look at. So don't update the
@@ -904,6 +905,7 @@ class CharmmParameterSet(ParameterSet):
                     warnings.warn('Patch %s not found' % tpatches[resname])
         # Now update the residues and patches with the ones we parsed here
         self.residues.update(residues)
+        self.patches.update(patches)
 
         if own_handle: f.close()
 

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -828,6 +828,14 @@ class CharmmParameterSet(ParameterSet):
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
                             for a1, a2 in zip(it, it):
+                                if restype == 'PRES':
+                                    # Patches can have bonds that refer to atoms not in the patch, so store these in a list of tuples
+                                    order = 1
+                                    if line.split()[0].upper() == 'DOUBLE':
+                                        order = 2
+                                    res.add_bonds.append( (a1, a2, order) )
+                                    continue
+
                                 if a1.startswith('-'):
                                     res.head = res[a2]
                                     continue
@@ -839,12 +847,6 @@ class CharmmParameterSet(ParameterSet):
                                     continue
                                 if a2.startswith('+'):
                                     res.tail = res[a1]
-                                    continue
-                                # Apparently PRES objects do not need to put +
-                                # or - in front of atoms that belong to adjacent
-                                # residues
-                                if restype == 'PRES' and (a1 not in res or
-                                                          a2 not in res):
                                     continue
                                 res.add_bond(a1, a2)
                         elif line[:4].upper() == 'CMAP':

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -816,11 +816,7 @@ class CharmmParameterSet(ParameterSet):
                             name = words[2].upper()
                             entity_type = words[1].upper()
                             if entity_type == 'ATOM':
-                                try:
-                                    res.delete_atoms.append(name)
-                                except exception as e:
-                                    print(dir(res))
-                                    raise(e)
+                                res.delete_atoms.append(name)
                             elif entity_type == 'IMPR':
                                 res.delete_impropers.append(words[2:5])
                             else:

--- a/parmed/exceptions.py
+++ b/parmed/exceptions.py
@@ -108,9 +108,6 @@ class PreProcessorWarning(ParmedWarning):
 class OpenMMWarning(ParmedWarning):
     """ If there is something we should warn when processing OpenMM objects """
 
-class IncompatiblePatchWarning(ParmedWarning):
-    """ If there is some warning information about why a patch is compatible """
-
 # Control flow exceptions
 
 class CharmmPsfEOF(ParmedError):

--- a/parmed/exceptions.py
+++ b/parmed/exceptions.py
@@ -36,6 +36,9 @@ class CharmmError(ParsingError):
 class ResidueError(ParmedError):
     """ For when there are problems defining a residue """
 
+class IncompatiblePatchError(ParmedError):
+    """ For when applying a PatchTemplate to a ResidueTemplate fails """
+
 class ParameterError(ParmedError):
     """ If a parameter is missing from a database """
 
@@ -104,6 +107,9 @@ class PreProcessorWarning(ParmedWarning):
 
 class OpenMMWarning(ParmedWarning):
     """ If there is something we should warn when processing OpenMM objects """
+
+class IncompatiblePatchWarning(ParmedWarning):
+    """ If there is some warning information about why a patch is compatible """
 
 # Control flow exceptions
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -388,9 +388,15 @@ class ResidueTemplate(object):
         # Create a copy
         # TODO: Once ResidueTemplate.from_residue() actually copies all info, use that instead?
         residue = _copy.copy(self)
-        # Process patch
+        # Delete atoms
         for atom_name in patch.delete_atoms:
             residue.delete_atom(atom_name)
+        # Replace atoms
+        for atom in patch.atoms:
+            if atom.name in residue:
+                # Overwrite type and charge
+                residue[atom.name].type = atom.type
+                residue[atom.name].charge = atom.charge
         # Delete impropers
         for impr in patch.delete_impropers:
             residue.remove(impr)

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -143,7 +143,7 @@ class ResidueTemplate(object):
             atom_name = atom.name
 
         if atom_name not in self._map:
-            raise RuntimeError("Could not find atom '%s' in ResidueTemplate, which contains atoms: %s" % (atom_name, self._map.keys()))
+            raise RuntimeError("Could not find atom '%s' in ResidueTemplate, which contains atoms: %s" % (atom_name, list(self._map.keys())))
 
         atom = self._map[atom_name]
 
@@ -257,7 +257,6 @@ class ResidueTemplate(object):
                         inst.connections.append(inst.atoms[idx])
                 else:
                     inst.add_bond(i1, i2)
-        # TODO: Does this method neglect to copy other information, like head, tail, patches, and impropers?
         return inst
 
     @property
@@ -434,7 +433,7 @@ class ResidueTemplate(object):
                 # Add bond
                 residue.add_bond(atom1_name, atom2_name, order)
             except:
-                raise Exception('Bond %s-%s could not be added to patched residue: %s' % (atom1_name, atom2_name))
+                raise Exception('Bond %s-%s could not be added to patched residue: atoms are %s' % (atom1_name, atom2_name, list(residue._map.keys())))
         # Delete impropers
         for impr in patch.delete_impropers:
             try:

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -333,6 +333,16 @@ class ResidueTemplate(object):
 
         return self
 
+    def apply_patch(self, patch):
+        """
+        Apply the specified PatchTemplate to the ResidueTemplate.
+
+        TODO:
+        * How do we handle patches that involve more than one residue?
+        """
+        # TODO
+        raise Exception('Not implemented.')
+
     def to_dataframe(self):
         """ Create a pandas dataframe from the atom information
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -224,6 +224,10 @@ class ResidueTemplate(object):
             self._crd = np.array([[a.xx, a.xy, a.xz] for a in self])
         return self._crd
 
+    @property
+    def net_charge(self):
+        return sum([a.charge for a in self])
+
     # Make ResidueTemplate look like a container of atoms, also indexable by the
     # atom name
     def __len__(self):
@@ -311,7 +315,7 @@ class ResidueTemplate(object):
         """
         if not self.atoms:
             raise ValueError('Cannot fix charges on an empty residue')
-        net_charge = sum(a.charge for a in self.atoms)
+        net_charge = self.net_charge
         if to is None:
             to = round(net_charge)
         else:

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -441,7 +441,7 @@ class ResidueTemplate(object):
         # Delete impropers
         for impr in patch.delete_impropers:
             try:
-                residue.remove(impr)
+                residue._impr.remove(impr)
             except ValueError as e:
                 raise IncompatiblePatchError('Improper %s was not found in residue to be patched.' % impr)
         # Check that the net charge is integral.

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -439,6 +439,11 @@ class ResidueTemplate(object):
         is_integral = (round(net_charge, precision) - round(net_charge)) == 0.0
         if not is_integral:
             raise Exception('Patch is not compatible with residue due to non-integral charge (charge was %f).' % net_charge)
+        # Ensure residue is connected
+        import networkx as nx
+        G = residue.to_networkx()
+        if not nx.is_connected(G):
+            raise Exception('Patched residue bond graph is not a connected graph.')
 
         return residue
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -442,6 +442,23 @@ class ResidueTemplate(object):
 
         return residue
 
+    def to_networkx(self):
+        """ Create a NetworkX graph of atoms and bonds
+
+        Returns
+        -------
+        G : :class:`networkx.Graph`
+            A NetworkX Graph representing the molecule
+
+        """
+        import networkx
+        G = networkx.Graph()
+        for atom in self.atoms:
+            G.add_node(atom.name, charge=atom.charge, type=atom.type)
+        for bond in self.bonds:
+            G.add_edge(bond.atom1.name, bond.atom2.name)
+        return G
+
     def to_dataframe(self):
         """ Create a pandas dataframe from the atom information
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -397,6 +397,9 @@ class ResidueTemplate(object):
                 # Overwrite type and charge
                 residue[atom.name].type = atom.type
                 residue[atom.name].charge = atom.charge
+        # Add bonds
+        for bond in patch.bonds:
+            residue.add_bond(bond.atom1.name, bond.atom2.name)
         # Delete impropers
         for impr in patch.delete_impropers:
             residue.remove(impr)

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -540,7 +540,8 @@ class PatchTemplate(ResidueTemplate):
     """
     def __init__(self, name=''):
         super(PatchTemplate, self).__init__(name)
-        self.delete = []
+        self.delete_atoms = []
+        self.delete_impropers = []
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -397,6 +397,8 @@ class ResidueTemplate(object):
                 # Overwrite type and charge
                 residue[atom.name].type = atom.type
                 residue[atom.name].charge = atom.charge
+            else:
+                residue.add_atom(Atom(name=atom.name, type=atom.type, charge=atom.charge))
         # Add bonds
         for bond in patch.bonds:
             residue.add_bond(bond.atom1.name, bond.atom2.name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -33,7 +33,6 @@ XML_ESCAPES = {
 
 import logging
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.DEBUG) # DEBUG
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -220,10 +219,8 @@ class OpenMMParameterSet(ParameterSet):
 
         [valid_residues_for_patch, valid_patches_for_residue] = self._determine_valid_patch_combinations(skip_residues)
         LOGGER.debug('Valid patch combinations:')
-        print('Valid patch combinations:') # DEBUG
         for patch_name in self.patches:
             LOGGER.debug('%8s : %s', patch_name, valid_residues_for_patch[patch_name])
-            print('%8s : %s' % (patch_name, valid_residues_for_patch[patch_name])) # DEBUG
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -464,7 +461,6 @@ class OpenMMParameterSet(ParameterSet):
                 except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
                     LOGGER.debug('%8s x %8s : %s', patch.name, residue.name, e)
-                    print('%8s x %8s : %s' % (patch.name, residue.name, e)) # DEBUG
                     continue
 
                 valid_residues_for_patch[patch.name].append(residue.name)
@@ -495,11 +491,12 @@ class OpenMMParameterSet(ParameterSet):
             try:
                 residue = self.residues[residue_name]
             except KeyError as e:
-                print('Compatible residue not found in self.residues')
-                print('   patch name: %s' % name)
-                print('   valid patch combinations: %s' % valid_residues_for_patch[name])
-                print('   residue name: %s' % residue_name)
-                raise(e)
+                msg =  'Compatible residue not found in self.residues\n'
+                msg += '   patch name: %s\n' % name
+                msg += '   valid patch combinations: %s\n' % valid_residues_for_patch[name]
+                msg += '   residue name: %s\n' % residue_name
+                msg += str(e)
+                raise(msg)
             patched_residue = residue.apply_patch(patch)
 
             for atom in patch.atoms:
@@ -532,9 +529,8 @@ class OpenMMParameterSet(ParameterSet):
             if (residue.tail is None) and (patched_residue.tail is not None):
                 dest.write('   <AddExternalBond atomName="%s"/>\n' % patched_residue.tail.name)
 
-            if patch.name in valid_patch_combinations:
-                for residue_name in valid_patch_combinations[patch.name]:
-                    dest.write('   <ApplyToResidue name="%s"/>\n' % residue_name)
+            for residue_name in valid_residues_for_patch[patch.name]:
+                dest.write('   <ApplyToResidue name="%s"/>\n' % residue_name)
 
             dest.write('  </Patch>\n')
         dest.write(' </Patches>\n')

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -460,6 +460,7 @@ class OpenMMParameterSet(ParameterSet):
                     patched_residue = residue.apply_patch(patch)
                 except Exception as e:
                     # Patching failed; continue to next patch
+                    print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
                     continue
                 # Check that the net charge is integral.
                 net_charge = patched_residue.net_charge

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -487,6 +487,8 @@ class OpenMMParameterSet(ParameterSet):
                            patch.override_level))
 
             # Construct an example patched residue
+            # TODO: We should also ensure that *all* compatible residues have the
+            # same added/changed atoms and deleted bonds, just to be safe.
             residue_name = valid_residues_for_patch[name][0]
             try:
                 residue = self.residues[residue_name]

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -429,7 +429,7 @@ class OpenMMParameterSet(ParameterSet):
             dest.write('  </Residue>\n')
         dest.write(' </Residues>\n')
 
-    def _determine_valid_patch_combinations(self, skip_residues, precision=4):
+    def _determine_valid_patch_combinations(self, skip_residues):
         """
         Determine valid (permissible) combinations of patches with residues that
         lead to integral net charges.
@@ -439,11 +439,6 @@ class OpenMMParameterSet(ParameterSet):
 
         skip_residues : set of ResidueTemplate
             List of residues to skip
-
-        precision : int, optional
-            Each valid patch should be produce a net charge that is integral to
-            this many decimal places.
-            Default is 4
 
         TODO:
         * residues and patches will need data structures to hold valid patches;
@@ -462,12 +457,9 @@ class OpenMMParameterSet(ParameterSet):
                     # Patching failed; continue to next patch
                     print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
                     continue
-                # Check that the net charge is integral.
-                net_charge = patched_residue.net_charge
-                is_integral = (round(net_charge, precision) - round(net_charge)) == 0.0
-                if is_integral:
-                    valid_patch_combinations[residue.name].append(patch.name)
-                    valid_patch_combinations[patch.name].append(residue.name)
+
+                valid_patch_combinations[residue.name].append(patch.name)
+                valid_patch_combinations[patch.name].append(residue.name)
         return valid_patch_combinations
 
     def _write_omm_patches(self, dest, valid_patch_combinations):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -18,7 +18,7 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 import warnings
-from parmed.exceptions import ParameterWarning
+from parmed.exceptions import ParameterWarning, IncompatiblePatchError, IncompatiblePatchWarning
 import itertools
 from collections import defaultdict
 
@@ -205,12 +205,7 @@ class OpenMMParameterSet(ParameterSet):
                 warnings.warn('Some residue templates are using unavailable '
                               'AtomTypes', ParameterWarning)
 
-        # DEBUG
-        print('Determining valid patch combinations...')
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
-        for patch_name in self.patches:
-            print('%8s : %s' % (patch_name, valid_patch_combinations[patch_name]))
-        print('')
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -442,9 +437,9 @@ class OpenMMParameterSet(ParameterSet):
                 # Attempt to patch the residue.
                 try:
                     residue.apply_patch(patch)
-                except Exception as e:
+                except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
-                    print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
+                    warnings.warn('%8s x %8s : %s' % (patch.name, residue.name, str(e)), IncompatiblePatchWarning)
                     continue
 
                 valid_patch_combinations[residue.name].append(patch.name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -460,6 +460,7 @@ class OpenMMParameterSet(ParameterSet):
 
                 valid_patch_combinations[residue.name].append(patch.name)
                 valid_patch_combinations[patch.name].append(residue.name)
+                                
         return valid_patch_combinations
 
     def _write_omm_patches(self, dest, valid_patch_combinations):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -197,7 +197,6 @@ class OpenMMParameterSet(ParameterSet):
                               'as write_unused is set to False', ParameterWarning)
         else:
             skip_residues = set()
-            skip_patches = set()
             skip_types = set()
         if self.atom_types:
             try:
@@ -326,16 +325,6 @@ class OpenMMParameterSet(ParameterSet):
                 skip_residues.add(name)
         return skip_residues
 
-    def _find_unused_patches(self):
-        """
-        Set all patches as unused.
-        TODO: Fix this
-        """
-        skip_patches = set()
-        for name, residue in iteritems(self.residues):
-            skip_patches.add(name)
-        return skip_patches
-
     def _find_unused_types(self, skip_residues):
         keep_types = set()
         for name, residue in iteritems(self.residues):
@@ -452,7 +441,7 @@ class OpenMMParameterSet(ParameterSet):
                 if residue in skip_residues: continue
                 # Attempt to patch the residue.
                 try:
-                    patched_residue = residue.apply_patch(patch)
+                    residue.apply_patch(patch)
                 except Exception as e:
                     # Patching failed; continue to next patch
                     print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
@@ -460,7 +449,7 @@ class OpenMMParameterSet(ParameterSet):
 
                 valid_patch_combinations[residue.name].append(patch.name)
                 valid_patch_combinations[patch.name].append(residue.name)
-                                
+
         return valid_patch_combinations
 
     def _write_omm_patches(self, dest, valid_patch_combinations):
@@ -479,7 +468,7 @@ class OpenMMParameterSet(ParameterSet):
                 dest.write('  <Patch name="%s">\n' % patch.name)
             else:
                 dest.write('  <Patch name="%s" override="%d">\n' % (patch.name,
-                           residue.override_level))
+                           patch.override_level))
 
             # Construct an example patched residue
             residue_name = valid_patch_combinations[name][0]

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -18,9 +18,12 @@ from parmed.utils.io import genopen
 from parmed.utils.six import add_metaclass, string_types, iteritems
 from parmed.utils.six.moves import range
 import warnings
-from parmed.exceptions import ParameterWarning, IncompatiblePatchError, IncompatiblePatchWarning
+from parmed.exceptions import ParameterWarning, IncompatiblePatchError
 import itertools
 from collections import defaultdict
+
+import logging
+LOGGER = logging.getLogger(__name__)
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -206,6 +209,9 @@ class OpenMMParameterSet(ParameterSet):
                               'AtomTypes', ParameterWarning)
 
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
+        LOGGER.debug('Valid patch combinations:')
+        for patch_name in self.patches:
+            LOGGER.debug('%8s : %s' % (patch_name, str(valid_patch_combinations[patch_name])))
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -439,7 +445,7 @@ class OpenMMParameterSet(ParameterSet):
                     residue.apply_patch(patch)
                 except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
-                    warnings.warn('%8s x %8s : %s' % (patch.name, residue.name, str(e)), IncompatiblePatchWarning)
+                    LOGGER.debug('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
                     continue
 
                 valid_patch_combinations[residue.name].append(patch.name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -22,6 +22,15 @@ from parmed.exceptions import ParameterWarning, IncompatiblePatchError
 import itertools
 from collections import defaultdict
 
+from xml.sax.saxutils import escape
+XML_ESCAPES = {
+    '&' : '&amp;',
+    '<' : '&lt;',
+    '>' : '&gt;',
+    "'" : '&#39;',
+    '"' : '&quot;'
+    }
+
 import logging
 LOGGER = logging.getLogger(__name__)
 
@@ -353,7 +362,8 @@ class OpenMMParameterSet(ParameterSet):
                 content = [content]
             for sub_content in content:
                 if isinstance(sub_content, string_types):
-                    dest.write('  <%s>%s</%s>\n' % (tag, sub_content, tag))
+                    escaped_sub_content = escape(sub_content, XML_ESCAPES)
+                    dest.write('  <%s>%s</%s>\n' % (tag, escaped_sub_content, tag))
                 elif isinstance(sub_content, dict):
                     if tag not in sub_content:
                         raise KeyError('Content of an attribute-containing element '
@@ -363,6 +373,7 @@ class OpenMMParameterSet(ParameterSet):
                     dest.write('  <%s' % tag)
                     for attribute in attributes:
                         dest.write(' %s="%s"' % (attribute, sub_content[attribute]))
+                    escaped_element_content = escape(element_content, XML_ESCAPES)
                     dest.write('>%s</%s>\n' % (element_content, tag))
                 else:
                     raise TypeError('Incorrect type of the %s element content' % tag)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -447,9 +447,9 @@ class OpenMMParameterSet(ParameterSet):
         """
         # Attempt to patch every residue, recording only valid combinations.
         valid_patch_combinations = defaultdict(list)
-        for residue in self.residues.values():
-            if residue in skip_residues: continue
-            for patch in self.patches.values():
+        for patch in self.patches.values():
+            for residue in self.residues.values():
+                if residue in skip_residues: continue
                 # Attempt to patch the residue.
                 try:
                     patched_residue = residue.apply_patch(patch)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -374,7 +374,7 @@ class OpenMMParameterSet(ParameterSet):
                     for attribute in attributes:
                         dest.write(' %s="%s"' % (attribute, sub_content[attribute]))
                     escaped_element_content = escape(element_content, XML_ESCAPES)
-                    dest.write('>%s</%s>\n' % (element_content, tag))
+                    dest.write('>%s</%s>\n' % (escaped_element_content, tag))
                 else:
                     raise TypeError('Incorrect type of the %s element content' % tag)
         dest.write(' </Info>\n')

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -211,7 +211,7 @@ class OpenMMParameterSet(ParameterSet):
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
         LOGGER.debug('Valid patch combinations:')
         for patch_name in self.patches:
-            LOGGER.debug('%8s : %s', patch_name, str(valid_patch_combinations[patch_name]))
+            LOGGER.debug('%8s : %s', patch_name, valid_patch_combinations[patch_name])
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -445,7 +445,7 @@ class OpenMMParameterSet(ParameterSet):
                     residue.apply_patch(patch)
                 except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
-                    LOGGER.debug('%8s x %8s : %s', patch.name, residue.name, str(e))
+                    LOGGER.debug('%8s x %8s : %s', patch.name, residue.name, e)
                     continue
 
                 valid_patch_combinations[residue.name].append(patch.name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -33,6 +33,7 @@ XML_ESCAPES = {
 
 import logging
 LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG) # DEBUG
 
 @add_metaclass(FileFormatType)
 class OpenMMParameterSet(ParameterSet):
@@ -219,8 +220,10 @@ class OpenMMParameterSet(ParameterSet):
 
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
         LOGGER.debug('Valid patch combinations:')
+        print('Valid patch combinations:') # DEBUG
         for patch_name in self.patches:
             LOGGER.debug('%8s : %s', patch_name, valid_patch_combinations[patch_name])
+            print('%8s : %s' % (patch_name, valid_patch_combinations[patch_name])) # DEBUG
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -373,7 +376,8 @@ class OpenMMParameterSet(ParameterSet):
                     dest.write('  <%s' % tag)
                     for attribute in attributes:
                         dest.write(' %s="%s"' % (attribute, sub_content[attribute]))
-                    escaped_element_content = escape(element_content, XML_ESCAPES)
+                    # TODO: Is this the right way to handle element content that contains lists, etc
+                    escaped_element_content = escape(str(element_content), XML_ESCAPES)
                     dest.write('>%s</%s>\n' % (escaped_element_content, tag))
                 else:
                     raise TypeError('Incorrect type of the %s element content' % tag)
@@ -457,6 +461,7 @@ class OpenMMParameterSet(ParameterSet):
                 except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
                     LOGGER.debug('%8s x %8s : %s', patch.name, residue.name, e)
+                    print('%8s x %8s : %s' % (patch.name, residue.name, e)) # DEBUG
                     continue
 
                 valid_patch_combinations[residue.name].append(patch.name)
@@ -520,6 +525,7 @@ class OpenMMParameterSet(ParameterSet):
             if patch.name in valid_patch_combinations:
                 for residue_name in valid_patch_combinations[patch.name]:
                     dest.write('   <ApplyToResidue name="%s"/>\n' % residue_name)
+
             dest.write('  </Patch>\n')
         dest.write(' </Patches>\n')
 

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -209,7 +209,8 @@ class OpenMMParameterSet(ParameterSet):
         # DEBUG
         print('Determining valid patch combinations...')
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
-        print(valid_patch_combinations)
+        for patch_name in self.patches:
+            print('%8s : %s' % (patch_name, valid_patch_combinations[patch_name]))
         print('')
 
         if charmm_imp:

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -211,7 +211,7 @@ class OpenMMParameterSet(ParameterSet):
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
         LOGGER.debug('Valid patch combinations:')
         for patch_name in self.patches:
-            LOGGER.debug('%8s : %s' % (patch_name, str(valid_patch_combinations[patch_name])))
+            LOGGER.debug('%8s : %s', patch_name, str(valid_patch_combinations[patch_name]))
 
         if charmm_imp:
             self._find_explicit_impropers()
@@ -445,7 +445,7 @@ class OpenMMParameterSet(ParameterSet):
                     residue.apply_patch(patch)
                 except IncompatiblePatchError as e:
                     # Patching failed; continue to next patch
-                    LOGGER.debug('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
+                    LOGGER.debug('%8s x %8s : %s', patch.name, residue.name, str(e))
                     continue
 
                 valid_patch_combinations[residue.name].append(patch.name)

--- a/parmed/parameters.py
+++ b/parmed/parameters.py
@@ -90,6 +90,7 @@ class ParameterSet(object):
         self.parametersets = []
         self._combining_rule = 'lorentz'
         self.residues = OrderedDict()
+        self.patches = OrderedDict()
         self.default_scee = self.default_scnb = 1.0
 
     def __copy__(self):
@@ -145,6 +146,8 @@ class ParameterSet(object):
             other.cmap_types[tuple(reversed(key))] = typ
         for key, item in iteritems(self.residues):
             other.residues[key] = copy(item)
+        for key, item in iteritems(self.patches):
+            other.patches[key] = copy(item)
         other.combining_rule = self.combining_rule
 
         return other

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -1042,6 +1042,13 @@ class TestCharmmParameters(utils.FileIOTestCase):
         else:
             self.assertEqual(a1, a2)
 
+    def test_charmm36_rtf(self):
+        """Test parsing of CHARMM36 RTF files."""
+        # Make sure there are no failures loading CHARMM36 RTF files.
+        param36 = parameters.CharmmParameterSet(get_fn('top_all36_prot.rtf'),
+                                                get_fn('top_all36_carb.rtf'),
+                                                get_fn('top_all36_cgenff.rtf'))
+
 class TestFileWriting(utils.FileIOTestCase):
     """ Tests the various file writing capabilities """
 

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -277,6 +277,7 @@ class TestResidueTemplate(unittest.TestCase):
         self.assertNotIn(a6, a5.bond_partners)
         self.assertEqual(len(templ.bonds), 4)
 
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
     def test_patch_residue(self):
         """ Tests ResidueTemplate.patch_residue function """
         templ = self.templ

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -9,6 +9,10 @@ try:
     import pandas as pd
 except ImportError:
     pd = None
+try:
+    import networkx as nx
+except ImportError:
+    nx = None
 import os
 import parmed as pmd
 from parmed import Atom, read_PDB, Structure
@@ -54,6 +58,20 @@ class TestResidueTemplate(unittest.TestCase):
         self.assertEqual(df.shape, (6, 20))
         self.assertAlmostEqual(df.charge.sum(), 0)
         self.assertEqual(df.atomic_number.sum(), 23)
+
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
+    def test_to_networkx(self):
+        """ Test converting ResidueTemplate to NetworkX graph """
+        a1, a2, a3, a4, a5, a6 = self.templ.atoms
+        self.templ.add_bond(a1, a2)
+        self.templ.add_bond(a2, a3)
+        self.templ.add_bond(a3, a4)
+        self.templ.add_bond(a5, a6)
+        G1 = self.templ.to_networkx()
+        assert not nx.is_connected(G1)
+        self.templ.add_bond(a2, a5)
+        G2 = self.templ.to_networkx()
+        assert nx.is_connected(G2)
 
     def test_add_atom(self):
         """ Tests the ResidueTemplate.add_atom function """

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -15,6 +15,7 @@ from parmed import Atom, read_PDB, Structure
 from parmed.amber import AmberParm, AmberOFFLibrary
 from parmed.exceptions import AmberWarning, Mol2Error
 from parmed.modeller import (ResidueTemplate, ResidueTemplateContainer,
+                             PatchTemplate,
                              PROTEIN, SOLVENT, StandardBiomolecularResidues)
 from parmed.formats import Mol2File, PDBFile
 from parmed.geometry import distance2
@@ -235,6 +236,50 @@ class TestResidueTemplate(unittest.TestCase):
         rescont[0].fix_charges()
         for a, c in zip(rescont[0].atoms, charges):
             self.assertEqual(a.charge, c)
+
+    def test_delete_atom(self):
+        """ Tests the ResidueTemplate.delete_atom function """
+        templ = copy(self.templ)
+        a1, a2, a3, a4, a5, a6 = templ.atoms
+        a7 = Atom(name='Unimportant', type='black hole')
+        templ.add_bond(a1, a2)
+        templ.add_bond(a2, a3)
+        templ.add_bond(a3, a4)
+        templ.add_bond(a2, a5)
+        templ.add_bond(a5, a6)
+        templ.delete_atom(a6)
+        #self.assertRaises(RuntimeError, lambda: templ.delete_atom(a7))
+        self.assertIn(a1, a2.bond_partners)
+        self.assertIn(a2, a1.bond_partners)
+        self.assertIn(a3, a2.bond_partners)
+        self.assertIn(a2, a3.bond_partners)
+        self.assertIn(a5, a2.bond_partners)
+        self.assertIn(a2, a5.bond_partners)
+        self.assertNotIn(a5, a6.bond_partners)
+        self.assertNotIn(a6, a5.bond_partners)
+        self.assertEqual(len(templ.bonds), 4)
+
+    def test_patch_residue(self):
+        """ Tests ResidueTemplate.patch_residue function """
+        templ = self.templ
+        a1, a2, a3, a4, a5, a6 = templ.atoms
+        templ.add_bond(a1, a2)
+        templ.add_bond(a2, a3)
+        templ.add_bond(a3, a4)
+        templ.add_bond(a2, a5)
+        templ.add_bond(a5, a6)
+        patch = PatchTemplate()
+        patch.delete_atoms.append(a6.name)
+        residue = self.templ.apply_patch(patch)
+        self.assertEqual(len(residue.atoms), 5)
+        self.assertEqual(len(residue.bonds), 4)
+        a1, a2, a3, a4, a5 = residue.atoms
+        self.assertIn(a1, a2.bond_partners)
+        self.assertIn(a2, a1.bond_partners)
+        self.assertIn(a3, a2.bond_partners)
+        self.assertIn(a2, a3.bond_partners)
+        self.assertIn(a5, a2.bond_partners)
+        self.assertIn(a2, a5.bond_partners)
 
     def test_add_bonds_atoms(self):
         """ Tests the ResidueTemplate.add_bond function w/ indices """

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -583,7 +583,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         openmm_params = openmm.OpenMMParameterSet.from_parameterset(charmm_params)
         print('openmm_params has %d residues and %d patches' % (len(openmm_params.residues), len(openmm_params.patches)))
 
-        openmm_params.write(get_fn('charmm.xml', written=True),
+        #openmm_params.write(get_fn('charmm.xml', written=True),
+        openmm_params.write(get_fn('charmm36.xml'),
                             provenance=dict(
                                 OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
                                 Reference='MacKerrell'

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -576,17 +576,20 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
     def test_ljforce_charmm(self):
         """ Test writing LennardJonesForce without NBFIX from Charmm parameter files"""
 
-        params = openmm.OpenMMParameterSet.from_parameterset(
-                pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
-                                              get_fn('top_all36_prot.rtf'))
-        )
-        params.write(get_fn('charmm.xml', written=True),
-                     provenance=dict(
-                         OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
-                         Reference='MacKerrell'
-                     ),
-                     separate_ljforce=True
-        )
+        charmm_params = pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
+                                                      get_fn('top_all36_prot.rtf'))
+
+        print('charmm_params has %d residues and %d patches' % (len(charmm_params.residues), len(charmm_params.patches)))
+        openmm_params = openmm.OpenMMParameterSet.from_parameterset(charmm_params)
+        print('openmm_params has %d residues and %d patches' % (len(openmm_params.residues), len(openmm_params.patches)))
+
+        openmm_params.write(get_fn('charmm.xml', written=True),
+                            provenance=dict(
+                                OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
+                                Reference='MacKerrell'
+                                ),
+                            separate_ljforce=True
+                            )
 
     def test_explicit_improper(self):
         """Test writing out the improper explicitly"""

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -284,7 +284,7 @@ class TestSystemCreation(unittest.TestCase):
 
 class TestWriteParameters(FileIOTestCase):
 
-    @unittest.skipIf(os.getenv('AMBERHOME') is None, 'Cannot test w/out Amber')
+    @unittest.skipIf((not has_openmm) or (os.getenv('AMBERHOME') is None), 'Cannot test w/out Amber and OpenMM')
     def test_write_xml_parameters(self):
         """ Test writing XML parameters loaded from Amber files """
         leaprc = StringIO("""\
@@ -500,15 +500,17 @@ CHIS = CHIE
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.amber.AmberParameterSet.from_leaprc(leaprc)
         )
-        params.write(get_fn('amber_conv.xml', written=True),
+        ffxml_filename = get_fn('amber_conv.xml', written=True)
+        params.write(ffxml_filename,
                      provenance=dict(OriginalFile='leaprc.ff14SB',
-                     Reference=['Maier & Simmerling', 'Simmerling & Maier'],
+                     Reference=['Maier and Simmerling', 'Simmerling and Maier'],
                      Source=dict(Source='leaprc.ff14SB',
                      sourcePackage='AmberTools', sourcePackageVersion='15'))
         )
+        forcefield = app.ForceField(ffxml_filename)
 
 
-    @unittest.skipIf(os.getenv('AMBERHOME') is None, 'Cannot test w/out Amber')
+    @unittest.skipIf((not has_openmm) or (os.getenv('AMBERHOME') is None), 'Cannot test w/out Amber and OpenMM')
     def test_write_xml_parameters_gaff(self):
         """ Test writing XML parameters loaded from Amber GAFF parameter files """
         leaprc = StringIO("""\
@@ -521,11 +523,14 @@ parm10 = loadamberparams gaff.dat
 Wang, J., Wang, W., Kollman P. A.; Case, D. A. "Automatic atom type and bond type perception in molecular mechanical calculations". Journal of Molecular Graphics and Modelling , 25, 2006, 247260.
 Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development and testing of a general AMBER force field". Journal of Computational Chemistry, 25, 2004, 1157-1174.
 """
-        params.write(get_fn('gaff.xml', written=True),
+        ffxml_filename = get_fn('gaff.xml', written=True)
+        params.write(ffxml_filename,
                      provenance=dict(OriginalFile='gaff.dat',
                      Reference=citations)
         )
+        forcefield = app.ForceField(ffxml_filename)
 
+    @unittest.skipUnless(has_openmm, "Cannot test without OpenMM")
     def test_write_xml_parameters_amber_write_unused(self):
         """Test the write_unused argument in writing XML files"""
         params = openmm.OpenMMParameterSet.from_parameterset(
@@ -541,6 +546,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         params.write(ffxml, write_unused=False)
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 1646)
+        ffxml.seek(0)
+        forcefield = app.ForceField(ffxml)
 
         params = openmm.OpenMMParameterSet.from_parameterset(
                   pmd.amber.AmberParameterSet(get_fn('atomic_ions.lib'),
@@ -555,65 +562,74 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         params.write(ffxml, write_unused=False)
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 57)
+        ffxml.seek(0)
+        forcefield = app.ForceField(ffxml)
 
+    @unittest.skipUnless(has_openmm, "Cannot test without OpenMM")
     def test_write_xml_small_amber(self):
         """ Test writing small XML modifications """
         params = openmm.OpenMMParameterSet.from_parameterset(
                 load_file(os.path.join(get_fn('parm'), 'frcmod.constph'))
         )
-        params.write(get_fn('test.xml', written=True))
+        ffxml_filename = get_fn('test.xml', written=True)
+        params.write(ffxml_filename)
+        forcefield = app.ForceField(ffxml_filename)
 
-    @unittest.skipIf(nx is None, "Cannot test without networkx")
+    @unittest.skipIf((nx is None) or (not has_openmm), "Cannot test without NetworkX and OpenMM")
     def test_write_xml_parameters_charmm(self):
-        """ Test writing XML parameter files from Charmm parameter files"""
+        """ Test writing XML parameter files from Charmm parameter files and reading them back into OpenMM ForceField """
 
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
                                               get_fn('top_all36_prot.rtf'),
                                               get_fn('toppar_water_ions.str'))
         )
-        params.write(get_fn('charmm_conv.xml', written=True),
+        ffxml_filename = get_fn('charmm_conv.xml', written=True)
+        params.write(ffxml_filename,
                      provenance=dict(
-                         OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
+                         OriginalFile='par_all36_prot.prm, top_all36_prot.rtf',
                          Reference='MacKerrell'
                      )
         )
+        forcefield = app.ForceField(ffxml_filename)
 
-    @unittest.skipIf(nx is None, "Cannot test without networkx")
+    @unittest.skipIf((nx is None) or (not has_openmm), "Cannot test without NetworkX and OpenMM")
     def test_ljforce_charmm(self):
-        """ Test writing LennardJonesForce without NBFIX from Charmm parameter files"""
+        """ Test writing LennardJonesForce without NBFIX from Charmm parameter files and reading them back into OpenMM ForceField """
 
         charmm_params = pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
                                                       get_fn('top_all36_prot.rtf'))
 
-        print('charmm_params has %d residues and %d patches' % (len(charmm_params.residues), len(charmm_params.patches)))
         openmm_params = openmm.OpenMMParameterSet.from_parameterset(charmm_params)
-        print('openmm_params has %d residues and %d patches' % (len(openmm_params.residues), len(openmm_params.patches)))
 
         #openmm_params.write(get_fn('charmm.xml', written=True),
-        openmm_params.write(get_fn('charmm36.xml'),
+        ffxml_filename = get_fn('charmm36.xml')
+        openmm_params.write(ffxml_filename,
                             provenance=dict(
-                                OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
+                                OriginalFile='par_all36_prot.prm, top_all36_prot.rtf',
                                 Reference='MacKerrell'
                                 ),
                             separate_ljforce=True
                             )
+        forcefield = app.ForceField(ffxml_filename)
 
-    @unittest.skipIf(nx is None, "Cannot test without networkx")
+    @unittest.skipIf((nx is None) and has_openmm, "Cannot test without networkx and openmm")
     def test_explicit_improper(self):
-        """Test writing out the improper explicitly"""
+        """ Test writing out the improper explicitly and reading it back into OpenMM ForceField """
 
         warnings.filterwarnings('ignore', category=ParameterWarning)
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
                                               get_fn('top_all36_prot.rtf'))
         )
-        params.write(get_fn('charmm.xml', written=True),
+        ffxml_filename = get_fn('charmm.xml', written=True)
+        params.write(ffxml_filename,
                      provenance=dict(
-                         OriginalFiles='par_all36_prot.prm & top_all36_prot.rtf',
+                         OriginalFiles='par_all36_prot.prm, top_all36_prot.rtf',
                          Reference='MacKerrel'
                      ),
                      charmm_imp=True)
+        forcefield = app.ForceField(ffxml_filename)
 
     def test_not_write_residues_with_same_templhash(self):
         """Test that no identical residues are written to XML, using the
@@ -630,6 +646,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         params.write(ffxml)
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 16)
+        ffxml.seek(0)
+        forcefield = app.ForceField(ffxml)
 
     def test_override_level(self):
         """Test correct support for the override_level attribute of
@@ -650,3 +668,5 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         control_line2 = '  <Residue name="NA">\n'
         self.assertEqual(output_lines[5], control_line1)
         self.assertEqual(output_lines[8], control_line2)
+        ffxml.seek(0)
+        forcefield = app.ForceField(ffxml)

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -606,7 +606,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         ffxml_filename = get_fn('charmm36.xml')
         openmm_params.write(ffxml_filename,
                             provenance=dict(
-                                OriginalFile='par_all36_prot.prm, top_all36_prot.rtf',
+                                OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
                                 Reference='MacKerrell'
                                 ),
                             separate_ljforce=True
@@ -625,7 +625,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         ffxml_filename = get_fn('charmm.xml', written=True)
         params.write(ffxml_filename,
                      provenance=dict(
-                         OriginalFiles='par_all36_prot.prm, top_all36_prot.rtf',
+                         OriginalFiles='par_all36_prot.prm & top_all36_prot.rtf',
                          Reference='MacKerrel'
                      ),
                      charmm_imp=True)

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -613,7 +613,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                             )
         forcefield = app.ForceField(ffxml_filename)
 
-    @unittest.skipIf((nx is None) and has_openmm, "Cannot test without networkx and openmm")
+    @unittest.skipIf((nx is None) or (not has_openmm), "Cannot test without networkx and openmm")
     def test_explicit_improper(self):
         """ Test writing out the improper explicitly and reading it back into OpenMM ForceField """
 

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -9,6 +9,11 @@ import warnings
 
 import numpy as np
 
+try:
+    import networkx as nx
+except ImportError:
+    nx = None
+
 import parmed as pmd
 from parmed.utils.six.moves import StringIO
 from parmed import openmm, load_file, exceptions, ExtraPoint, unit as u
@@ -558,6 +563,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         )
         params.write(get_fn('test.xml', written=True))
 
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
     def test_write_xml_parameters_charmm(self):
         """ Test writing XML parameter files from Charmm parameter files"""
 
@@ -573,6 +579,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                      )
         )
 
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
     def test_ljforce_charmm(self):
         """ Test writing LennardJonesForce without NBFIX from Charmm parameter files"""
 
@@ -592,6 +599,7 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
                             separate_ljforce=True
                             )
 
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
     def test_explicit_improper(self):
         """Test writing out the improper explicitly"""
 

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -646,8 +646,6 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         params.write(ffxml)
         ffxml.seek(0)
         self.assertEqual(len(ffxml.readlines()), 16)
-        ffxml.seek(0)
-        forcefield = app.ForceField(ffxml)
 
     def test_override_level(self):
         """Test correct support for the override_level attribute of
@@ -668,5 +666,3 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         control_line2 = '  <Residue name="NA">\n'
         self.assertEqual(output_lines[5], control_line1)
         self.assertEqual(output_lines[8], control_line2)
-        ffxml.seek(0)
-        forcefield = app.ForceField(ffxml)


### PR DESCRIPTION
This PR improves support for reading CHARMM patches and adds support for writing them in [OpenMM `ffxml` format](http://docs.openmm.org/development/userguide/application.html#patches).

Patches are stored in the `ParameterSet.patches` field as an `OrderedDict` using an improved version of the `PatchTemplate` structure.

The `ResidueTemplate.apply_patch()` convenience function can be used to apply a `PatchTemplate` to generate a modified residue template. An exception is thrown unless
* all atoms to be changed or deleted are present
* all bonds to be added involve extant atoms
* the resulting net charge of the `ResidueTemplate` is integral (to a specified precision)
* the bond graph has exactly one connected component

The last criteria introduces an optional dependency on `NetworkX`, which is handled the same way `Pandas` is handled. A `ResidueTemplate.to_networkx()` convenience function is provided for generating bond graphs.

When writing OpenMM `ffxml` parameter sets, single-residue patches are automatically tested against residues for compatibility using `ResidueTemplate.apply_patch()`. Patches that involve more than one residue are not currently handled, but support will be added in a future PR.

Future improvements (in a separate PR):
* Add support for multi-residue patches 
* Refine logic to `_write_omm_patches` that distinguishes patch atoms that are added vs modified and bonds that are deleted; currently, only one compatible `patch x residue` combination is used to determine this, but no guarantee is made this will work for every `patch x residue` combination.
* `PatchTemplate` may need to implement its own `__copy__` to copy additional information it stores.

Tests have been added for any new functionality added.

Feedback/modifications/suggestions welcomed!

cc: https://github.com/choderalab/openmm-forcefields/issues/22