### PR TITLE
Update docs

### DIFF
--- a/doc/amber.rst
+++ b/doc/amber.rst
@@ -285,7 +285,6 @@ The corresponding classes are:
     NetCDFRestart
     NetCDFTraj
     AmberMdcrd
-    netcdffiles.use
 
 Inpcrd and Restart files
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -494,41 +493,8 @@ endian <http://en.wikipedia.org/wiki/Endianness>`_), and extensible (i.e., you
 can extend a file convention to include more data *without* breaking existing
 parsers).
 
-Python cannot read NetCDF files without the support of an external package. In
-particular, the following packages provide Python bindings to the NetCDF API:
+ParmEd uses, by default, numpy as a backend.
 
-    1. `scipy <http://www.scipy.org/>`_
-    2. `netCDF4 <https://github.com/Unidata/netcdf4-python>`_
-    3. `ScientificPython <http://dirac.cnrs-orleans.fr/plone/software/scientificpython/>`_
-
-All three of these files provide similar, although not identical interfaces. The
-ParmEd API supports all three NetCDF backends. You can swap out backends at any
-time using the :func:`use <parmed.amber.netcdffiles.use>` function. If you do
-not choose one, one will be picked automatically based on the available
-packages.  If several of those packages are available, the first one in the
-above list that is available will be picked.
-
-For most users, simply ensuring that at least one of the above packages is
-available and working and using the default will suffice. For the other small
-percentage that may want more fine-grained control, the :func:`use
-<parmed.amber.netcdffiles.use>` function will let you specify a particular
-implementation to use.  You can change the back-end at any time, but note that
-the behavior of a NetCDF object *created* with one implementation is undefined
-if you switch to a different one. So you are cautioned against switching NetCDF
-implementations when open NetCDF file handles are still open.
-
-An example of switching between NetCDF implementations is shown below::
-
-    from parmed.amber import netcdffiles
-    # Use the default NetCDF package (if one is already selected,
-    # this does nothing)
-    netcdffiles.use() # You can also pass "None"
-    # Use scipy for NetCDF files
-    netcdffiles.use('scipy')
-    # Use ScientificPython for NetCDF files
-    netcdffiles.use('Scientific') # Can also be ScientificPython
-    # Use netCDF4
-    netcdffiles.use('netCDF4')
 
 Amber mask syntax
 -----------------

--- a/parmed/amber/_chamberparm.py
+++ b/parmed/amber/_chamberparm.py
@@ -87,8 +87,8 @@ class ChamberParm(AmberParm):
 
     See Also
     --------
-    See :class:`AmberParm` for list of other attributes present in ChamberParm
-    instances
+    :class:`AmberParm` : for list of other attributes present in ChamberParm
+        instances
     """
 
     _cmap_prefix = "CHARMM_"

--- a/parmed/namd/namdbinfiles.py
+++ b/parmed/namd/namdbinfiles.py
@@ -26,7 +26,7 @@ class NamdBinFile(object):
 
     See also
     --------
-    :class:`NamdBinCoor` and :class:`NamdBinVel`
+    NamdBinCoor, NamdBinVel
     """
     _SCALE_FACTOR = 1.0
     def __init__(self, values=[]):

--- a/parmed/openmm/reporters.py
+++ b/parmed/openmm/reporters.py
@@ -666,8 +666,8 @@ class ProgressReporter(StateDataReporter):
 
     See Also
     --------
-    In addition to the above, ProgressReporter also accepts arguments for
-    StateDataReporter
+    StateDataReporter : In addition to the above, ProgressReporter also accepts arguments for
+        StateDataReporter
     """
 
     @needs_openmm

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -632,8 +632,8 @@ class Structure(object):
 
         See Also
         --------
-        :func:`parmed.utils.pandautils.create_dataframe` for full
-        documentation of the generated DataFrame
+        :func:`parmed.utils.pandautils.create_dataframe` : for full
+            documentation of the generated DataFrame
         """
         from parmed.utils.pandautils import create_dataframe
         return create_dataframe(self)
@@ -651,7 +651,7 @@ class Structure(object):
 
         See Also
         --------
-        :func:`parmed.utils.pandautils.load_dataframe` for full documentation
+        :func:`parmed.utils.pandautils.load_dataframe` : for full documentation
         """
         from parmed.utils.pandautils import load_dataframe
         return load_dataframe(self, df)
@@ -3910,8 +3910,8 @@ class StructureView(object):
 
         See Also
         --------
-        :func:`parmed.utils.pandautils.create_dataframe` for full
-        documentation of the generated DataFrame
+        :func:`parmed.utils.pandautils.create_dataframe` : for full
+            documentation of the generated DataFrame
         """
         from parmed.utils.pandautils import create_dataframe
         return create_dataframe(self)
@@ -3927,7 +3927,7 @@ class StructureView(object):
 
         See Also
         --------
-        :func:`parmed.utils.pandautils.load_dataframe` for full documentation
+        :func:`parmed.utils.pandautils.load_dataframe` : for full documentation
         """
         from parmed.utils.pandautils import load_dataframe
         return load_dataframe(self, df)

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -1031,8 +1031,8 @@ class ExtraPoint(Atom):
 
     See Also
     --------
-    :class:`Atom` -- The ExtraPoint constructor also takes all `Atom` arguments
-    as well, and shares all of the same properties
+    :class:`Atom` : The ExtraPoint constructor also takes all `Atom` arguments
+        as well, and shares all of the same properties
     """
     def __init__(self, *args, **kwargs):
         if 'weights' in kwargs:


### PR DESCRIPTION
Tried to recompile docs locally, ran into a couple issues:

* As of commit https://github.com/ParmEd/ParmEd/commit/cd40b754e2ef4497cf3b6f3eb7bd0873a8c4bf46, some functions referenced in the docs no longer exist, and referencing those non-existent functions throws errors when compiling documentation. I removed references to the `netcdffiles.use` function and trimmed the documentation appropriately

* After some sphinx and numpydoc errors when compiling, there's been some issues with the "See Also" standards for numpydoc. I edited them so they would compile.

Docs compiled locally (using sphinx 3.0.4 and numpydoc 1.1.0)