### PR TITLE
Bugfix necessary to allow openmoltools to work with recent ParmEd

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -103,6 +103,14 @@ class OpenMMParameterSet(ParameterSet):
           foreign parameter sets (e.g., CHARMM) into OpenMM parameter sets,
           and not restored on conversion from OpenMM to other formats
 
+        Parameters
+        ----------
+        params : :class:`parmed.parameters.ParameterSet`
+            ParameterSet containing the list of parameters to be converted to a
+            OpenMM-compatible parameter set
+        residue : :class:`parmed.modeller.Residue`
+            The residue to remediate
+
         """
         # Populate atomic numbers in residue template
         # TODO: This can be removed if the parameter readers are guaranteed to populate this correctly
@@ -126,9 +134,9 @@ class OpenMMParameterSet(ParameterSet):
         return True
 
     @classmethod
-    def from_parameterset(cls, params, copy=False):
+    def from_parameterset(cls, params, copy=False, remediate_residues=True):
         """
-        Instantiates a CharmmParameterSet from another ParameterSet (or
+        Instantiates an OpenMMParameterSet from another ParameterSet (or
         subclass). The main thing this feature is responsible for is converting
         lower-case atom type names into all upper-case and decorating the name
         to ensure each atom type name is unique.
@@ -145,11 +153,14 @@ class OpenMMParameterSet(ParameterSet):
         Parameters
         ----------
         params : :class:`parmed.parameters.ParameterSet`
-            ParameterSet containing the list of parameters to be converted to a
-            CHARMM-compatible set
-        copy : bool, optional
+            ParameterSet containing the list of parameters to be converted to as
+            OpenMM-compatible parameter set
+        copy : bool, optional, default=False
             If True, the returned parameter set is a deep copy of ``params``. If
             False, the returned parameter set is a shallow copy. Default False.
+        remediate_residues : bool, optional, default=True
+            If True, will remove non-chemical bonds and drop Residue definitions
+            that are missing parameters
 
         Returns
         -------
@@ -179,16 +190,19 @@ class OpenMMParameterSet(ParameterSet):
         new_params._combining_rule = params.combining_rule
         new_params.default_scee = params.default_scee
         new_params.default_scnb = params.default_scnb
+
         # Add only ResidueTemplate instances (no ResidueTemplateContainers)
         # Maintain original residue ordering
         remediated_residues = list()
         for name, residue in iteritems(params.residues):
             if isinstance(residue, ResidueTemplate):
-                if OpenMMParameterSet._remediate_residue_template(new_params, residue):
+                if (not remediate_residues) or OpenMMParameterSet._remediate_residue_template(new_params, residue, drop_residues_without_parameters=drop_residues_without_parameters):
                     remediated_residues.append(residue)
-            new_params.residues = OrderedDict()
-            for residue in remediated_residues:
-                new_params.residues[residue.name] = residue
+
+        new_params.residues = OrderedDict()
+        for residue in remediated_residues:
+            new_params.residues[residue.name] = residue
+
         for name, patch in iteritems(params.patches):
             if isinstance(patch, PatchTemplate):
                 new_params.patches[name] = patch

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -196,7 +196,7 @@ class OpenMMParameterSet(ParameterSet):
         remediated_residues = list()
         for name, residue in iteritems(params.residues):
             if isinstance(residue, ResidueTemplate):
-                if (not remediate_residues) or OpenMMParameterSet._remediate_residue_template(new_params, residue, drop_residues_without_parameters=drop_residues_without_parameters):
+                if (not remediate_residues) or OpenMMParameterSet._remediate_residue_template(new_params, residue):
                     remediated_residues.append(residue)
 
         new_params.residues = OrderedDict()

--- a/test/files/molecule.frcmod
+++ b/test/files/molecule.frcmod
@@ -1,0 +1,16 @@
+Remark line goes here
+MASS
+
+BOND
+
+ANGLE
+
+DIHE
+
+IMPROPER
+ca-ca-ca-ha         1.1          180.0         2.0          Using general improper torsional angle  X- X-ca-ha, penalty score=  6.0)
+
+NONBON
+
+
+

--- a/test/files/molecule.mol2
+++ b/test/files/molecule.mol2
@@ -1,0 +1,83 @@
+@<TRIPOS>MOLECULE
+2-(ethylamino)-1,2-diphenyl-ethanol
+   37    38     0     0     0
+SMALL
+USER_CHARGES
+
+@<TRIPOS>ATOM
+      1 C1          1.4622    1.5826   -4.2713 C.3       1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1452
+      2 C2          1.5369    1.5268   -5.7592 C.3       1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.0952
+      3 N1          1.9627    0.3522   -3.6734 N.3       1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.8195
+      4 C3          2.9723    1.3260   -1.6921 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1146
+      5 C4          2.7299    2.1102   -0.5643 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1191
+      6 C5          3.7277    2.9518   -0.0725 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1292
+      7 C6          4.9679    3.0090   -0.7084 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1251
+      8 C7          5.2103    2.2247   -1.8362 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1292
+      9 C8          4.2125    1.3832   -2.3280 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1191
+     10 C9          3.2973   -1.6035   -1.5056 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.0772
+     11 C10         3.8057   -2.3637   -2.5588 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1069
+     12 C11         5.0838   -2.9149   -2.4677 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1334
+     13 C12         5.8536   -2.7058   -1.3234 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1239
+     14 C13         5.3452   -1.9456   -0.2702 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1334
+     15 C14         4.0671   -1.3944   -0.3613 C.ar      1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.1069
+     16 C15         1.9309   -1.0140   -1.6029 C.3       1 2-(ethylamino)-1,2-diphenyl-ethanol         0.2040
+     17 C16         1.8881    0.4112   -2.2266 C.3       1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1817
+     18 O1          1.3789   -0.9474   -0.2766 O.3       1 2-(ethylamino)-1,2-diphenyl-ethanol        -0.5932
+     19 H1          0.4267    1.7156   -3.9441 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0329
+     20 H2          2.0634    2.4102   -3.8834 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0329
+     21 H3          1.1597    2.4538   -6.2045 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0396
+     22 H4          2.5670    1.3594   -6.0923 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0396
+     23 H5          0.9219    0.6986   -6.1311 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0396
+     24 H6          1.4049   -0.4337   -4.0064 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.3673
+     25 H7          1.7668    2.0728   -0.0623 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1324
+     26 H8          3.5392    3.5620    0.8058 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1324
+     27 H9          5.7446    3.6644   -0.3254 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1323
+     28 H10         6.1758    2.2693   -2.3315 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1324
+     29 H11         4.4100    0.7752   -3.2069 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1324
+     30 H12         3.2134   -2.5325   -3.4543 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1320
+     31 H13         5.4798   -3.5063   -3.2879 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1308
+     32 H14         6.8487   -3.1352   -1.2526 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1298
+     33 H15         5.9444   -1.7828    0.6209 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1308
+     34 H16         3.6790   -0.8030    0.4638 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.1320
+     35 H17         1.2556   -1.6809   -2.1690 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0339
+     36 H18         0.9027    0.8516   -2.0266 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.0751
+     37 H19         0.4723   -0.6313   -0.3843 H         1 2-(ethylamino)-1,2-diphenyl-ethanol         0.4167
+@<TRIPOS>BOND
+     1    1    2 1
+     2    1    3 1
+     3    4    5 ar
+     4    5    6 ar
+     5    6    7 ar
+     6    7    8 ar
+     7    8    9 ar
+     8    4    9 ar
+     9   10   11 ar
+    10   11   12 ar
+    11   12   13 ar
+    12   13   14 ar
+    13   14   15 ar
+    14   10   15 ar
+    15   16   17 1
+    16   10   16 1
+    17    4   17 1
+    18   16   18 1
+    19    3   17 1
+    20    1   19 1
+    21    1   20 1
+    22    2   21 1
+    23    2   22 1
+    24    2   23 1
+    25    3   24 1
+    26    5   25 1
+    27    6   26 1
+    28    7   27 1
+    29    8   28 1
+    30    9   29 1
+    31   11   30 1
+    32   12   31 1
+    33   13   32 1
+    34   14   33 1
+    35   15   34 1
+    36   16   35 1
+    37   17   36 1
+    38   18   37 1

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -547,6 +547,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         except KeyError:
             # A KeyError is expected
             pass
+        else:
+            assert False, "app.ForceField() should fail with a KeyError when residue templates without parameters are not removed, but it did not."
 
     def test_write_xml_parameters_amber_write_unused(self):
         """Test the write_unused argument in writing XML files"""

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -531,6 +531,23 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         )
         forcefield = app.ForceField(ffxml_filename)
 
+    def test_write_xml_parameters_antechamber(self):
+        """ Test writing XML residue definition from Antechamber mol2 """
+        leaprc = "molecule = loadmol2 %s\n" % get_fn('molecule.mol2')
+        leaprc += "loadamberparams %s\n" % get_fn('molecule.frcmod')
+        leaprc = StringIO(leaprc)
+        params = openmm.OpenMMParameterSet.from_parameterset(
+                pmd.amber.AmberParameterSet.from_leaprc(leaprc),
+                remediate_residues=False
+        )
+        ffxml_filename = get_fn('residue.xml', written=True)
+        params.write(ffxml_filename)
+        try:
+            forcefield = app.ForceField(ffxml_filename)
+        except KeyError:
+            # A KeyError is expected
+            pass
+
     def test_write_xml_parameters_amber_write_unused(self):
         """Test the write_unused argument in writing XML files"""
         params = openmm.OpenMMParameterSet.from_parameterset(

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -668,6 +668,12 @@ class TestWriteCHARMMParameters(FileIOTestCase):
                                               get_fn('top_all36_prot.rtf'),
                                               get_fn('toppar_water_ions.str')) # WARNING: contains duplicate water templates
         )
+
+        # Check that patch ACE remains but duplicate patches ACED, ACP, ACPD
+        assert 'ACE' in params.patches, "Patch ACE was expected to be retained, but is missing"
+        for name in ['ACED', 'ACP', 'ACPD']:
+            assert name not in params.patches, "Duplicate patch {} was expected to be pruned, but is present".format(name)
+
         del params.residues['TP3M'] # Delete to avoid duplicate water template topologies
         ffxml_filename = get_fn('charmm_conv.xml', written=True)
         params.write(ffxml_filename,
@@ -760,5 +766,7 @@ class TestWriteCHARMMParameters(FileIOTestCase):
                          OriginalFiles='par_all36_prot.prm & top_all36_prot.rtf',
                          Reference='MacKerrel'
                      ),
-                     charmm_imp=True)
+                     charmm_imp=True,
+                     separate_ljforce=True,
+                     )
         forcefield = app.ForceField(ffxml_filename)


### PR DESCRIPTION
Fixes #977 and https://github.com/pandegroup/openmm/issues/2047

This PR contains three bugfixes:
* Prune duplicate patches when converting to `OpenMMParameterSet` (https://github.com/pandegroup/openmm/issues/2047)
* The addition of a `remediate_residues` flag to `parmed.openmm.OpenMMParameterSet.from_parameterset()` that allows `openmoltools` to skip the step where residues without defined atom types are discarded (#977)
* Minor performance improvement via deleting unnecessary code