### PR TITLE
Fix ParmEd 3.4 to work with OpenMM 7.6

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -35,9 +35,12 @@ from .vec3 import Vec3
 try:
     from simtk.openmm import app
     from simtk import openmm as mm
-    from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
-except ImportError:  # pragma: no cover
-    app = mm = None  # pragma: no cover
+    try:
+        from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
+    except ModuleNotFoundError:
+        from openmm.app.internal.unitcell import reducePeriodicBoxVectors
+except ImportError:
+    mm = app = None
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
support future namespace change in openMM while keeping things backwards compatible (#1176)