### PR TITLE
Fix bug with restart reporter for OpenMM minimization

### DIFF
--- a/parmed/tools/simulations/openmm.py
+++ b/parmed/tools/simulations/openmm.py
@@ -562,7 +562,7 @@ def simulate(parm, args):
                                       maxIterations=mdin.cntrl_nml['maxcyc'])
             rep.report(simulation)
             # Write a restart file with the new coordinates
-            restrt_reporter = RestartReporter(restart, 1, parm.ptr('natom'), False,
+            restrt_reporter = RestartReporter(restart, 1, False,
                                               mdin.cntrl_nml['ntxo'] == 2, write_velocities=False)
             restrt_reporter.report(simulation, simulation.context.getState(getPositions=True,
                                    enforcePeriodicBox=bool(mdin.cntrl_nml['ntb'])))


### PR DESCRIPTION
There was a spurious argument in the `RestartReporter` function call for OpenMM minimization causing the error:

>    TypeError: __init__() got multiple values for argument 'write_velocities'

Getting rid of the `parm.ptr('natom')` argument resolves the error and brings the function in line with what is written to the script file (lines 553-554).