### PR TITLE
Added 'cgnr' charge group property to Atom class

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -1805,7 +1805,7 @@ class GromacsTopologyFile(Structure):
                 dest.write('%5d %10s %6d %6s %6s %6d %10.8f %10.6f   ; '
                            'qtot %.6f\n' % (atom.idx+1, atom.type,
                             residue.idx+1, residue.name, atom.name,
-                            atom.idx+1, atom.charge, atom.mass, runchg))
+                            atom.cgnr, atom.charge, atom.mass, runchg))
         dest.write('\n')
         # Do valence terms now
         EPs = [a for a in struct.atoms if isinstance(a, ExtraPoint)]

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -425,6 +425,8 @@ class Atom(_ListItem):
     vdw_weight : ``float``
         In the AMOEBA force field, this is the weight of the van der Waals
         interaction on the parent atom
+    cgnr : ``int``
+        Charge group number, as required in GROMOS type force fields
 
     Notes
     -----
@@ -467,7 +469,7 @@ class Atom(_ListItem):
                  charge=None, mass=0.0, nb_idx=0, solvent_radius=0.0,
                  screen=0.0, tree='BLA', join=0.0, irotat=0.0, occupancy=0.0,
                  bfactor=0.0, altloc='', number=-1, rmin=None, epsilon=None,
-                 rmin14=None, epsilon14=None):
+                 rmin14=None, epsilon14=None, cgnr=0):
         self.list = list
         self._idx = -1
         self.atomic_number = atomic_number
@@ -506,6 +508,7 @@ class Atom(_ListItem):
         self._rmin14 = _strip_units(rmin14, u.angstroms)
         self._epsilon14 = _strip_units(epsilon14, u.kilocalories_per_mole)
         self.children = []
+        self.cgnr = cgnr # GROMOS type charge group number
 
     #===================================================
 
@@ -515,7 +518,7 @@ class Atom(_ListItem):
                   charge=item.charge, mass=item.mass, nb_idx=item.nb_idx,
                   solvent_radius=item.solvent_radius, screen=item.screen, tree=item.tree,
                   join=item.join, irotat=item.irotat, occupancy=item.occupancy,
-                  bfactor=item.bfactor, altloc=item.altloc)
+                  bfactor=item.bfactor, altloc=item.altloc, cgnr=item.cgnr)
         new.atom_type = item.atom_type
         new.anisou = copy(item.anisou)
         for key in item.other_locations:


### PR DESCRIPTION
…and store accordingly when writing to Gromacs .top topology file.

We have been using ParmEd to work on GROMOS-like force field topologies, which need correct charge groups to be assigned within the topology file. Without knowing much about ParmEd coding, I added minimal changes here in order to be able to set an Atom.cgnr property (integer) and write it into the according column when storing a Gromacs .top file. Previously, each atom's index has been put into this column, resulting in one charge group per atom.

File input methods not changed.