### PR TITLE
Fix unused variable warning in rdparm.cpp

### DIFF
--- a/src/_rdparm.cpp
+++ b/src/_rdparm.cpp
@@ -197,5 +197,7 @@ init_rdparm(void) {
 #else
     m = Py_InitModule3("_rdparm", optrdparmMethods,
             "Optimized prmtop file reading library written in C++");
+			
+	(void)m; // silence unused variable warning
 #endif
 }


### PR DESCRIPTION
I know this is pretty minor but it always bothers me when I see it in the build output.  Now `m` has a use in the python 3 version of the code so it won't trigger a warning.