### PR TITLE
Option to keep duplicate templates when writing OpenMM ffXML

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -239,9 +239,9 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin):
         return new_params
 
     @needs_lxml
-    def write(self, dest, provenance=None, write_unused=True, skip_duplicates=True,
-              separate_ljforce=False,
-              improper_dihedrals_ordering='default', charmm_imp=False):
+    def write(self, dest, provenance=None, write_unused=True, separate_ljforce=False,
+              improper_dihedrals_ordering='default', charmm_imp=False,
+              skip_duplicates=True):
         """ Write the parameter set to an XML file for use with OpenMM
 
         Parameters
@@ -275,14 +275,6 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin):
             templates remaining and parameters including those atom types will
             not be written. A ParameterWarning is issued if any such residues are
             found in a).
-        skip_duplicates : bool
-            If True: residues which appear identical to an existing residue will
-            not be written. This is usually the best choice. The most common
-            reason for setting skip_duplicates to false is if you have different
-            parametrizations for stereoisomers. Note that since OpenMM's residue
-            hashing is not aware of chirality, if you wish to use the results in
-            simulations you will need to explicitly provide the template names
-            for affected residues.
         separate_ljforce : bool
             If True will use a separate LennardJonesForce to create a
             CostumNonbondedForce to compute L-J interactions. It will set sigma
@@ -301,6 +293,14 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin):
         charmm_imp: bool
             If True, will check for existence of IMPR in each residue and patch template,
             and write out the explicit improper definition without wildcards in the ffxml file.
+        skip_duplicates : bool
+            If True: residues which appear identical to an existing residue will
+            not be written. This is usually the best choice. The most common
+            reason for setting skip_duplicates to false is if you have different
+            parametrizations for stereoisomers. Note that since OpenMM's residue
+            hashing is not aware of chirality, if you wish to use the results in
+            simulations you will need to explicitly provide the template names
+            for affected residues.
 
         Notes
         -----
@@ -339,9 +339,8 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin):
         root = etree.Element('ForceField')
         self._write_omm_provenance(root, provenance)
         self._write_omm_atom_types(root, skip_types)
-        self._write_omm_residues(root, skip_residues,
-            valid_patches_for_residue=valid_patches_for_residue,
-            skip_duplicates=skip_duplicates)
+        self._write_omm_residues(root, skip_residues, skip_duplicates,
+            valid_patches_for_residue=valid_patches_for_residue)
         self._write_omm_patches(root, valid_residues_for_patch)
         self._write_omm_bonds(root, skip_types)
         self._write_omm_angles(root, skip_types)
@@ -542,7 +541,7 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin):
                 etree.SubElement(xml_section, 'Type', element=str(element), **properties)
 
     @needs_lxml
-    def _write_omm_residues(self, xml_root, skip_residues, skip_duplicates=False, valid_patches_for_residue=None):
+    def _write_omm_residues(self, xml_root, skip_residues, skip_duplicates, valid_patches_for_residue=None):
         if not self.residues: return
         if valid_patches_for_residue is None:
             valid_patches_for_residue = OrderedDict()


### PR DESCRIPTION
There are cases where it makes sense for a ffXML file to contain multiple templates that will be considered identical according to OpenMM's topology-matching approach. The most obvious use-case is stereoisomers - sugars in particular become a huge problem under the default scheme. Another is metal ions of the same element but different valency (for those brave enough to actually use them). 