### PR TITLE
set `python_requires` to `>=3.8`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,5 +126,6 @@ if __name__ == '__main__':
           ext_modules=extensions,
           cmdclass=cmdclass,
           package_data={'parmed.modeller': ['data/*.lib', 'data/*.json']},
+          python_requires='>=3.8',
           **kws
     )


### PR DESCRIPTION
Python support has been restricted to Python v3.8 and newer, but `python_requires` is not set. Thus, the new version of ParmEd will still be installed when one use `pip` to install ParmEd on an older Python version. By setting `python_requires`, pip with old Python versions will not install the new version of ParmEd.