### PR TITLE
Ensure processing of CHARMM residues and patches in deterministic order

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -12,6 +12,7 @@ import os
 import re
 import warnings
 from copy import copy as _copy
+from collections import OrderedDict
 
 from ..constants import TINY
 from ..exceptions import CharmmError, ParameterWarning
@@ -733,10 +734,10 @@ class CharmmParameterSet(ParameterSet):
             own_handle = False
             f = tfile
         hpatch = tpatch = None # default Head and Tail patches
-        residues = dict()
-        patches = dict()
-        hpatches = dict()
-        tpatches = dict()
+        residues = OrderedDict()
+        patches = OrderedDict()
+        hpatches = OrderedDict()
+        tpatches = OrderedDict()
         line = next(f)
         line_index = 0
         try:

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -149,9 +149,9 @@ class ResidueTemplate(object):
         atom = self._map[atom_name]
 
         # Adjust head and tail if needed
-        if (self.head is not None) and (self.head.name == atom_name):
+        if self.head == atom:
             self.head = None
-        if (self.tail is not None) and (self.tail.name == atom_name):
+        if self.tail == atom:
             self.tail = None
 
         # Remove all bonds involving this atom

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -149,9 +149,9 @@ class ResidueTemplate(object):
         atom = self._map[atom_name]
 
         # Adjust head and tail if needed
-        if self.head == atom:
+        if (self.head is not None) and (self.head.name == atom_name):
             self.head = None
-        if self.tail == atom:
+        if (self.tail is not None) and (self.tail.name == atom_name):
             self.tail = None
 
         # Remove all bonds involving this atom

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -601,11 +601,6 @@ class OpenMMParameterSet(ParameterSet):
             if (residue.tail is None) and (patched_residue.tail is not None):
                 etree.SubElement(patch_xml, 'AddExternalBond', atomName=patched_residue.tail.name)
 
-            # DEBUG
-            if (patch.name == 'CTER'):
-                print('residue: {}'.format(residue))
-                print('patched_residue: {}'.format(patched_residue))
-
             if write_apply_to_residue:
                 for residue_name in valid_residues_for_patch[patch.name]:
                     etree.SubElement(patch_xml, 'ApplyToResidue', name=residue_name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -24,7 +24,7 @@ import warnings
 from parmed.exceptions import ParameterWarning, IncompatiblePatchError
 import itertools
 
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 
 try:
     from lxml import etree

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -23,7 +23,8 @@ from parmed.utils.six.moves import range
 import warnings
 from parmed.exceptions import ParameterWarning, IncompatiblePatchError
 import itertools
-from collections import defaultdict
+
+from collections import defaultdict, OrderedDict
 
 try:
     from lxml import etree
@@ -174,13 +175,16 @@ class OpenMMParameterSet(ParameterSet):
         new_params._combining_rule = params.combining_rule
         new_params.default_scee = params.default_scee
         new_params.default_scnb = params.default_scnb
-        # add only ResidueTemplate instances (no ResidueTemplateContainers)
+        # Add only ResidueTemplate instances (no ResidueTemplateContainers)
+        # Maintain original residue ordering
         remediated_residues = list()
         for name, residue in iteritems(params.residues):
             if isinstance(residue, ResidueTemplate):
                 if OpenMMParameterSet._remediate_residue_template(new_params, residue):
                     remediated_residues.append(residue)
-            new_params.residues = { residue.name : residue for residue in remediated_residues }
+            new_params.residues = OrderedDict()
+            for residue in remediated_residues:
+                new_params.residues[residue.name] = residue
         for name, patch in iteritems(params.patches):
             if isinstance(patch, PatchTemplate):
                 new_params.patches[name] = patch
@@ -498,8 +502,13 @@ class OpenMMParameterSet(ParameterSet):
 
         """
         # Attempt to patch every residue, recording only valid combinations.
-        valid_residues_for_patch = defaultdict(list)
-        valid_patches_for_residue = defaultdict(list)
+        valid_residues_for_patch = OrderedDict()
+        for patch in self.patches.values():
+            valid_residues_for_patch[patch.name] = list()
+        valid_patches_for_residue = OrderedDict()
+        for residue in self.residues.values():
+            valid_patches_for_residue[residue.name] = list()
+
         for patch in self.patches.values():
             for residue in self.residues.values():
                 if residue in skip_residues: continue
@@ -591,6 +600,11 @@ class OpenMMParameterSet(ParameterSet):
                 etree.SubElement(patch_xml, 'AddExternalBond', atomName=patched_residue.head.name)
             if (residue.tail is None) and (patched_residue.tail is not None):
                 etree.SubElement(patch_xml, 'AddExternalBond', atomName=patched_residue.tail.name)
+
+            # DEBUG
+            if (patch.name == 'CTER'):
+                print('residue: {}'.format(residue))
+                print('patched_residue: {}'.format(patched_residue))
 
             if write_apply_to_residue:
                 for residue_name in valid_residues_for_patch[patch.name]:

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -312,21 +312,24 @@ class TestResidueTemplate(unittest.TestCase):
         a1, a2, a3, a4, a5, a6 = templ.atoms
         templ.add_bond(a1, a2)
         templ.add_bond(a2, a3)
-        templ.add_bond(a3, a4)
+        templ.add_bond(a2, a4)
         templ.add_bond(a2, a5)
         templ.add_bond(a5, a6)
+        self.assertIs(templ.tail, templ[4])
         patch = PatchTemplate()
+        patch.delete_atoms.append(a5.name)
         patch.delete_atoms.append(a6.name)
         residue = self.templ.apply_patch(patch)
-        self.assertEqual(len(residue.atoms), 5)
-        self.assertEqual(len(residue.bonds), 4)
-        a1, a2, a3, a4, a5 = residue.atoms
+        self.assertEqual(len(residue.atoms), 4)
+        self.assertEqual(len(residue.bonds), 3)
+        a1, a2, a3, a4 = residue.atoms
         self.assertIn(a1, a2.bond_partners)
         self.assertIn(a2, a1.bond_partners)
         self.assertIn(a3, a2.bond_partners)
         self.assertIn(a2, a3.bond_partners)
-        self.assertIn(a5, a2.bond_partners)
-        self.assertIn(a2, a5.bond_partners)
+        self.assertIn(a4, a2.bond_partners)
+        self.assertIn(a2, a4.bond_partners)
+        self.assertIs(residue.tail, None)
 
     def test_add_bonds_atoms(self):
         """ Tests the ResidueTemplate.add_bond function w/ indices """


### PR DESCRIPTION
This PR ensures that patches and residues are processed and compared in deterministic order---the same order as read in. 

This allows us to avoid issues like [this](https://github.com/choderalab/openmm-forcefields/pull/61#issuecomment-365117418) where patches are compared against random base residues for determining what should be added/deleted in a patch.