### PR TITLE
Break when parsing unsupported lonepairs

### DIFF
--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -904,6 +904,7 @@ class CharmmParameterSet(ParameterSet, CharmmImproperMatchingMixin):
                                 warnings.warn('LONEPAIR type %s not supported; only BISEctor and '
                                               'RELAtive supported' % words[1])
                                 skip_adding_residue = True
+                                break
                             a1, a2, a3, a4 = words[2:6]
                             keywords = {words[index][0:4].upper() : float(words[index+1])
                                         for index in range(6,len(words),2) }


### PR DESCRIPTION
Even though the residue would be marked to skip, upon encountering the COLINEAR lonepair type the parser tries to keep going and fails.

Now top_all36_cgenff.rtf can be parsed for chamber actions.