### PR TITLE
fix typo in parsing residue from ANISOU records

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -519,7 +519,7 @@ class PDBFile(object):
                         continue # Skip the rest of this record
                     aname = line[12:16].strip()
                     altloc = line[16].strip()
-                    rname = line[17:21].strip()
+                    rname = line[17:20].strip()
                     chain = line[21].strip()
                     try:
                         resid = int(line[22:26])


### PR DESCRIPTION
@swails. treat with care--I haven't learned how to run the ParmEd tests, but I hope this won't break anything.  It fixes some of the problems I've had with ANISOU cards that involved alternate conformers.  But I don't have a simple test case yet that shows before and after.  (What I see is in the middle of a complex workflow....). If you want to wait on this until I can create a test case, that's fine.

It would still be nice if the code could provide some information about the offending ANISOU card when printing out this warning.  But that probably involves some API issues, and verbosity levels, etc.--more than just adding a print() statement.