### PR TITLE
Fix typo in OpenMM ffxml tag name "CMAPTorsionForce"

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -704,7 +704,7 @@ class OpenMMParameterSet(ParameterSet):
     @needs_lxml
     def _write_omm_cmaps(self, xml_root, skip_types):
         if not self.cmap_types: return
-        xml_force = etree.SubElement(xml_root, 'CmapTorsionForce')
+        xml_force = etree.SubElement(xml_root, 'CMAPTorsionForce')
         maps = dict()
         counter = 0
         econv = u.kilocalorie.conversion_factor_to(u.kilojoule)


### PR DESCRIPTION
cc: https://github.com/choderalab/openmm-forcefields/pull/61#issuecomment-365052830

CMAP forces were incorrectly being written to OpenMM ffxml file with the misspelled tag `<CMapTorsionForce>` instead of the correct `<CMAPTorsionForce>` used [here](https://github.com/pandegroup/openmm/blob/master/wrappers/python/simtk/openmm/app/forcefield.py#L2278). 

I'm trying to think of an appropriate test to make sure that all tags are correctly handled. 
A force-by-force breakdown could work, but is difficult to manage.