### PR TITLE
Fix the order of assignment of the NBFIX terms.

### DIFF
--- a/parmed/parameters.py
+++ b/parmed/parameters.py
@@ -219,7 +219,7 @@ class ParameterSet(object):
                         (rmin, epsilon, rmin14, epsilon14) = atom.atom_type.nbfix[other_atom]
                         if (other_atom, atom.type) in params.nbfix_types:
                             continue
-                        params.nbfix_types[(atom.type, other_atom)] = (rmin, epsilon)
+                        params.nbfix_types[(atom.type, other_atom)] = (epsilon, rmin)
         for bond in struct.bonds:
             if bond.type is None: continue
             key = (bond.atom1.type, bond.atom2.type)


### PR DESCRIPTION
I used the topology converted from PSF to the gromacs format but the
simulation crashed, and after checking the topology file I found the
epsilon and sigma were wrong. It seems PR #1097 only partially changed
the order of assignment of NBFIX. This commit should fix the issue.