### PR TITLE
nbfix_symmetry - gromacs test skip

### DIFF
--- a/test/test_parmed_parameterset.py
+++ b/test/test_parmed_parameterset.py
@@ -1,7 +1,7 @@
 """ Tests the functionality in parmed/parameters.py """
 import parmed as pmd
 import unittest
-from utils import get_fn
+from utils import get_fn, HAS_GROMACS
 import warnings
 
 class TestParameterSet(unittest.TestCase):
@@ -79,6 +79,7 @@ class TestParameterSet(unittest.TestCase):
             self.assertEqual(ubt.req, 2.0)
             self.assertEqual(ubt.k, 150.0)
 
+    @unittest.skipUnless(HAS_GROMACS, "Cannot run NBFIX SYMMETRY tests without GROMACS")
     def test_nbfix_symmetry(self):
         """ Tests that nbfixes are being added to each atom type """
         struct = pmd.load_file(get_fn('2PPN_bulk.top'))


### PR DESCRIPTION
TL;DR - Test nbfix_symmetry uses a topology file from OpenFF, which, Gromacs
has.  Without any of the Gromacs data paths, the test fails.  With the
Gromacs data paths, the tests pass.

It might be that nbfix_symmetry has nothing to do with Gromacs, and a better "fix" would be using a topology file without the Gromacs dependency.  I just don't know if that is the case.


Super long story - 
---

No local GROMACS or system GROMACS, the test `test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry` fails
```
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ env | grep GMX 
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ 
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ pytest test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry
====================================================================== test session starts =======================================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /projects2/insite/thomas.watson/Programs/ParmEd.stx
plugins: dependency-0.5.1
collected 1 item                                                                                                                                                 

test/test_parmed_parameterset.py F                                                                                                                         [100%]

============================================================================ FAILURES ============================================================================
______________________________________________________________ TestParameterSet.test_nbfix_symmetry ______________________________________________________________

self = <test_parmed_parameterset.TestParameterSet testMethod=test_nbfix_symmetry>

    def test_nbfix_symmetry(self):
        """ Tests that nbfixes are being added to each atom type """
>       struct = pmd.load_file(get_fn('2PPN_bulk.top'))

test/test_parmed_parameterset.py:84: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/thomas.watson/Programs/ParmEd/parmed/formats/registry.py:211: in load_file
    return cls(filename, *args, **kwargs)
/home/thomas.watson/Programs/ParmEd/parmed/gromacs/gromacstop.py:349: in __init__
    self.read(fname, defines, parametrize)
/home/thomas.watson/Programs/ParmEd/parmed/gromacs/gromacstop.py:386: in read
    for line in f:
/home/thomas.watson/Programs/ParmEd/parmed/gromacs/_gromacsfile.py:42: in __iter__
    for line in self._handle:
/home/thomas.watson/Programs/ParmEd/parmed/gromacs/_cpp.py:174: in __iter__
    self._ppcmdmap[cmd](self, args)
/home/thomas.watson/Programs/ParmEd/parmed/gromacs/_cpp.py:29: in wrapper
    return func(self, args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <parmed.gromacs._cpp.CPreProcessor object at 0x7f9966aacc50>, args = '"oplsaa.ff/forcefield.itp"'

    @_strip_pp_comments
    def _pp_include(self, args):
        if self._satisfiedstack and not self._satisfiedstack[-1]:
            return
        # Locate the include file
        rematch = includere.match(args)
        if not rematch:
            raise PreProcessorError('Bad #include syntax')
        includefile = rematch.groups()[0]
        self.included_files.append(includefile)
        for folder in self._includes:
            testfile = path.join(folder, includefile)
            if path.isfile(testfile):
                break
        else:
            if self._notfound_fatal:
>               raise PreProcessorError(f'Could not find {includefile}')
E               parmed.exceptions.PreProcessorError: Could not find oplsaa.ff/forcefield.itp

/home/thomas.watson/Programs/ParmEd/parmed/gromacs/_cpp.py:283: PreProcessorError
==================================================================== short test summary info =====================================================================
FAILED test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry - parmed.exceptions.PreProcessorError: Could not find oplsaa.ff/forcefield.itp
======================================================================= 1 failed in 2.01s ========================================================================
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ 
```

Using System GROMACS, the test `test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry` passes

```
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ module load gromacs/2021.2
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ env | grep GMX 
GMXBIN=/software_common/gromacs_latest/2021.2/bin
GMXTOOLCHAINDIR=/software_common/gromacs_latest/2021.2/share/cmake
GMXDATA=/software_common/gromacs_latest/2021.2/share/gromacs
GMXLDLIB=/software_common/gromacs_latest/2021.2/lib
GMXMAN=/software_common/gromacs_latest/2021.2/share/man
GMXPREFIX=/software_common/gromacs_latest/2021.2
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ 
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ pytest test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry
====================================================================== test session starts =======================================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /projects2/insite/thomas.watson/Programs/ParmEd.stx
plugins: dependency-0.5.1
collected 1 item                                                                                                                                                 

test/test_parmed_parameterset.py .                                                                                                                         [100%]

======================================================================= 1 passed in 4.03s ========================================================================
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ 
```


Purging the environment variables in the order https://parmed.github.io/ParmEd/html/gromacs.html to demonstrate the test fails.
```
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ export GMXBIN=
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ export GMXDATA=
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ export PATH=/projects2/common/SOFTWARE/miniconda3/envs/apps3/bin:/projects2/insite/thomas.watson/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/thomas.watson/.dotnet/tools
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ pytest test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry
====================================================================== test session starts =======================================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /projects2/insite/thomas.watson/Programs/ParmEd.stx
plugins: dependency-0.5.1
collected 1 item                                                                                                                                                 

test/test_parmed_parameterset.py F                                                                                                                         [100%]

============================================================================ FAILURES ============================================================================
______________________________________________________________ TestParameterSet.test_nbfix_symmetry ______________________________________________________________

self = <test_parmed_parameterset.TestParameterSet testMethod=test_nbfix_symmetry>

    def test_nbfix_symmetry(self):
        """ Tests that nbfixes are being added to each atom type """
>       struct = pmd.load_file(get_fn('2PPN_bulk.top'))

```

With the skip unless
```(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ pytest test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry
====================================================================== test session starts =======================================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /projects2/insite/thomas.watson/Programs/ParmEd.stx
plugins: dependency-0.5.1
collected 1 item                                                                                                                                                 

test/test_parmed_parameterset.py s                                                                                                                         [100%]

======================================================================= 1 skipped in 1.24s =======================================================================
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ module load gromacs/2021.2
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ pytest test/test_parmed_parameterset.py::TestParameterSet::test_nbfix_symmetry
====================================================================== test session starts =======================================================================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /projects2/insite/thomas.watson/Programs/ParmEd.stx
plugins: dependency-0.5.1
collected 1 item                                                                                                                                                 

test/test_parmed_parameterset.py .                                                                                                                         [100%]

======================================================================= 1 passed in 3.84s ========================================================================
(apps3) [thomas.watson@stxfrontend001 ParmEd.stx](master)$ 
```