### PR TITLE
Recalculate 1-4 nonbonded terms in combining_rules setter

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1589,8 +1589,9 @@ class Structure:
                 combine = lambda sig1, sig2: (sig1 + sig2)/2
             elif thing == "geometric":
                 combine = lambda sig1, sig2: (sig1 * sig2)**2
-
-            for adj in structure.adjusts:
+            if any((not np.isclose(adj.type.sigma, combine(adj.atom1.sigma_14, adj.atom2.sigma_14))) for adj in self.adjusts):
+                raise ValueError("Cannot change the combining rule with modified off-diagonal 1-4 Lennard-Jones parameters")
+            for adj in self.adjusts:
                 adj.type.sigma = combine(adj.atom1.sigma_14, adj.atom2.sigma_14)
 
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1577,7 +1577,18 @@ class Structure:
     def combining_rule(self, thing):
         if thing not in ('lorentz', 'geometric'):
             raise ValueError("combining_rule must be 'lorentz' or 'geometric'")
-        self._combining_rule = thing
+        if self._combining_rule != thing
+            self._combining_rule = thing
+            if thing == 'lorentz':
+                for adj in structure.adjusts:
+                    sig1 = adj.atom1.sigma
+                    sig2 = adj.atom2.sigma
+                    adj.type.sigma = (sig1 + sig2)/2
+            elif thing == 'geometric':
+                for adj in structure.adjusts:
+                    sig1 = adj.atom1.sigma
+                    sig2 = adj.atom2.sigma
+                    adj.type.sigma = (sig1 * sig2) ** 0.5
 
     #===================================================
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -1574,11 +1574,11 @@ class Structure:
         return self._combining_rule
 
     @combining_rule.setter
-    def combining_rule(self, thing):
+    def combining_rule(self, thing, recalculate_14=False):
         if thing not in ('lorentz', 'geometric'):
             raise ValueError("combining_rule must be 'lorentz' or 'geometric'")
-        if self._combining_rule != thing
-            self._combining_rule = thing
+        self._combining_rule = thing
+        if recalculate_14:
             if thing == 'lorentz':
                 for adj in structure.adjusts:
                     sig1 = adj.atom1.sigma

--- a/parmed/utils/__init__.py
+++ b/parmed/utils/__init__.py
@@ -22,7 +22,7 @@ def tag_molecules(struct) -> List[Set[int]]:
     """
     # Make sure our recursion limit is large enough, but never shrink it
     from sys import setrecursionlimit, getrecursionlimit
-    setrecursionlimit(max(len(struct.atoms), getrecursionlimit()))
+    setrecursionlimit(max(int(1.2 * len(struct.atoms)), getrecursionlimit()))
 
     if not struct.bonds:
         for i, atom in enumerate(struct.atoms):


### PR DESCRIPTION
Currently, if the `Structure.adjusts` section is pre-calculated, they will not be recalculated when the `Structure.combining_rule` is updated later. This PR add an option in the `combining_rule` setter method to recalculate sigmas in `Structure.adjusts` to match with the new combining rule. Inspired by @mattwthompson patch in https://github.com/mosdef-hub/foyer/pull/433.