### PR TITLE
Fix for PyRosetta4 Pose to ParmEd structure conversion

### DIFF
--- a/parmed/rosetta/pose.py
+++ b/parmed/rosetta/pose.py
@@ -12,7 +12,7 @@ from parmed.topologyobjects import Atom, ExtraPoint, Bond
 from parmed.utils.six.moves import range
 
 try:
-    from rosetta import Pose, AtomID
+    from pyrosetta import Pose, AtomID
 except ImportError:
     Pose = AtomID = None
 
@@ -74,7 +74,7 @@ class RosettaPose(object):
                 else:
                     atom = Atom(**params)
 
-                atom.xx, atom.xy, atom.xz = tuple(at.xyz())
+                atom.xx, atom.xy, atom.xz = (at.xyz()[0], at.xyz[1], at.xyz[2])
 
                 struct.add_atom(atom, resname, resid, chain, '')
                 atnum += 1

--- a/parmed/rosetta/pose.py
+++ b/parmed/rosetta/pose.py
@@ -74,7 +74,7 @@ class RosettaPose(object):
                 else:
                     atom = Atom(**params)
 
-                atom.xx, atom.xy, atom.xz = (at.xyz()[0], at.xyz[1], at.xyz[2])
+                atom.xx, atom.xy, atom.xz = (at.xyz()[0], at.xyz()[1], at.xyz()[2])
 
                 struct.add_atom(atom, resname, resid, chain, '')
                 atnum += 1


### PR DESCRIPTION
I was having an issue where trying to convert PyRosetta4 Pose objects into ParmEd structures was making my system hang. This appears to be caused by calling the `tuple` function on the `pyrosetta.rosetta.numeric.xyzVector_double_t` containing the atomic coordinates. The small change in the code below fixes this.

I also updated the import to the new style (importing from rosetta rather than pyrosetta is marked to become deprecated and produces a warning).

