### PR TITLE
missing check for DihedralType in Dihedral.funct

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -2138,7 +2138,7 @@ class Dihedral(_FourAtomTerm):
     @property
     def funct(self):
         if self._funct is None:
-            if self.type is not None and isinstance(self.type, DihedralTypeList):
+            if self.type is not None and isinstance(self.type, (DihedralType, DihedralTypeList)):
                 return 9
             elif self.type is not None and isinstance(self.type, RBTorsionType):
                 return 3

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -2138,11 +2138,12 @@ class Dihedral(_FourAtomTerm):
     @property
     def funct(self):
         if self._funct is None:
-            if self.type is not None and isinstance(self.type, (DihedralType, DihedralTypeList)):
+            if self.type is not None and isinstance(self.type, DihedralTypeList):
                 return 9
+            elif self.type is not None and isinstance(self.type, DihedralType):
+                return 1
             elif self.type is not None and isinstance(self.type, RBTorsionType):
                 return 3
-            return 1
         return self._funct
 
     @funct.setter

--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -2138,12 +2138,18 @@ class Dihedral(_FourAtomTerm):
     @property
     def funct(self):
         if self._funct is None:
+            # see https://manual.gromacs.org/documentation/current/reference-manual/topologies/topology-file-formats.html
+            # for more info on funct types and their meaning
             if self.type is not None and isinstance(self.type, DihedralTypeList):
-                return 9
+                return 9 # multiple proper dihedral
             elif self.type is not None and isinstance(self.type, DihedralType):
-                return 1
+                return 1 # proper dihedral
             elif self.type is not None and isinstance(self.type, RBTorsionType):
-                return 3
+                return 3 # Ryckaert-Bellemans dihedral
+            elif self.type is not None:
+                raise NotImplementedError(
+                    f"Dihedral.type (self.type) must be: DihedralTypeList, DihedralType, or RBTorsionType."
+                )
         return self._funct
 
     @funct.setter


### PR DESCRIPTION
The `funct` property in the [Dihedral](https://github.com/ParmEd/ParmEd/blob/master/parmed/topologyobjects.py#L2138) class can return incorrect `self._funct` when `self.type` is `DihedralType`. This ensures `Dihedral.funct` checks for `DihedralType` and subsequently returns 1.