### PR TITLE
Reading a Gromacs topology fails with insertion code or negative number

### DIFF
--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -491,10 +491,10 @@ class GromacsTopologyFile(Structure):
             atom = Atom(atomic_number=atomic_number, name=words[4],
                         type=words[1], charge=charge, mass=mass)
         # check for insertion code
-        if words[2].isnumeric():
+        try:
             icode = ''
             resnum = int(words[2])
-        else:
+        except:
             icode = words[2][-1]
             resnum = int(words[2][:-1])
         return atom, words[3], resnum, icode

--- a/parmed/gromacs/gromacstop.py
+++ b/parmed/gromacs/gromacstop.py
@@ -308,7 +308,8 @@ class GromacsTopologyFile(Structure):
                     dihedral_types = dict()
                     exc_types = dict()
                 elif current_section == 'atoms':
-                    molecule.add_atom(*self._parse_atoms(line, params))
+                    atom, resname, resnum, icode = self._parse_atoms(line, params)
+                    molecule.add_atom(atom, resname, resnum, inscode=icode)
                 elif current_section == 'bonds':
                     bond, bond_type = self._parse_bonds(line, bond_types, molecule.atoms)
                     molecule.bonds.append(bond)
@@ -489,7 +490,14 @@ class GromacsTopologyFile(Structure):
         else:
             atom = Atom(atomic_number=atomic_number, name=words[4],
                         type=words[1], charge=charge, mass=mass)
-        return atom, words[3], int(words[2])
+        # check for insertion code
+        if words[2].isnumeric():
+            icode = ''
+            resnum = int(words[2])
+        else:
+            icode = words[2][-1]
+            resnum = int(words[2][:-1])
+        return atom, words[3], resnum, icode
 
     def _parse_bonds(self, line, bond_types, atoms):
         """ Parses a bond line. Returns a Bond, BondType/None """


### PR DESCRIPTION
Hi Jason. I found a bug in my previous PR. Although rare, negative residues numbers fail with this setup. So I replaced the conditional with a `try-except` clause. According to the tests I did, it should work correctly in all cases.