### PR TITLE
Add flag to optionally write HETATM tags in PDBs

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -709,7 +709,7 @@ class PDBFile(object):
 
     @staticmethod
     def write(struct, dest, renumber=True, coordinates=None, altlocs='all',
-              write_anisou=False, charmm=False,
+              write_anisou=False, charmm=False, use_hetatoms=True,
               standard_resnames=False, increase_tercount=True):
         """ Write a PDB file from a Structure instance
 
@@ -752,6 +752,9 @@ class PDBFile(object):
             If True, SEGID will be written in columns 73 to 76 of the PDB file
             in the typical CHARMM-style PDB output. This will be omitted for any
             atom that does not contain a SEGID identifier.
+        use_hetatoms: bool, optional, default True
+            If True, certain atoms will have the HETATM tag instead of ATOM
+            as per the PDB-standard. 
         standard_resnames : bool, optional, default False
             If True, common aliases for various amino and nucleic acid residues
             will be converted into the PDB-standard values.
@@ -787,7 +790,6 @@ class PDBFile(object):
         if charmm:
             atomrec = ('ATOM  %5d %-4s%1s%-4s%1s%4d%1s   %8.3f%8.3f%8.3f%6.2f'
                        '%6.2f      %-4s%2s%-2s\n')
-            hetatomrec = atomrec.replace('ATOM  ', 'HETATM')
             anisourec = ('ANISOU%5d %-4s%1s%-4s%1s%4d%1s %7d%7d%7d%7d%7d%7d'
                          '      %2s%-2s\n')
             terrec = ('TER   %5d      %-4s%1s%4d\n')
@@ -799,7 +801,7 @@ class PDBFile(object):
                          '      %2s%-2s\n')
             terrec = ('TER   %5d      %-3s %1s%4d\n')
             reslen = 3
-        hetatomrec = atomrec.replace('ATOM  ', 'HETATM')
+        hetatomrec = atomrec.replace('ATOM  ', 'HETATM') if use_hetatoms else atomrec
         if struct.box is not None:
             dest.write('CRYST1%9.3f%9.3f%9.3f%7.2f%7.2f%7.2f %-11s%4s\n' % (
                     struct.box[0], struct.box[1], struct.box[2], struct.box[3],

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1018,10 +1018,10 @@ ATOM      5  SG  CYX H   2      36.833  15.443  15.640  1.00 15.60           S
         """Tests HETATM/ATOM tag writing"""
         structure = Structure()
         a = Atom(name='CA', atomic_number=6)
-        structure.add_atom(a, 'ASH', 2, 'A')
-        structure.add_atom(a, 'DG', 2, 'A')
-        structure.add_atom(a, 'T', 2, 'A')
-        structure.add_atom(a, 'MOL', 2, 'A')
+        structure.add_atom(copy(a), 'ASH', 2, 'A')
+        structure.add_atom(copy(a), 'DG', 2, 'A')
+        structure.add_atom(copy(a), 'T', 2, 'A')
+        structure.add_atom(copy(a), 'MOL', 2, 'A')
 
         coordinates = np.zeros((len(structure.atoms), 3))
 

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1027,19 +1027,16 @@ ATOM      5  SG  CYX H   2      36.833  15.443  15.640  1.00 15.60           S
 
         output = StringIO()
 
-        # Test 1: write HETATM tags
+        tests = [{"use_hetatoms": True, "tags": ['ATOM', 'ATOM', 'ATOM', 'HETATM']},
+                 {"use_hetatoms": False, "tags": ['ATOM', 'ATOM', 'ATOM', 'ATOM']}]
 
-        structure.write_pdb(output, use_hetatoms=True, coordinates=coordinates)
-        output.seek(0)
-        for line, tag in zip(output, ['ATOM', 'ATOM', 'ATOM', 'HETATM']):
-            assert line.startswith(tag)
+        for test in tests:
+            output.seek(0)
+            structure.write_pdb(output, use_hetatoms=test["use_hetatoms"], coordinates=coordinates)
+            output.seek(0)
 
-        # Test 2: do NOT write HETATM tags
-
-        output.seek(0)
-        structure.write_pdb(output, use_hetatoms=False, coordinates=coordinates)
-        for line, tag in zip(output, ['ATOM', 'ATOM', 'ATOM', 'ATOM']):
-            assert line.startswith(tag)
+            for tag in test["tags"]:
+                assert output.readline().startswith(tag)
 
     def test_anisou_read(self):
         """ Tests that read_PDB properly reads ANISOU records """

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1014,6 +1014,28 @@ ATOM      5  SG  CYX H   2      36.833  15.443  15.640  1.00 15.60           S
         self.assertNotIn('WAT', resname_set)
         self.assertIn('HOH', resname_set)
 
+    def test_pdb_write_hetatoms(self):
+        """Tests HETATM/ATOM tag writing"""
+        structure = Structure()
+        a = Atom(name='CA', atomic_number=6)
+        structure.add_atom(a, 'ASH', 2, 'A')
+        structure.add_atom(a, 'DG', 2, 'A')
+        structure.add_atom(a, 'T', 2, 'A')
+        structure.add_atom(a, 'MOL', 2, 'A')
+
+        coordinates = np.zeros((len(structure.atoms), 3))
+
+        structure.write_pdb("hetatom.pdb", use_hetatoms=True, coordinates=coordinates)
+        structure.write_pdb("no_hetatom.pdb", use_hetatoms=False, coordinates=coordinates)
+
+        with open('hetatom.pdb') as f:
+            for line, tag in zip(f, ['ATOM', 'ATOM', 'ATOM', 'HETATM']):
+                assert line.startswith(tag)
+
+        with open('no_hetatom.pdb') as f:
+            for line, tag in zip(f, ['ATOM', 'ATOM', 'ATOM', 'ATOM']):
+                assert line.startswith(tag)
+
     def test_anisou_read(self):
         """ Tests that read_PDB properly reads ANISOU records """
         pdbfile = read_PDB(self.pdb)

--- a/test/test_parmed_formats.py
+++ b/test/test_parmed_formats.py
@@ -1025,16 +1025,21 @@ ATOM      5  SG  CYX H   2      36.833  15.443  15.640  1.00 15.60           S
 
         coordinates = np.zeros((len(structure.atoms), 3))
 
-        structure.write_pdb("hetatom.pdb", use_hetatoms=True, coordinates=coordinates)
-        structure.write_pdb("no_hetatom.pdb", use_hetatoms=False, coordinates=coordinates)
+        output = StringIO()
 
-        with open('hetatom.pdb') as f:
-            for line, tag in zip(f, ['ATOM', 'ATOM', 'ATOM', 'HETATM']):
-                assert line.startswith(tag)
+        # Test 1: write HETATM tags
 
-        with open('no_hetatom.pdb') as f:
-            for line, tag in zip(f, ['ATOM', 'ATOM', 'ATOM', 'ATOM']):
-                assert line.startswith(tag)
+        structure.write_pdb(output, use_hetatoms=True, coordinates=coordinates)
+        output.seek(0)
+        for line, tag in zip(output, ['ATOM', 'ATOM', 'ATOM', 'HETATM']):
+            assert line.startswith(tag)
+
+        # Test 2: do NOT write HETATM tags
+
+        output.seek(0)
+        structure.write_pdb(output, use_hetatoms=False, coordinates=coordinates)
+        for line, tag in zip(output, ['ATOM', 'ATOM', 'ATOM', 'ATOM']):
+            assert line.startswith(tag)
 
     def test_anisou_read(self):
         """ Tests that read_PDB properly reads ANISOU records """


### PR DESCRIPTION
HETATM tags in PDB can cause problems for certain use cases. For example NAMD doesn't recognise them and raises errors. Adding an option to `write_pdb` to optionally use `ATOM  ` instead of `HETATM` fixes this problem. The default is still the same as was before.