### PR TITLE
Bugfix/rdparm cpp leak

### DIFF
--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -38,11 +38,14 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
     ParmFormatMap parmFormats;
     std::vector<std::string> flagList;
     std::string version;
+    ExitStatus retval;
 
     Py_BEGIN_ALLOW_THREADS
 
-    ExitStatus retval = readparm(fname, flagList, parmData, parmComments,
-                                 unkParmData, parmFormats, version);
+    retval = readparm(fname, flagList, parmData, parmComments,
+                      unkParmData, parmFormats, version);
+
+    Py_END_ALLOW_THREADS
 
     if (retval == NOOPEN) {
         error_message = "Could not open " + fname + " for reading";
@@ -67,8 +70,6 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
         PyErr_SetString(PyExc_RuntimeError, error_message.c_str());
         return NULL;
     }
-
-    Py_END_ALLOW_THREADS
 
     // If we got here, the parsing must have been OK. Create the parm_data,
     // formats, and comments dicts to pass back to Python

--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -16,6 +16,11 @@ typedef int Py_ssize_t;
 // Optimized readparm
 #include "readparm.h"
 
+void SetItem_PyDict_AndDecref(PyObject *dict, const char* key, PyObject *value) {
+    PyDict_SetItemString(dict, key, value);
+    Py_DECREF(value);
+}
+
 static PyObject* rdparm(PyObject *self, PyObject *args) {
 
     char *filename;
@@ -115,14 +120,11 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
                 PyErr_SetString(PyExc_RuntimeError, "This should be unreachable");
                 return NULL;
         }
-        PyDict_SetItemString(parm_data, flag.c_str(), list);
-        Py_DECREF(list);
+        SetItem_PyDict_AndDecref(parm_data, flag.c_str(), list);
 
         // Now comments
         if (parmComments.count(flag) == 0) {
-            PyObject *empty_list = PyList_New(0);
-            PyDict_SetItemString(comments, flag.c_str(), empty_list);
-            Py_DECREF(empty_list);
+            SetItem_PyDict_AndDecref(comments, flag.c_str(), PyList_New(0));
         } else {
             int ncom = parmComments[flag].size();
             PyObject *commentList = PyList_New(ncom);
@@ -131,14 +133,12 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
                 PyList_SET_ITEM(commentList, j,
                                 PyString_FromString(line.c_str()));
             }
-            PyDict_SetItemString(comments, flag.c_str(), commentList);
-            Py_DECREF(commentList);
+            SetItem_PyDict_AndDecref(comments, flag.c_str(), commentList);
         }
 
         // Now formats
         PyObject *fmt = PyString_FromString(parmFormats[flag].fmt.c_str());
-        PyDict_SetItemString(formats, flag.c_str(), fmt);
-        Py_DECREF(fmt);
+        SetItem_PyDict_AndDecref(formats, flag.c_str(), fmt);
 
         // Now flag list
         PyList_SET_ITEM(flag_list, (Py_ssize_t)i,

--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -39,6 +39,8 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
     std::vector<std::string> flagList;
     std::string version;
 
+    Py_BEGIN_ALLOW_THREADS
+
     ExitStatus retval = readparm(fname, flagList, parmData, parmComments,
                                  unkParmData, parmFormats, version);
 
@@ -65,6 +67,8 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
         PyErr_SetString(PyExc_RuntimeError, error_message.c_str());
         return NULL;
     }
+
+    Py_END_ALLOW_THREADS
 
     // If we got here, the parsing must have been OK. Create the parm_data,
     // formats, and comments dicts to pass back to Python

--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -116,10 +116,13 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
                 return NULL;
         }
         PyDict_SetItemString(parm_data, flag.c_str(), list);
+        Py_DECREF(list);
 
         // Now comments
         if (parmComments.count(flag) == 0) {
-            PyDict_SetItemString(comments, flag.c_str(), PyList_New(0));
+            PyObject *empty_list = PyList_New(0);
+            PyDict_SetItemString(comments, flag.c_str(), empty_list);
+            Py_DECREF(empty_list);
         } else {
             int ncom = parmComments[flag].size();
             PyObject *commentList = PyList_New(ncom);
@@ -129,11 +132,13 @@ static PyObject* rdparm(PyObject *self, PyObject *args) {
                                 PyString_FromString(line.c_str()));
             }
             PyDict_SetItemString(comments, flag.c_str(), commentList);
+            Py_DECREF(commentList);
         }
 
         // Now formats
         PyObject *fmt = PyString_FromString(parmFormats[flag].fmt.c_str());
         PyDict_SetItemString(formats, flag.c_str(), fmt);
+        Py_DECREF(fmt);
 
         // Now flag list
         PyList_SET_ITEM(flag_list, (Py_ssize_t)i,


### PR DESCRIPTION
Fixes #991 

This seems to fix the memory leak (indeed, it was a cause of a major leak, since `PyDict_Set*Item` increments the refcount of the value it adds, but the `PyList_New` increments the refcount as well.  As a result, a ref was leaking and the lists and dicts never got cleaned up.

This fixes that leak, and after running the `_rdparm.rdparm` function hundreds of times, the memory usage held steady at 37.5 MB (before it would climb up to 1GB+ after ~30-60 seconds).

Another improvement is that during the C++ prmtop file parsing, `_rdparm.rdparm` now releases the GIL, making it much better for multithreading.