### PR TITLE
Prototype for heterogenous mass repartitioning

### DIFF
--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3291,23 +3291,15 @@ class HMassRepartition(Action):
         # coordination of four). This quickly avoids silly cases like
         # accidentally flagging a rigid water as a three-membered ring.
         #
-        num_hyd_partners =\
-                sum((bp.atomic_number == 1) for bp in atom.bond_partners)
+        num_hyd_partners = sum((bp.atomic_number == 1) for bp in atom.bond_partners)
         num_hvy_partners = len(atom.bond_partners) - num_hyd_partners
         if not (num_hvy_partners >= 2 and num_hyd_partners in [1, 2]):
             return False
-        # Use rdkit Atom.IsInRing() method.
-        #
+
         rmol = self._residue_to_rdkit(atom.residue)
-        for patom, ratom in zip(atom.residue.atoms, rmol.GetAtoms()):
-            if patom != atom:
-                continue
-            if ratom.IsInRing():
-                return True
-            else:
-                return False
-        # This should really never be reached...
-        return False
+        for pa, ra in zip(atom.residue.atoms, rmol.GetAtoms()):
+            if pa == atom:
+                return ra.IsInRing()
 
     def execute(self):
         # Back up the masses in case something goes wrong

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3322,10 +3322,7 @@ class HMassRepartition(Action):
                         return self.new_h_mass
             else:
                 # Cannot enable heterogeneous partitioning. Issue a warning.
-                warnings.warn(
-                    'Cannot use heterogeneous mass repartitioning without '
-                    'rdkit installed.\nContinuing with standard scheme.'
-                )
+                raise ImportError("Heterogeneous mass repartitioning requires rdkit.")
 
         for i, atom in enumerate(self.parm.atoms):
             if atom.atomic_number != 1: continue

--- a/parmed/tools/actions.py
+++ b/parmed/tools/actions.py
@@ -3265,13 +3265,13 @@ class HMassRepartition(Action):
         for atom in mol.atoms:
             atom.type = element_by_name(atom.name)
 
-        stdout_bak = sys.stdout
         rslt = io.StringIO()
-        sys.stdout = rslt
-        Mol2File.write(mol, sys.stdout)
+        Mol2File.write(mol, rslt)
         mol2str = rslt.getvalue()
+        # clean the rslt string
+        rslt.truncate(0)
+        rslt.seek(0)
         rmol = Chem.MolFromMol2Block(mol2str, sanitize=False)
-        sys.stdout = stdout_bak
         return rmol
 
     def is_in_ring(self, atom):


### PR DESCRIPTION
This is a draft implementation of the two-tier mass repartitioning
strategy recently published by the Sugita group. The main change is that
an additional "alternate" target hydrogen mass is supplied for hydrogens
that are connected to a ring. The complete strategy proposed for AMBER
force fields is:

1. reduce the target mass from 3 x 1.008 to 2.5 x 1.008
2. use an alternate target mass of 2 x 1.008

Changes to the code:

- A new optional keyword `altmass` has been added to the HMassRepartition
action that supplies the alternative mass.
- A quick scheme to produce rdkit mol objects from single-residue ParmEd
molecules has been added so that we can access the IsInRing() method for
determining which atoms are in rings.

Things to improve:

The use of rdkit molecules seems to work fine in practice, but is
obviously terribly inefficient -- a new molecule is created for each and
every atom to check rather than the other way around. I can think of
multiple ways to restructure this, but I'll kick that to the development
community. The current implementation seems to work very robustly
regardless.