### PR TITLE
reading gromacs topologies with insertion codes fixed

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -308,7 +308,8 @@ class GromacsTopologyFile(Structure):
                     dihedral_types = dict()
                     exc_types = dict()
                 elif current_section == 'atoms':
-                    molecule.add_atom(*self._parse_atoms(line, params))
+                    atom, resname, resnum, icode = self._parse_atoms(line, params)
+                    molecule.add_atom(atom, resname, resnum, inscode=icode)
                 elif current_section == 'bonds':
                     bond, bond_type = self._parse_bonds(line, bond_types, molecule.atoms)
                     molecule.bonds.append(bond)
@@ -489,7 +490,14 @@ class GromacsTopologyFile(Structure):
         else:
             atom = Atom(atomic_number=atomic_number, name=words[4],
                         type=words[1], charge=charge, mass=mass)
-        return atom, words[3], int(words[2])
+        # check for insertion code
+        if words[2].isnumeric():
+            icode = ''
+            resnum = int(words[2])
+        else:
+            icode = words[2][-1]
+            resnum = int(words[2][:-1])
+        return atom, words[3], resnum, icode
 
     def _parse_bonds(self, line, bond_types, atoms):
         """ Parses a bond line. Returns a Bond, BondType/None """


### PR DESCRIPTION
I fix the issue https://github.com/ParmEd/ParmEd/issues/1153. I tested it and it works correctly. In addition, it does not imply severe modifications that must be extensively tested. I hope it helps

Mario S.