### PR TITLE
Fix Cl Bondi radius to match leap

### DIFF
--- a/parmed/tools/changeradii.py
+++ b/parmed/tools/changeradii.py
@@ -31,7 +31,7 @@ def bondi(parm):
         elif atom.atomic_number == 16:
             atom.solvent_radius = 1.8
         elif atom.atomic_number == 17:
-            atom.solvent_radius = 1.5
+            atom.solvent_radius = 1.7
         else:
             atom.solvent_radius = 1.5
 


### PR DESCRIPTION
The current radius is neither the actual Bondi radius (1.75), nor the value used in leap (1.7)