### PR TITLE
Optionally don't de-duplicate matching atom types in OpenMM conversion

### DIFF
--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -27,7 +27,7 @@ __all__ = ['load_topology']
 
 
 @needs_openmm
-def load_topology(topology, system=None, xyz=None, box=None, unique_atom_types=True):
+def load_topology(topology, system=None, xyz=None, box=None, condense_atom_types=True):
     """
     Creates a :class:`parmed.structure.Structure` instance from an OpenMM
     Topology, optionally filling in parameters from a System
@@ -47,10 +47,10 @@ def load_topology(topology, system=None, xyz=None, box=None, unique_atom_types=T
         information unless ``box`` (below) is also specified
     box : array of 6 floats
         Unit cell dimensions
-    unique_atom_Types : bool, default=True
-        If True, create unique atom types based on de-duplcating properties. If False,
+    condense_atom_types : bool, default=True
+        If True, create unique atom types based on de-duplicating properties. If False,
         create one atom type for each atom in the system, even if its properties match
-        an existin atom type.
+        an existing atom type.
 
     Returns
     -------
@@ -183,7 +183,7 @@ def load_topology(topology, system=None, xyz=None, box=None, unique_atom_types=T
         elif isinstance(force, mm.CMAPTorsionForce):
             _process_cmap(struct, force)
         elif isinstance(force, mm.NonbondedForce):
-            _process_nonbonded(struct, force, unique_atom_types)
+            _process_nonbonded(struct, force, condense_atom_types)
         elif isinstance(force, ignored_forces):
             continue
         else:
@@ -376,7 +376,7 @@ def _process_cmap(struct, force):
             struct.cmap_types.append(cmap_type)
     struct.cmap_types.claim()
 
-def _process_nonbonded(struct, force, unique_atom_types):
+def _process_nonbonded(struct, force, condense_atom_types):
     """ Adds nonbonded parameters to the structure """
     typemap = dict()
     element_typemap = defaultdict(int)
@@ -387,7 +387,7 @@ def _process_nonbonded(struct, force, unique_atom_types):
         atype_name = (atom.type if atom.type != ''
                       else Element[atom.atomic_number])
         key = (atype_name, sig._value, eps._value)
-        if key in typemap and unique_atom_types:
+        if key in typemap and condense_atom_types:
             atom_type = typemap[key]
         else:
             if atom.type == '':

--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -27,7 +27,7 @@ __all__ = ['load_topology']
 
 
 @needs_openmm
-def load_topology(topology, system=None, xyz=None, box=None):
+def load_topology(topology, system=None, xyz=None, box=None, unique_atom_types=True):
     """
     Creates a :class:`parmed.structure.Structure` instance from an OpenMM
     Topology, optionally filling in parameters from a System
@@ -47,6 +47,10 @@ def load_topology(topology, system=None, xyz=None, box=None):
         information unless ``box`` (below) is also specified
     box : array of 6 floats
         Unit cell dimensions
+    unique_atom_Types : bool, default=True
+        If True, create unique atom types based on de-duplcating properties. If False,
+        create one atom type for each atom in the system, even if its properties match
+        an existin atom type.
 
     Returns
     -------
@@ -179,7 +183,7 @@ def load_topology(topology, system=None, xyz=None, box=None):
         elif isinstance(force, mm.CMAPTorsionForce):
             _process_cmap(struct, force)
         elif isinstance(force, mm.NonbondedForce):
-            _process_nonbonded(struct, force)
+            _process_nonbonded(struct, force, unique_atom_types)
         elif isinstance(force, ignored_forces):
             continue
         else:
@@ -372,7 +376,7 @@ def _process_cmap(struct, force):
             struct.cmap_types.append(cmap_type)
     struct.cmap_types.claim()
 
-def _process_nonbonded(struct, force):
+def _process_nonbonded(struct, force, unique_atom_types):
     """ Adds nonbonded parameters to the structure """
     typemap = dict()
     element_typemap = defaultdict(int)
@@ -383,7 +387,7 @@ def _process_nonbonded(struct, force):
         atype_name = (atom.type if atom.type != ''
                       else Element[atom.atomic_number])
         key = (atype_name, sig._value, eps._value)
-        if key in typemap:
+        if key in typemap and unique_atom_types:
             atom_type = typemap[key]
         else:
             if atom.type == '':

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -93,6 +93,22 @@ class TestOpenMM(FileIOTestCase, EnergyTestCase):
         self.assertEqual(len(parm.residues), len(structure.residues))
         self.assertEqual(len(parm.bonds), len(structure.bonds))
 
+    def test_load_topology_uncondensed_atom_types(self):
+        """ Tests condense_atom_types arg """
+        ommparm = app.AmberPrmtopFile(get_fn('complex.prmtop'))
+        parm = load_file(get_fn('complex.prmtop'))
+        system = ommparm.createSystem(implicitSolvent=app.OBC1)
+        structure_condensed = openmm.load_topology(ommparm.topology, system, condense_atom_types=True)
+        structure_uncondensed = openmm.load_topology(ommparm.topology, system, condense_atom_types=False)
+
+        num_unique_atom_types_condensed = len(set([a.atom_type for a in structure_condensed]))
+        num_unique_atom_types_uncondensed = len(set([a.atom_type for a in structure_uncondensed]))
+
+        assert num_unique_atom_types_uncondensed > num_unique_atom_types_condensed
+
+        # This may change if this or a similar flag does a partial condensing, see PR #1087
+        assert num_unique_atom_types_uncondensed == len([*structure_uncondensed.atoms])
+
     def test_load_topology_use_atom_id_as_typename(self):
         """ Tests loading an OpenMM Topology and using Atom.id to name types """
         ommparm = load_file(get_fn('ash.parm7'), get_fn('ash.rst7'))

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -107,7 +107,7 @@ class TestOpenMM(FileIOTestCase, EnergyTestCase):
         assert num_unique_atom_types_uncondensed > num_unique_atom_types_condensed
 
         # This may change if this or a similar flag does a partial condensing, see PR #1087
-        assert num_unique_atom_types_uncondensed == len([*structure_uncondensed.atoms])
+        assert num_unique_atom_types_uncondensed == len(structure_uncondensed.atoms)
 
     def test_load_topology_use_atom_id_as_typename(self):
         """ Tests loading an OpenMM Topology and using Atom.id to name types """


### PR DESCRIPTION
In https://github.com/openforcefield/openforcefield/issues/580 (well, everywhere using the SMIRNOFF specification, but it's not always fatal), uniqueness of valence terms based on the atom types they are built off of is not guaranteed. This is not _usually_ a problem since you typically only need the relevant parameters and atom types as part of the valence term (i.e. the length and force constant of a bond and the atom indices - but not atom types! - of the two atoms involved). But some of the bookkeepping does rely on that; we were encountering an issue with atom types being stored as dictionary keys. One approach would be to change that behavior, but this sort of thing is probably going to crop up elsewhere. A not-very-performant but catch-all solution is to make each atom have its own atom type object.