### PR TITLE
Fix bug with adding positional restraints for OpenMM (ParmEd#1301)

### DIFF
--- a/parmed/tools/simulations/openmm.py
+++ b/parmed/tools/simulations/openmm.py
@@ -53,7 +53,7 @@ def positional_restraints(mask, weights, refc, scriptfile=None):
     """
     parm = mask.parm # store the parm object
     try:
-        refc = refc.reshape((-1, len(parm.atoms), 3))
+        refc = refc.coordinates.reshape((-1, len(parm.atoms), 3))
     except ValueError:
         raise SimulationError('Invalid shape of coordinate array')
 


### PR DESCRIPTION
Closes #1301 by calling the coordinate array from the Rst7 object.