### PR TITLE
Fix AmberParm.from_structure with CMAPs v3.4

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -304,7 +304,7 @@ class AmberParm(AmberFormat, Structure):
             return struct
         if struct.unknown_functional:
             raise TypeError('Cannot instantiate an AmberParm from unknown functional')
-        if (struct.urey_bradleys or struct.impropers or struct.cmaps or
+        if (struct.urey_bradleys or struct.impropers or
                 struct.trigonal_angles or struct.pi_torsions or
                 struct.out_of_plane_bends or struct.stretch_bends or
                 struct.torsion_torsions or struct.multipole_frames):

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -9,7 +9,6 @@ import math
 import numpy as np
 import os
 import re
-import sys
 import parmed as pmd
 from parmed.amber import (
     readparm, asciicrd, mask, parameters, mdin, FortranFormat, titratable_residues, AmberOFFLibrary
@@ -24,6 +23,7 @@ import parmed.unit as u
 from parmed.utils import PYPY
 from parmed.utils.six import string_types, iteritems
 from parmed.utils.six.moves import range, zip, StringIO
+from parmed.gromacs import GromacsTopologyFile
 import pickle
 import random
 import saved_outputs as saved
@@ -33,7 +33,6 @@ from utils import (
     get_fn, FileIOTestCase, equal_atoms, create_random_structure, HAS_GROMACS,
     diff_files, has_openmm
 )
-import warnings
 try:
     from string import letters
 except ImportError:
@@ -380,6 +379,10 @@ class TestReadParm(FileIOTestCase):
         parm2.write_parm(f)
         f.seek(0)
         check_parm_for_cmap(readparm.AmberParm(f))
+        # Check that from_structure works correctly when reading from GROMACS with just cmap
+        from_struct_parm = readparm.AmberParm.from_structure(GromacsTopologyFile.from_structure(parm))
+        self.assertIs(type(from_struct_parm), type(parm))
+        check_parm_for_cmap(from_struct_parm)
 
     def test_chamber_gas_parm(self):
         """Test the ChamberParm class with a non-periodic (gas phase) prmtop"""


### PR DESCRIPTION
Same as #1233, but for the v3.4 branch.