### PR TITLE
Fix DeprecationWarning when importing ABCs

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -7,7 +7,12 @@ Date: Aug. 11, 2015
 """
 from __future__ import division, print_function
 
-from collections import defaultdict, Sequence
+import six
+if six.PY2:
+    from collections import Sequence
+else:
+    from collections.abc import Sequence
+from collections import defaultdict
 from contextlib import closing
 import math
 import os

--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -7,15 +7,12 @@ Date: Aug. 11, 2015
 """
 from __future__ import division, print_function
 
-import six
-if six.PY2:
-    from collections import Sequence
-else:
-    from collections.abc import Sequence
 from collections import defaultdict
 from contextlib import closing
 import math
 import os
+import re
+import warnings
 from parmed.amber.offlib import AmberOFFLibrary
 from parmed.constants import TINY
 from parmed.exceptions import ParameterError, AmberWarning, ParameterWarning
@@ -27,10 +24,12 @@ from parmed.periodic_table import Mass, element_by_mass, AtomicNum
 from parmed.topologyobjects import (AtomType, BondType, AngleType, DihedralType,
                                     DihedralTypeList)
 from parmed.utils.io import genopen
-from parmed.utils.six import add_metaclass, string_types, iteritems
+from parmed.utils.six import add_metaclass, string_types, iteritems, PY2
 from parmed.utils.six.moves import map
-import re
-import warnings
+if PY2:
+    from collections import Sequence
+else:
+    from collections.abc import Sequence
 
 # parameter file regexes
 subs = dict(FLOATRE=r'([+-]?(?:\d+(?:\.\d*)?|\.\d+))',

--- a/setup.py
+++ b/setup.py
@@ -181,9 +181,6 @@ if __name__ == '__main__':
           url='https://parmed.github.io/ParmEd/html/index.html',
           license='LGPL (or GPL if released with AmberTools)',
           packages=packages,
-          install_requires=[
-              'six',
-          ],
           ext_modules=extensions,
           cmdclass=cmdclass,
           test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,9 @@ if __name__ == '__main__':
           url='https://parmed.github.io/ParmEd/html/index.html',
           license='LGPL (or GPL if released with AmberTools)',
           packages=packages,
+          install_requires=[
+              'six',
+          ],
           ext_modules=extensions,
           cmdclass=cmdclass,
           test_suite='nose.collector',


### PR DESCRIPTION
I'm suggesting this change because I'm getting the following
```sh
<...>/venv/lib/python3.7/site-packages/parmed/amber/parameters.py:10: DeprecationWarning:
  
  Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
whenever I'm running our test suite over at https://github.com/plotly/dash-bio ;)