### PR TITLE
Set atomic number when applying a patch

### DIFF
--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -474,7 +474,7 @@ class ResidueTemplate(object):
                 residue[atom.name].type = atom.type
                 residue[atom.name].charge = atom.charge
             else:
-                residue.add_atom(Atom(name=atom.name, type=atom.type, charge=atom.charge))
+                residue.add_atom(Atom(name=atom.name, type=atom.type, charge=atom.charge, atomic_number=atom.atomic_number))
             modifications_made = True
         # Add bonds
         for (atom1_name, atom2_name, order) in patch.add_bonds:


### PR DESCRIPTION
When applying a patch to a residue, the atomic number was not set correctly for the added atoms.  The result was that bonds were not added correctly when writing an OpenMM force field, since it thought all the new atoms were virtual sites or drude particles.  See https://github.com/openmm/openmm/issues/3815.