### PR TITLE
Fix AmberParm.from_structure with CMAPs

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -286,7 +286,7 @@ class AmberParm(AmberFormat, Structure):
             return struct
         if struct.unknown_functional:
             raise TypeError('Cannot instantiate an AmberParm from unknown functional')
-        if (struct.urey_bradleys or struct.impropers or struct.cmaps or
+        if (struct.urey_bradleys or struct.impropers or
                 struct.trigonal_angles or struct.pi_torsions or
                 struct.out_of_plane_bends or struct.stretch_bends or
                 struct.torsion_torsions or struct.multipole_frames):

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -7,7 +7,6 @@ import math
 import numpy as np
 import os
 import re
-import sys
 from io import StringIO
 import parmed as pmd
 from parmed.amber import (
@@ -21,6 +20,7 @@ from parmed import topologyobjects, load_file, Structure
 from parmed.tools import change
 import parmed.unit as u
 from parmed.utils import PYPY
+from parmed.gromacs import GromacsTopologyFile
 import pickle
 import random
 import saved_outputs as saved
@@ -30,7 +30,6 @@ from utils import (
     get_fn, FileIOTestCase, equal_atoms, create_random_structure, HAS_GROMACS,
     diff_files, has_openmm
 )
-import warnings
 from string import ascii_letters as letters
 
 def _picklecycle(obj):
@@ -360,6 +359,10 @@ class TestReadParm(FileIOTestCase):
         parm2.write_parm(f)
         f.seek(0)
         check_parm_for_cmap(readparm.AmberParm(f))
+        # Check that from_structure works correctly when reading from GROMACS with just cmap
+        from_struct_parm = readparm.AmberParm.from_structure(GromacsTopologyFile.from_structure(parm))
+        self.assertIs(type(from_struct_parm), type(parm))
+        check_parm_for_cmap(from_struct_parm)
 
     def test_chamber_gas_parm(self):
         """Test the ChamberParm class with a non-periodic (gas phase) prmtop"""


### PR DESCRIPTION
AmberParm.from_structure would fail when converting a topology of some sort that contained only a CMAP, despite this being a now-supported potential term in canonical Amber topology files.

This was already properly supported when *reading* Amber topology files, but not when converting from another format.  This adds a test and fixes that shortcoming.

Fixes #1228