### PR TITLE
Improving parameterized inferrence

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -307,9 +307,9 @@ class Structure:
                 retstr.append(' (triclinic)')
             else:
                 retstr.append(' (orthogonal)')
-        # Just assume that if the first bond has a defined type, so does
+        # Just assume that if the first atom has a defined type, so does
         # everything else... we don't want __repr__ to be super expensive
-        if len(self.bonds) > 0 and self.bonds[0].type is not None:
+        if self.atoms[0].type:
             retstr.append('; parametrized>')
         else:
             retstr.append('; NOT parametrized>')

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -309,10 +309,10 @@ class Structure:
                 retstr.append(' (orthogonal)')
         # Just assume that if the first atom has a defined type, so does
         # everything else... we don't want __repr__ to be super expensive
-        if self.atoms[0].atom_type is not UnassignedAtomType and self.atoms[0]._epsilon is None:
-            retstr.append('; parameterized>')
-        else:
+        if self.atoms[0].atom_type is UnassignedAtomType and self.atoms[0]._epsilon is None:
             retstr.append('; NOT parameterized>')
+        else:
+            retstr.append('; parameterized>')
         return ''.join(retstr)
 
     #===================================================

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -309,7 +309,7 @@ class Structure:
                 retstr.append(' (orthogonal)')
         # Just assume that if the first atom has a defined type, so does
         # everything else... we don't want __repr__ to be super expensive
-        if self.atoms[0].type:
+        if self.atoms[0].atom_type is not UnassignedAtomType and self.atoms[0]._epsilon is None:
             retstr.append('; parameterized>')
         else:
             retstr.append('; NOT parameterized>')

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -310,9 +310,9 @@ class Structure:
         # Just assume that if the first atom has a defined type, so does
         # everything else... we don't want __repr__ to be super expensive
         if self.atoms[0].type:
-            retstr.append('; parametrized>')
+            retstr.append('; parameterized>')
         else:
-            retstr.append('; NOT parametrized>')
+            retstr.append('; NOT parameterized>')
         return ''.join(retstr)
 
     #===================================================


### PR DESCRIPTION
In [parmed.structure.Structure._ _repr_ _](https://github.com/ParmEd/ParmEd/blob/master/parmed/structure.py#L293), parameterization is inferred from bonds/bond types. However, for a system of non-bonded parameterized atoms, Structure appears unparameterized. An improvement is suggested here based on atom types.