### PR TITLE
Fix logic for handling CHARMM impropers and warn if improper parameters are missing when writing OpenMM ffxml

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -24,6 +24,9 @@ from parmed.utils.six.moves import range
 import warnings
 from parmed.exceptions import ParameterWarning, IncompatiblePatchError
 import itertools
+from itertools import product, combinations
+from ..topologyobjects import (DihedralType, ImproperType)
+
 
 from collections import OrderedDict
 
@@ -191,6 +194,10 @@ class OpenMMParameterSet(ParameterSet):
         new_params.default_scee = params.default_scee
         new_params.default_scnb = params.default_scnb
 
+        # Copy CHARMM improper type map, if present, since this is needed for matching impropers
+        if hasattr(params, '_improper_key_map'):
+            new_params._improper_key_map = new_params._improper_key_map
+
         # Add only ResidueTemplate instances (no ResidueTemplateContainers)
         # Maintain original residue ordering
         remediated_residues = list()
@@ -335,9 +342,58 @@ class OpenMMParameterSet(ParameterSet):
         else:
             dest.write(xml)
 
+
+    def match_improper_type(self, a1, a2, a3, a4):
+        """ Matches a CHARMM improper type based on atom type names """
+        args = (a1, a2, a3, a4)
+        typ = self._match_improper_with_typemap(self.improper_types, *args)
+        if typ is None:
+            typ = self._match_improper_with_typemap(self.improper_periodic_types, *args)
+        return typ
+
+    def _match_improper_with_typemap(self, typemap, a1, a2, a3, a4):
+
+        if (a1, a2, a3, a4) in typemap: return typemap[(a1, a2, a3, a4)]
+        if (a4, a3, a2, a1) in typemap: return typemap[(a4, a3, a2, a1)]
+
+        # Now try any of the sortings. The documented CHARMM ordering does not seem to work for
+        # all systems CHARMM supports :(
+
+        key = tuple(sorted([a1, a2, a3, a4]))
+        if self._improper_key_map.get(key, None) in typemap:
+            return typemap[self._improper_key_map[key]]
+
+        for exact1, exact2, exact3 in combinations((a1, a2, a3, a4), 3):
+            key = tuple(sorted([exact1, exact2, exact3, 'X']))
+            if self._improper_key_map.get(key, None) in typemap:
+                return typemap[self._improper_key_map[key]]
+
+        for exact1, exact2 in combinations((a1, a2, a3, a4), 2):
+            key = tuple(sorted([exact1, exact2, 'X', 'X']))
+            if self._improper_key_map.get(key, None) in typemap:
+                return typemap[self._improper_key_map[key]]
+
+        return None
+
     def _find_explicit_impropers(self):
-        improper_harmonic = OrderedDict()
-        improper_periodic = OrderedDict()
+        """
+        For every residue, find any explicitly-specified (e.g. CHARMM) improper torsions and identify all wild-card improper parameters that match.
+        Expand all of these out into explicit impropers.
+        This is necessary for OpenMM to correctly handle impropers for these residues.        
+
+        .. todo :: 
+
+           * Do we need to do this for patches as well?
+
+        """
+
+        # Regenerate improper key map
+        self._improper_key_map = OrderedDict()
+        for key in self.improper_types.keys():
+            self._improper_key_map[tuple(sorted(key))] = key
+
+        improper_harmonic = OrderedDict() # improper_harmonic[key] is the harmonic improper parameter for unique key `key`
+        improper_periodic = OrderedDict() # improper_harmonic[key] is the periodic improper parameter for unique key `key`
 
         def get_types(residue, atomname):
             """Return list of atom type(s) that match the given atom name.
@@ -358,71 +414,33 @@ class OpenMMParameterSet(ParameterSet):
             else:
                 return [ a_types[a_names.index(atomname)] ]
 
+        # Iterate over all residues
+        # TODO: Do we have to iterate over all patched residues too?
         for name, residue in iteritems(self.residues):
             for impr in residue._impr:
+                # Get the list of types involved in this improper
                 types = [ get_types(residue, atomname) for atomname in impr ]
-                for (t1, t2, t3, t4) in itertools.product(*types):
-                    MATCH = False
-                    key = tuple(sorted((t1, t2, t3, t4)))
-                    altkeys1 = (t1, t2, t3, t4)
-                    altkeys2 = (t4, t3, t2, t1)
-                    if key in self.improper_types:
-                        improper_harmonic[altkeys1] = self.improper_types[key]
-                        MATCH = True
-                    elif key in self.improper_periodic_types:
-                        improper_periodic[altkeys1] = self.improper_periodic_types[key]
-                        MATCH = True
-                    elif altkeys1 in self.improper_periodic_types:
-                        improper_periodic[altkeys1] = self.improper_periodic_types[altkeys1]
-                        MATCH = True
-                    elif altkeys2 in self.improper_periodic_types:
-                        improper_periodic[altkeys1] = self.improper_periodic_types[altkeys2]
-                        MATCH = True
+                improper_found = False
+                for key in product(*types):
+                    # Search for an improper that matches these types
+                    improper = self.match_improper_type(*key)
+                    if improper is None:
+                        continue
+                    # Add this to our types
+                    if isinstance(improper, ImproperType):
+                        improper_harmonic[key] = improper
+                        improper_found = True
+                    elif isinstance(improper, DihedralType):
+                        improper_periodic[key] = improper
+                        improper_found = True
                     else:
-                        # Check for wildcards
-                        key_placeholder = None
-                        for anchor in itertools.combinations([t1, t2, t3, t4], 2):
-                            key = tuple(sorted([anchor[0], anchor[1], 'X', 'X']))
-                            if key in self.improper_types:
-                                if MATCH and key != key_placeholder:
-                                    flag = (altkeys1[0], altkeys1[-1])
-                                    if flag[0] == key_placeholder[0] and flag[1] == key_placeholder[1]:
-                                        # Match was already found.
-                                        warnings.warn("{} and {} match improper {}. Using {}".format(key, key_placeholder,
-                                                      altkeys1, key_placeholder))
-                                        break
+                        raise Exception('Something went wrong with improper type for {} returning an unexpected object {}'.format(key, improper))
+                    
+                # Warn if no improper was found
+                if not improper_found:                        
+                    warnings.warn('No improper found for improper {} in residue {} (types were {})'.format(impr, name, types))
 
-                                    if flag[0] == key[0] and flag[1] == key[1]:
-                                        improper_harmonic[altkeys1] = self.improper_types[key]
-                                        warnings.warn("{} and {} match improper {}. Using {}".format(key, key_placeholder,
-                                                        altkeys1, key), ParameterWarning)
-
-                                MATCH = True
-                                key_placeholder = key
-                                improper_harmonic[altkeys1] = self.improper_types[key]
-                            if key not in self.improper_types:
-                                for anchor in itertools.combinations([t1, t2, t3, t4], 2):
-                                    key = tuple(sorted([anchor[0], anchor[1], 'X', 'X']))
-                                    if key in self.improper_periodic_types:
-                                        if MATCH and key != key_placeholder:
-                                            flag = (altkeys1[0], altkeys1[-1])
-                                            if flag[0] == key_placeholder[0] and flag[1] == key_placeholder[1]:
-                                                # Match already found.
-                                                warnings.warn("{} and {} match improper {}. Using {}".format(key,
-                                                              key_placeholder, altkeys1, key_placeholder), ParameterWarning)
-                                                break
-
-                                            if flag[0] == key[0] and flag[1] == key[1]:
-                                                warnings.warn("More than one improper matches for {}. Using {}".format(
-                                                        altkeys1, key), ParameterWarning)
-                                                improper_periodic[altkeys1] = self.improper_periodic_types[key]
-
-                                        MATCH = True
-                                        key_placeholder = key
-                                        improper_periodic[altkeys1] = self.improper_periodic_types[key]
-                    if not MATCH:
-                        warnings.warn("No improper parameter found for {}".format(altkeys1), ParameterWarning)
-
+        # Update our impropers
         self.improper_periodic_types = improper_periodic
         self.improper_types = improper_harmonic
 
@@ -445,6 +463,7 @@ class OpenMMParameterSet(ParameterSet):
                 # TODO: Do we need to check if `psi_eq` is the same?
                 atoms2 = unique_keys[unique_key]
                 improper_types[atoms2].psi_k += improper.psi_k
+                warnings.warn('Compressing improper {} because it contains same atoms as {}'.format(improper, improper_types[atoms2]))
             else:
                 # Store this improper
                 unique_keys[unique_key] = atoms


### PR DESCRIPTION
When writing an OpenMM ffxml from a `CharmmParameterSet`, the logic for matching CHARMM impropers to expand generics found in residue templates into specific impropers differed from the way `CharmmParameterSet` would actually match torsions. This PR uses the same logic as in `CharmmParameterSet`, and also adds a `warning` if an improper isn't found.

This addresses [this issue](https://github.com/pandegroup/openmm/issues/2139#issuecomment-411503059) where the converted forcefield suddenly lost a lot of impropers.