### PR TITLE
Add explicit hydrogens when loading in SMILES

### DIFF
--- a/parmed/rdkit/rdkit.py
+++ b/parmed/rdkit/rdkit.py
@@ -27,7 +27,7 @@ class RDKit:
         return PDBFile.parse(fh)
 
     @staticmethod
-    def from_smiles(smiles, coordinates=True):
+    def from_smiles(smiles, coordinates=True, hydrogens=False):
         """
         Load smiles string to :class:`Structure`
 
@@ -36,6 +36,8 @@ class RDKit:
         smiles : str, smiles
         coordinates : bool, default True
             if True, use `rdkit.Chem.AllChem.EmbedMultipleConfs to assign coordinates
+        hydrogens : bool, default False
+            if True, use `rdkit.Chem.AddHs` to generate explicit hydrogens
 
         Returns
         -------
@@ -44,6 +46,9 @@ class RDKit:
         from rdkit import Chem
         from rdkit.Chem import AllChem
         mol = Chem.MolFromSmiles(smiles)
+
+        if hydrogens:
+            mol = Chem.AddHs(mol)
 
         if coordinates:
             AllChem.EmbedMultipleConfs(mol, useExpTorsionAnglePrefs=True, useBasicKnowledge=True)

--- a/parmed/rdkit/rdkit.py
+++ b/parmed/rdkit/rdkit.py
@@ -36,7 +36,7 @@ class RDKit:
         smiles : str, smiles
         coordinates : bool, default True
             if True, use `rdkit.Chem.AllChem.EmbedMultipleConfs to assign coordinates
-        hydrogens : bool, default False
+        hydrogens : bool, default True
             if True, use `rdkit.Chem.AddHs` to generate explicit hydrogens
 
         Returns

--- a/parmed/rdkit/rdkit.py
+++ b/parmed/rdkit/rdkit.py
@@ -27,7 +27,7 @@ class RDKit:
         return PDBFile.parse(fh)
 
     @staticmethod
-    def from_smiles(smiles, coordinates=True, hydrogens=False):
+    def from_smiles(smiles, coordinates=True, hydrogens=True):
         """
         Load smiles string to :class:`Structure`
 

--- a/test/test_parmed_rdkit.py
+++ b/test/test_parmed_rdkit.py
@@ -26,14 +26,14 @@ class TestRDKit(unittest.TestCase):
         smiles = 'C1=CC=CN=C1'
 
         # coordinates = False
-        parm = pmd.rdkit.from_smiles(smiles, coordinates=False)
+        parm = pmd.rdkit.from_smiles(smiles, coordinates=False, hydrogens=False)
         self.assertEqual([atom.name for atom in parm.atoms], ['C1', 'C2', 'C3', 'C4', 'N1', 'C5']) 
         self.assertEqual(parm.residues[0].name, 'UNL')
         self.assertIs(parm.coordinates, None)
         self.assertIs(parm.get_coordinates(), None)
 
         # coordinates = True (default)
-        parm = pmd.rdkit.from_smiles(smiles)
+        parm = pmd.rdkit.from_smiles(smiles, coordinates=True, hydrogens=False)
         np.testing.assert_allclose(parm.coordinates[0], [-1.072,  0.829 ,  0.108])
 
     def test_load_smiles_explicit_hydrogen(self):

--- a/test/test_parmed_rdkit.py
+++ b/test/test_parmed_rdkit.py
@@ -35,3 +35,13 @@ class TestRDKit(unittest.TestCase):
         # coordinates = True (default)
         parm = pmd.rdkit.from_smiles(smiles)
         np.testing.assert_allclose(parm.coordinates[0], [-1.072,  0.829 ,  0.108])
+
+    def test_load_smiles_explicit_hydrogen(self):
+        """ test adding explict hydrogens from smiles string"""
+        smiles = "CC"
+
+        num_atoms = 8 # CH3-CH3
+        parm = pmd.rdkit.from_smiles(smiles=smiles, coordinates=False, hydrogens=True)
+        self.assertEqual(len(parm.atoms), num_atoms)
+        self.assertEqual([atom.name for atom in parm.atoms], ['C1', 'C2', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'])
+


### PR DESCRIPTION
Previously, if a user decided to use `parmed.rdkit.load_smiles` to
generate a `parmed` structure, no explicit hydrogens are added to the
structure, this can be an issue if trying to generate hydrocarbon
systems.

This PR leverages the built-in `rdkit` method `rdkit.Chem.AddHs` to generate explicit
hydrogens for an rdkit mol. An additional boolean flag: `hydrogens=True` has been added to this method. Since this could break others' workflows, the default value is `False` to comply with current functionality.
