### PR TITLE
Bug in Atom.umass

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -725,7 +725,7 @@ class Atom(_ListItem):
 
     @property
     def umass(self):
-        return self._mass * u.daltons
+        return self.mass * u.daltons
 
     @property
     def usolvent_radius(self):


### PR DESCRIPTION
**Bug**: 
   `self._mass` seems to be undefined in the [Atom](https://github.com/ParmEd/ParmEd/blob/master/parmed/topologyobjects.py#L232) class. Therefore, calling [Atom.umass](https://github.com/ParmEd/ParmEd/blob/master/parmed/topologyobjects.py#L727) raises an AttributeError.

**Fix**: 
   Replace `self._mass` with `self.mass`