### PR TITLE
Bump recursion limit

### DIFF
--- a/parmed/utils/__init__.py
+++ b/parmed/utils/__init__.py
@@ -22,7 +22,7 @@ def tag_molecules(struct) -> List[Set[int]]:
     """
     # Make sure our recursion limit is large enough, but never shrink it
     from sys import setrecursionlimit, getrecursionlimit
-    setrecursionlimit(max(len(struct.atoms), getrecursionlimit()))
+    setrecursionlimit(max(int(1.2 * len(struct.atoms)), getrecursionlimit()))
 
     if not struct.bonds:
         for i, atom in enumerate(struct.atoms):


### PR DESCRIPTION
Fixes #1175 

It seems there may be a couple extra calls to _set_owner than just once per atom, so make sure we grow the recursion limit enough for systems with >1000 atoms all in the same molecule.