### PR TITLE
Ignore blank lines in mol2

### DIFF
--- a/parmed/formats/mol2.py
+++ b/parmed/formats/mol2.py
@@ -91,7 +91,7 @@ class Mol2File(metaclass=FileFormatType):
             headtail = 'head'
             molecule_number = 0
             for line in f:
-                if line.startswith('#') or (not line.strip() and section is None):
+                if line.startswith('#') or (not line.strip() and section is None) or line == '\n':
                     continue
                 if line.startswith('@<TRIPOS>'):
                     section = line[9:].strip()


### PR DESCRIPTION
Some programs such as MDAnalysis with generate mol2 files with blank lines between the ATOM BOND and SUBSTRUCTURE sections.

Loading these with  `parmed.load_file` results in `IndexError: list index out of range`. See example file: [l_H22.txt](https://github.com/ParmEd/ParmEd/files/9244102/l_H22.txt)

I think the blank lines are in spec and there has been some discussions here: https://github.com/MDAnalysis/mdanalysis/issues/3747

This PR adds a small change to mol2 parser that continues on blank lines and this allows the file to be loaded. Please let me know if there is a better solution or I can do something different.

Cheers,
Alex
