### PR TITLE
Have OpenMMParameterSet remove non-chemical H-H bonds from water upon creation

### DIFF
--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -10,7 +10,6 @@ import os
 from parmed.residue import AminoAcidResidue, RNAResidue, DNAResidue
 from parmed.structure import Structure
 from parmed.topologyobjects import Atom, Bond, AtomList, TrackedList
-from parmed.periodic_table import AtomicNum, Element
 from parmed.utils.six import iteritems
 from parmed.exceptions import IncompatiblePatchError
 import warnings
@@ -288,8 +287,7 @@ class ResidueTemplate(object):
         # Count number of appearances of each element
         element_count = defaultdict(int)
         for atom in self.atoms:
-            element = Element[atom.atomic_number]
-            element_count[element] += 1
+            element_count[atom.element_name] += 1
         # Pop EPs if they are present, since they are not chemical
         if 'EP' in element_count:
             element_count.pop('EP')

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -157,10 +157,7 @@ class ResidueTemplate(object):
         # Remove all bonds involving this atom
         for bond in list(self.bonds):
             if (bond.atom1 == atom) or (bond.atom2 == atom):
-                # Remove this bond from all atoms it spans
-                bond.delete()
-                # Delete the bond from the residue
-                self.bonds.remove(bond)
+                self.delete_bond(bond)
 
         # Remove all impropers involving this atom
         for impr in list(self._impr):
@@ -229,8 +226,11 @@ class ResidueTemplate(object):
             The bond to be deleted
 
         """
-        bond.delete()
-        self.bonds.remove(bond)
+        if bond in self.bonds:
+            bond.delete()
+            self.bonds.remove(bond)
+        else:
+            raise Exception('The specified bond {} is not present in this residue {}'.format(bond, self))
 
     @classmethod
     def from_residue(cls, residue):

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -230,7 +230,7 @@ class ResidueTemplate(object):
             bond.delete()
             self.bonds.remove(bond)
         else:
-            raise Exception('The specified bond {} is not present in this residue {}'.format(bond, self))
+            raise ValueError('The specified bond {} does not belong to this residue {}'.format(bond, self))
 
     @classmethod
     def from_residue(cls, residue):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -105,6 +105,8 @@ class OpenMMParameterSet(ParameterSet):
         # Populate atomic numbers in residue template
         # TODO: This can be removed if the parameter readers are guaranteed to populate this correctly
         for atom in residue.atoms:
+            if atom.type not in params.atom_types_str:
+                raise Exception('Residue {} contains atom type {} not found in parameter set'.format(residue.name, atom.type))
             atom.atomic_number = params.atom_types_str[atom.type].atomic_number
 
         # Check waters

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -112,7 +112,7 @@ class OpenMMParameterSet(ParameterSet):
         # Check waters
         if residue.empirical_chemical_formula == 'H2O':
             # Remove any H-H bonds if they are present
-            for bond in residue.bonds:
+            for bond in list(residue.bonds):
                 if (bond.atom1.element_name == 'H') and (bond.atom2.element_name == 'H'):
                     LOGGER.debug('Deleting H-H bond from water residue {}'.format(residue.name))
                     residue.delete_bond(bond)

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -19,6 +19,7 @@ from .geometry import angle, dihedral, distance2
 from .utils.decorators import deprecated
 from .utils.six import iteritems, string_types
 from .utils.six.moves import range, zip
+from .periodic_table import Element
 
 __all__ = ['Angle', 'AngleType', 'Atom', 'AtomList', 'Bond', 'BondType', 'ChiralFrame', 'Cmap',
            'CmapType', 'Dihedral', 'DihedralType', 'DihedralTypeList', 'Improper', 'ImproperType',
@@ -813,6 +814,9 @@ class Atom(_ListItem):
     @element.setter
     def element(self, value):
         self.atomic_number = value
+    @property
+    def element_name(self):
+        return Element[self.atomic_number]
 
     #===================================================
 

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -105,6 +105,24 @@ class TestResidueTemplate(unittest.TestCase):
         self.assertEqual(len(struct.residues), 1)
         self.assertEqual(len(struct.bonds), 5)
 
+    def test_delete_bond(self):
+        """ Tests the ResidueTemplate.delete_bond function """
+        templ = self.templ
+
+        a1, a2, a3, a4, a5, a6 = self.templ.atoms
+        self.templ.add_bond(a1, a2)
+        self.templ.add_bond(a2, a3)
+        self.templ.add_bond(a3, a4)
+        self.templ.add_bond(a2, a5)
+        self.templ.add_bond(a5, a6)
+
+        bond = templ.bonds[0]
+        self.assertEqual(len(templ.bonds), 5)
+        templ.delete_bond(bond)
+        self.assertEqual(len(templ.bonds), 4)
+        # Make sure we can't delete the bond again
+        self.assertRaises(ValueError, lambda: templ.delete_bond(bond))
+
     def test_copy(self):
         """ Tests ResidueTemplate __copy__ functionality """
         for atom in self.templ:

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -51,6 +51,16 @@ class TestResidueTemplate(unittest.TestCase):
         repr(PROTEIN) # make sure it works, don't care what its value is
         assert str(PROTEIN) == 'PROTEIN'
 
+    def test_chemical_formula(self):
+        """ Test computation of empirical chemical formula. """
+        a1, a2, a3, a4, a5, a6 = self.templ.atoms
+        self.templ.add_bond(a1, a2)
+        self.templ.add_bond(a2, a3)
+        self.templ.add_bond(a2, a4)
+        self.templ.add_bond(a2, a5)
+        self.templ.add_bond(a5, a6)
+        self.assertEqual(self.templ.empirical_chemical_formula, 'C2H3O')
+
     @unittest.skipIf(pd is None, "Cannot test without pandas")
     def test_data_frame(self):
         """ Test converting ResidueTemplate to a DataFrame """

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -615,8 +615,9 @@ class TestWriteCHARMMParameters(FileIOTestCase):
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
                                               get_fn('top_all36_prot.rtf'),
-                                              get_fn('toppar_water_ions.str'))
+                                              get_fn('toppar_water_ions.str')) # WARNING: contains duplicate water templates
         )
+        del params.residues['TP3M'] # Delete to avoid duplicate water template topologies
         ffxml_filename = get_fn('charmm_conv.xml', written=True)
         params.write(ffxml_filename,
                      provenance=dict(
@@ -638,8 +639,9 @@ class TestWriteCHARMMParameters(FileIOTestCase):
         params = openmm.OpenMMParameterSet.from_parameterset(
                 pmd.charmm.CharmmParameterSet(get_fn('par_all36_cgenff.prm'),
                                               get_fn('top_all36_cgenff.rtf'),
-                                              get_fn('toppar_water_ions.str'))
+                                              get_fn('toppar_water_ions.str')) # WARNING: contains duplicate water templates
         )
+        del params.residues['TP3M'] # Delete to avoid duplicate water template topologies        
         ffxml_filename = get_fn('charmm_conv.xml', written=True)
         params.write(ffxml_filename,
                      provenance=dict(

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -641,7 +641,7 @@ class TestWriteCHARMMParameters(FileIOTestCase):
                                               get_fn('top_all36_cgenff.rtf'),
                                               get_fn('toppar_water_ions.str')) # WARNING: contains duplicate water templates
         )
-        del params.residues['TP3M'] # Delete to avoid duplicate water template topologies        
+        del params.residues['TP3M'] # Delete to avoid duplicate water template topologies
         ffxml_filename = get_fn('charmm_conv.xml', written=True)
         params.write(ffxml_filename,
                      provenance=dict(

--- a/test/test_parmed_topologyobjects.py
+++ b/test/test_parmed_topologyobjects.py
@@ -159,6 +159,7 @@ class TestTopologyObjects(unittest.TestCase):
         # the first atom)
         self.assertEqual(a1.atomic_number, 6)
         self.assertEqual(a1.element, 6)
+        self.assertEqual(a1.element_name, 'C')
         self.assertEqual(a1.name, 'C1')
         self.assertEqual(a1.type, 'CT')
         self.assertEqual(a1.charge, -0.1)
@@ -1117,7 +1118,7 @@ class TestTopologyObjects(unittest.TestCase):
         self.assertEqual(repr(dihed_types[0]), '<DihedralTypes %s>' % list.__repr__(dihed_types[0]))
         # Now try DihedralTypeList.from_rbtorsion
         dtl = DihedralTypeList.from_rbtorsion(RBTorsionType(1, 2, 3, -4, -1, 0))
-        
+
         # Now test DihedralTypeList.__copy__
         cp = copy(dihed_types[0])
         self.assertIsNot(cp, dihed_types[0])


### PR DESCRIPTION
This PR partially addresses https://github.com/ParmEd/ParmEd/issues/941

- [x] `OpenMMParameterSet.from_parameterset()` now removes unphysical H-H bonds from waters
- [x] Added an `empirical_chemical_formula` property to `Residue` that returns the Hill notation chemical formula (e.g. `H2O`, `C6H6`), provided the `Atom` objects in the residue have `atomic_number` correctly set. Note that the CHARMM parameter reader does not actually set the `atomic_number` fields, so this must be done defensively by `OpenMMParameterSet.from_parameterset()`. (If it's a bug that the CHARMM reader doesn't set this correctly, we should fix that.)
- [x] Added `delete_bond` method to `Residue`
- [x] Added `element_name` field to `Atom`

Currently, the [`test_write_xml_parameters_charmm`](https://github.com/ParmEd/ParmEd/blob/master/test/test_parmed_openmm.py#L612-L633) will fail because, once H-H bonds are removed, there are now two identical water residue templates in [`toppar_water_ions.str`](https://github.com/ParmEd/ParmEd/blob/master/test/files/toppar_water_ions.str#L65-L87), causing OpenMM's `ForceField` to throw an exception. This means that there is no way for ParmEd to correctly read CHARMM parameter sets and write them to OpenMM if they contain duplicate waters, as the standard `toppar_water_ions.str` does. 

To fix this, I am currently presuming we will need to add the capability to specify which residue templates to omit when reading a CHARMM parameter file (pending response to https://github.com/choderalab/openmm-forcefields/issues/56#issuecomment-359291070).

cc: @peastman
cc: https://github.com/choderalab/openmm-forcefields/issues/56
cc: https://github.com/pandegroup/openmm/issues/1939#issuecomment-359130400