### PR TITLE
allow LINKR records in PDB files

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -131,7 +131,7 @@ class PDBFile(object):
                         'REVDAT', 'SEQADV', 'SHEET ', 'SSBOND', 'FORMUL',
                         'HETNAM', 'HETSYN', 'SEQRES', 'SITE  ', 'ENDMDL',
                         'MODEL ', 'TER   ', 'JRNL  ', 'REMARK', 'TER', 'DBREF ',
-                        'DBREF2', 'DBREF1', 'DBREF', 'HET'}:
+                        'DBREF2', 'DBREF1', 'DBREF', 'HET', 'LINKR '}:
                     continue
                 # Hack to support reduce-added flags
                 elif line[:6] == 'USER  ' and line[6:9] == 'MOD':


### PR DESCRIPTION
PDB files created by refmac often have LINKR records, which is a variant of the "official" PDB LINK record.  Since refmac files are very common
(e.g. all of pdb_redo uses this program), parmed should not reject a
file as PDB format just because it has a LINKR record.  This change would be in
line with other non-standard record types that are already allowed.