### PR TITLE
Fix/openmm namespace change

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -31,7 +31,10 @@ from .vec3 import Vec3
 try:
     from simtk.openmm import app
     from simtk import openmm as mm
-    from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
+    try:
+        from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
+    except ModuleNotFoundError:
+        from openmm.app.internal.unitcell import reducePeriodicBoxVectors
 except ImportError:
     mm = app = None
 


### PR DESCRIPTION
Like https://github.com/ParmEd/ParmEd/pull/1173 this PR address the namespace changes coming to openMM, but does this in a backwards compatible way. The main issue I ran into using the openMM dev build was the logic on how parmed checks the version/capabilities of openMM.

```
>>> from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'simtk.openmm.app.internal'
>>> from openmm.app.internal.unitcell import reducePeriodicBoxVectors
>>> 
```

I'm not sure when the next parmed release is planned, but this change is backwards compatible with other openmm versions and perhaps is a good stopgap for users that want to use the latest version of both openmm and parmed. 