### PR TITLE
Changed simtk.openmm to openmm

### DIFF
--- a/GmxTests/11a.Toluene-Cyclohexane_conversion/cross_compare.py
+++ b/GmxTests/11a.Toluene-Cyclohexane_conversion/cross_compare.py
@@ -37,9 +37,9 @@ from chemistry import gromacs
 from chemistry import amber
 
 # OpenMM import
-import simtk.unit as u
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm.unit as u
+import openmm as mm
+import openmm.app as app
 
 
 def energy_components(Sim, verbose=False):

--- a/GmxTests/11a.Toluene-Cyclohexane_conversion/cross_compare_4way.py
+++ b/GmxTests/11a.Toluene-Cyclohexane_conversion/cross_compare_4way.py
@@ -37,9 +37,9 @@ from chemistry import gromacs
 from chemistry import amber
 
 # OpenMM import
-import simtk.unit as u
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm.unit as u
+import openmm as mm
+import openmm.app as app
 
 
 def energy_components(Sim, verbose=False):

--- a/GmxTests/molecule.py
+++ b/GmxTests/molecule.py
@@ -249,9 +249,9 @@ if "forcebalance" in __name__:
     #| OpenMM interface functions |#
     #==============================#
     try: 
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
     except: 
         warn('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
     

--- a/GmxTests/test.py
+++ b/GmxTests/test.py
@@ -31,9 +31,9 @@ from parmed import gromacs, amber
 from parmed.amber.mdin import Mdin
 
 # OpenMM import
-import simtk.unit as u
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm.unit as u
+import openmm as mm
+import openmm.app as app
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-a', '--amber', action='store_true', help='Pass this flag to run AMBER tests along with Gromacs / OpenMM.')

--- a/doc/gromacs.rst
+++ b/doc/gromacs.rst
@@ -245,8 +245,8 @@ Furthermore, you may check the correctness of topology loading by using the
 :class:`GromacsTopologyFile` object to calculate an OpenMM potential energy and
 force, then comparing that result with your own output from Gromacs::
 
-    >>> import simtk.openmm as mm
-    >>> import simtk.openmm.app as app
+    >>> import openmm as mm
+    >>> import openmm.app as app
     >>> system = gmx_top.createSystem() # OpenMM System creation
     >>> integ = mm.VerletIntegrator(1.0*u.femtosecond)
     >>> plat = mm.Platform.getPlatformByName('Reference')

--- a/doc/omm_amber.rst
+++ b/doc/omm_amber.rst
@@ -32,8 +32,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
     
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
     
     # ParmEd Imports
     from parmed import load_file, unit as u
@@ -214,8 +214,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
     
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
     
     # ParmEd Imports
     from parmed import load_file, unit as u

--- a/doc/omm_charmm.rst
+++ b/doc/omm_charmm.rst
@@ -32,8 +32,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
     
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
     
     # ParmEd Imports
     from parmed.charmm import CharmmPsfFile, CharmmCrdFile, CharmmParameterSet
@@ -231,8 +231,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
     
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
     
     # ParmEd Imports
     from parmed.charmm import CharmmPsfFile, CharmmCrdFile, CharmmParameterSet

--- a/doc/omm_gromacs.rst
+++ b/doc/omm_gromacs.rst
@@ -32,8 +32,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
 
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
 
     # ParmEd Imports
     from parmed import load_file
@@ -215,8 +215,8 @@ distribution) will set up and run the simulation using OpenMM::
     import sys
 
     # OpenMM Imports
-    import simtk.openmm as mm
-    import simtk.openmm.app as app
+    import openmm as mm
+    import openmm.app as app
 
     # ParmEd Imports
     from parmed import load_file

--- a/doc/omm_rosetta.rst
+++ b/doc/omm_rosetta.rst
@@ -49,9 +49,9 @@ Start an OpenMM simulation
 Finally, we can use the following code to solvate and
 start simulating our ParmEd :class:`Structure`::
 
-    from simtk.openmm import *
-    from simtk.openmm.app import *
-    from simtk.unit import *
+    from openmm import *
+    from openmm.app import *
+    from openmm.unit import *
 
     ff = ForceField('amber99sbildn.xml', 'tip3p.xml')
 

--- a/doc/openmm.rst
+++ b/doc/openmm.rst
@@ -141,8 +141,8 @@ energy components to be compared between programs more effectively. For
 example::
 
     >>> import parmed as pmd
-    >>> from simtk.openmm import app
-    >>> from simtk import openmm as mm
+    >>> from openmm import app
+    >>> from openmm as mm
     >>> # Instantiate the parm and create the system
     ... parm = pmd.load_file('tip4p.parm7', 'tip4p.rst7')
     >>> system = parm.createSystem(nonbondedMethod=app.PME,
@@ -217,8 +217,8 @@ file with the ff99SB force field::
     import parmed as chem
     import parmed.unit as u
 
-    from simtk.openmm import app
-    from simtk import openmm as mm
+    from openmm import app
+    from openmm as mm
 
     pdb = app.PDBFile('input.pdb')
     forcefield = app.ForceField('amber99sb.xml', 'tip3p.xml')

--- a/examples/amber/simulate_amber_gb.py
+++ b/examples/amber/simulate_amber_gb.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file, unit as u

--- a/examples/amber/simulate_amber_pme.py
+++ b/examples/amber/simulate_amber_pme.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file, unit as u

--- a/examples/charmm/simulate_charmm_gb.py
+++ b/examples/charmm/simulate_charmm_gb.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file, unit as u

--- a/examples/charmm/simulate_charmm_gui.py
+++ b/examples/charmm/simulate_charmm_gui.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file, unit as u

--- a/examples/gromacs/simulate_gromacs_gb.py
+++ b/examples/gromacs/simulate_gromacs_gb.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file

--- a/examples/gromacs/simulate_gromacs_pme.py
+++ b/examples/gromacs/simulate_gromacs_pme.py
@@ -4,8 +4,8 @@ from __future__ import division, print_function
 import sys
 
 # OpenMM Imports
-import simtk.openmm as mm
-import simtk.openmm.app as app
+import openmm as mm
+import openmm.app as app
 
 # ParmEd Imports
 from parmed import load_file

--- a/examples/rosetta/simulate_ala12_mutant.py
+++ b/examples/rosetta/simulate_ala12_mutant.py
@@ -3,9 +3,9 @@
 from __future__ import print_function
 
 # OpenMM imports
-from simtk.openmm import *
-from simtk.openmm.app import *
-from simtk.unit import *
+from openmm import *
+from openmm.app import *
+from openmm.unit import *
 
 # ParmEd imports
 from parmed import load_rosetta

--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -26,8 +26,8 @@ from .asciicrd import AmberAsciiRestart
 from .netcdffiles import NetCDFRestart
 
 try:
-    from simtk import openmm as mm
-    from simtk.openmm import app
+    import openmm as mm
+    from openmm import app
 except ImportError:
     mm = app = None
 
@@ -948,7 +948,7 @@ class AmberParm(AmberFormat, Structure):
         nonbondedMethod : cutoff method
             This is the cutoff method. It can be either the NoCutoff,
             CutoffNonPeriodic, CutoffPeriodic, PME, or Ewald objects from the
-            simtk.openmm.app namespace
+            openmm.app namespace
         nonbondedCutoff : float or distance Quantity
             The nonbonded cutoff must be either a floating point number
             (interpreted as nanometers) or a Quantity with attached units. This

--- a/parmed/entos/converters.py
+++ b/parmed/entos/converters.py
@@ -81,7 +81,7 @@ def to_entos_qmmm_system(
     multiscale_input: QMMMInput
         The QM/MM input
     """
-    from simtk.openmm.app import LJPME, NoCutoff
+    from openmm.app import LJPME, NoCutoff
     if not HAS_MISTRAL:
         raise ImportError("You must install Entos mistral to create a QMMMInput object")
     if struct.coordinates is None:

--- a/parmed/openmm/reporters.py
+++ b/parmed/openmm/reporters.py
@@ -203,7 +203,7 @@ class StateDataReporter:
         simulation : Simulation
             The simulation to generate a report for
         """
-        import simtk.openmm as mm
+        import openmm as mm
         system = simulation.system
         frclist = system.getForces()
         if self._temperature:

--- a/parmed/openmm/topsystem.py
+++ b/parmed/openmm/topsystem.py
@@ -31,9 +31,9 @@ def load_topology(topology, system=None, xyz=None, box=None, condense_atom_types
 
     Parameters
     ----------
-    topology : :class:`simtk.openmm.app.Topology`
+    topology : :class:`openmm.app.Topology`
         The Topology instance with the list of atoms and bonds for this system
-    system : :class:`simtk.openmm.System` or str, optional
+    system : :class:`openmm.System` or str, optional
         If provided, parameters from this System will be applied to the
         Structure. If a string is given, it will be interpreted as the file name
         of an XML-serialized System, and it will be deserialized into a System
@@ -79,7 +79,7 @@ def load_topology(topology, system=None, xyz=None, box=None, condense_atom_types
     If an OpenMM Atom.id attribute is populated by a non-integer, it will be
     used to name the corresponding ParmEd AtomType object.
     """
-    import simtk.openmm as mm
+    import openmm as mm
     struct = Structure()
     atommap = dict()
     for c in topology.chains():

--- a/parmed/openmm/utils.py
+++ b/parmed/openmm/utils.py
@@ -75,7 +75,7 @@ def energy_decomposition_system(structure, system, platform=None,
         Each entry is a tuple with the name of the force followed by its
         contribution
     """
-    import simtk.openmm as mm
+    import openmm as mm
     # First get all of the old force groups so we can restore them
     old_groups = [f.getForceGroup() for f in system.getForces()]
     old_recip_group = []

--- a/parmed/openmm/xmlfile.py
+++ b/parmed/openmm/xmlfile.py
@@ -55,10 +55,10 @@ class XmlFile(metaclass=FileFormatType):
         Parses XML file and returns deserialized object. The return value
         depends on the serialized object, summarized below
 
-            - System : returns simtk.openmm.System
-            - State : returns simtk.openmm.State
-            - Integrator : returns simtk.openmm.Integrator subclass
-            - ForceField : returns simtk.openmm.app.ForceField
+            - System : returns openmm.System
+            - State : returns openmm.State
+            - Integrator : returns openmm.Integrator subclass
+            - ForceField : returns openmm.app.ForceField
 
         Parameters
         ----------
@@ -75,8 +75,8 @@ class XmlFile(metaclass=FileFormatType):
         OpenMM requires the entire contents of this file read into memory. As a
         result, this function may require a significant amount of memory.
         """
-        import simtk.openmm as mm
-        from simtk.openmm import app
+        import openmm as mm
+        from openmm import app
         if isinstance(filename, str):
             with closing(genopen(filename, 'r')) as f:
                 contents = f.read()
@@ -102,7 +102,7 @@ class _OpenMMStateContents:
 
     Parameters
     ----------
-    state : :class:`simtk.openmm.State`
+    state : :class:`openmm.State`
         OpenMM State containing relevant state information
 
     Attributes

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -29,9 +29,9 @@ from .vec3 import Vec3
 
 # Try to import the OpenMM modules
 try:
-    from simtk.openmm import app
-    from simtk import openmm as mm
-    from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
+    from openmm import app
+    import openmm as mm
+    from openmm.app.internal.unitcell import reducePeriodicBoxVectors
 except ImportError:
     mm = app = None
 
@@ -1931,7 +1931,7 @@ class Structure:
         nonbondedMethod : cutoff method
             This is the cutoff method. It can be either the NoCutoff,
             CutoffNonPeriodic, CutoffPeriodic, PME, LJPME, or Ewald objects
-            from the simtk.openmm.app namespace
+            from the openmm.app namespace
         nonbondedCutoff : float or distance Quantity
             The nonbonded cutoff must be either a floating point number
             (interpreted as nanometers) or a Quantity with attached units. This
@@ -2490,7 +2490,7 @@ class Structure:
         nonbondedMethod : cutoff method
             This is the cutoff method. It can be either the NoCutoff,
             CutoffNonPeriodic, CutoffPeriodic, PME, or Ewald objects from the
-            simtk.openmm.app namespace
+            openmm.app namespace
         nonbondedCutoff : float or distance Quantity
             The nonbonded cutoff must be either a floating point number
             (interpreted as nanometers) or a Quantity with attached units. This
@@ -2859,7 +2859,7 @@ class Structure:
         nonbondedMethod : cutoff method
             This is the cutoff method. It can be either the NoCutoff,
             CutoffNonPeriodic, CutoffPeriodic, PME, or Ewald objects from the
-            simtk.openmm.app namespace. Default is NoCutoff
+            openmm.app namespace. Default is NoCutoff
         nonbondedCutoff : float or distance Quantity
             The nonbonded cutoff must be either a floating opint number
             (interpreted as nanometers) or a Quantity with attached units. This
@@ -2879,7 +2879,7 @@ class Structure:
         solventDielectric : float=78.5
             The dielectric constant of the water used in GB
         """
-        from simtk.openmm.app.internal.customgbforces import (
+        from openmm.app.internal.customgbforces import (
             GBSAHCTForce, GBSAOBC1Force, GBSAOBC2Force, GBSAGBnForce, GBSAGBn2Force
         )
         if implicitSolvent is None: return None

--- a/parmed/tools/simulations/openmm.py
+++ b/parmed/tools/simulations/openmm.py
@@ -16,10 +16,10 @@ from ..exceptions import SimulationError, SimulationWarning, UnhandledArgumentWa
 import sys
 import warnings
 try:
-    from simtk.openmm.vec3 import Vec3
-    from simtk.openmm.app import (forcefield as ff, OBC1, OBC2, GBn, HCT, GBn2,
+    from openmm.vec3 import Vec3
+    from openmm.app import (forcefield as ff, OBC1, OBC2, GBn, HCT, GBn2,
                                   Simulation, DCDReporter, amberprmtopfile)
-    import simtk.openmm as mm
+    import openmm as mm
     HAS_OPENMM = True
 except ImportError:
     HAS_OPENMM = False
@@ -32,8 +32,8 @@ _SCRIPT_HEADER = """\
 import os, sys
 
 # Import the OpenMM modules that are necessary
-from simtk.openmm.app import *
-from simtk.openmm import *
+from openmm.app import *
+from openmm import *
 
 # Import the Amber/OpenMM modules
 from parmed.amber import AmberParm, Rst7, AmberMdcrd, AmberMask, NetCDFTraj

--- a/parmed/unit/__init__.py
+++ b/parmed/unit/__init__.py
@@ -20,7 +20,7 @@ __email__ = "cmbruns@stanford.edu"
 # `parmed.unit` package can be used interchangeably with OpenMM
 
 try:
-    from simtk.unit import *
+    from openmm.unit import *
 except ImportError:
     from .unit import Unit, is_unit
     from .quantity import Quantity, is_quantity

--- a/parmed/utils/decorators.py
+++ b/parmed/utils/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 import warnings
 
 try:
-    import simtk.openmm as mm
+    import openmm as mm
     HAS_OPENMM = True
 except ImportError:
     HAS_OPENMM = False

--- a/parmed/vec3.py
+++ b/parmed/vec3.py
@@ -39,7 +39,7 @@ from . import unit
 # available, we try to import it from there, first, and only define our own if
 # OpenMM is not available.
 try:
-    from simtk.openmm.vec3 import Vec3
+    from openmm.vec3 import Vec3
 except ImportError:
     class Vec3(namedtuple('Vec3', ['x', 'y', 'z'])):
         """Vec3 is a 3-element tuple that supports many math operations."""

--- a/test/test_parmed_rosetta.py
+++ b/test/test_parmed_rosetta.py
@@ -3,7 +3,7 @@ from itertools import chain
 from utils import get_fn
 import unittest
 try:
-    from simtk.openmm.app import PDBFile
+    from openmm.app import PDBFile
 except:
     PDBFile = None
 try:

--- a/test/utils.py
+++ b/test/utils.py
@@ -15,8 +15,8 @@ import numpy as np
 from parmed import gromacs, openmm
 
 try:
-    from simtk import openmm as mm
-    from simtk.openmm import app
+    import openmm as mm
+    from openmm import app
     openmm_version = tuple([int(x) for x in mm.__version__.split('.')])
     CPU = mm.Platform.getPlatformByName('CPU')
     Reference = mm.Platform.getPlatformByName('Reference')


### PR DESCRIPTION
New versions of openmm have switched to the `openmm` namespace, rather than `simtk.openmm`. Imports of `simtk.openmm` produce a warning a runtime.

This PR should remove all references to `simtk`.