### PR TITLE
Added 3D-RISM and GBNSR6 to mdin configuration

### DIFF
--- a/parmed/amber/mdin/cntrl.py
+++ b/parmed/amber/mdin/cntrl.py
@@ -95,3 +95,4 @@ class cntrl:
             'iamd' : 0, 'restraintwt' : 0.0, 'barostat' : 1, 'mcbarint' : 100,
             'lj1264' : 0, 'icnstph' : 0, 'solvph' : 7.0, 'ntcnstph' : 10,
         }
+        self.gbnsr6: Dict[str, InputDataType] = {'inp': 1}

--- a/parmed/amber/mdin/gbnsr6.py
+++ b/parmed/amber/mdin/gbnsr6.py
@@ -1,0 +1,36 @@
+"""
+This module contains all of the gbnsr6 namelist variables for the
+amber programs and automatically loads those dictionaries with the   
+default values found in that program (sander only).                  
+
+                           GPL LICENSE INFO                             
+
+Copyright (C) 2022 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.
+"""
+
+from typing import Dict
+
+from .typing import InputDataType
+class gbnsr6:
+
+    def __init__(self):
+        self.gbnsr6: Dict[str, InputDataType] = {
+            'b': 0.028, 'alpb': 1, 'epsin': 1.0, 'epsout': 78.5, 'istrng': 0.0, 'rs': 0.52, 'dprob': 1.4,
+            'space': 0.5, 'arcres': 0.2, 'rbornstat': 0, 'dgij': 0, 'radiopt': 0, 'chagb': 0, 'roh': 0.586,
+            'tau': 1.47, 'cavity_surften': 0.005
+        }

--- a/parmed/amber/mdin/gbnsr6.py
+++ b/parmed/amber/mdin/gbnsr6.py
@@ -5,7 +5,7 @@ default values found in that program (sander only).
 
                            GPL LICENSE INFO                             
 
-Copyright (C) 2022 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
+Copyright (C) 2023 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/parmed/amber/mdin/mdin.py
+++ b/parmed/amber/mdin/mdin.py
@@ -100,7 +100,13 @@ class Mdin:
                 if not header_printed:
                     file.write(f"{header}\n")
                     header_printed = True
-                if isinstance(val, str):
+                if isinstance(val, (list, tuple)):
+                    if isinstance(val[0], str):
+                        temp_out = ','.join(map(lambda x: f"'{x}'", val))
+                        line = addOn(line, f"{var}={temp_out}, ", file)
+                    else:
+                        line = addOn(line, f"{var}={','.join(map(str, val))}, ", file)
+                elif isinstance(val, str):
                     line = addOn(line, f"{var}='{val}', ", file)
                 else:
                     line = addOn(line, f"{var}={val}, ", file)

--- a/parmed/amber/mdin/mdin.py
+++ b/parmed/amber/mdin/mdin.py
@@ -225,9 +225,6 @@ class Mdin:
         if namelist in namelist_map:
 
             nml, nml_defaults = namelist_map[namelist]
-            if namelist == 'rism':
-                print(f"{nml}")
-                print(f"{nml_defaults}")
             if variable in nml:
                 mytype = type(nml_defaults[variable])
                 nml[variable] = mytype(value)

--- a/parmed/amber/mdin/mdin.py
+++ b/parmed/amber/mdin/mdin.py
@@ -10,6 +10,8 @@ from .cntrl import cntrl
 from .ewald import ewald
 from .pb import pb
 from .qmmm import qmmm
+from .rism import rism
+from .gbnsr6 import gbnsr6
 from ...exceptions import InputError
 
 
@@ -32,6 +34,8 @@ class Mdin:
         self.ewald_obj = ewald() # object with ewald namelist vars in a dictionary
         self.pb_obj = pb()       # object with pb namelist vars in a dictionary
         self.qmmm_obj = qmmm()   # object with qmmm namelist vars in a dictionary
+        self.rism_obj = rism()   # object with rism namelist vars in a dictionary
+        self.gbnsr6_obj = gbnsr6()   # object with gbnsr6 namelist vars in a dictionary
         self.verbosity = 0       # verbosity level: 0 -- print nothing
                                  #                  1 -- print errors
                                  #                  2 -- 1 + warnings
@@ -46,6 +50,10 @@ class Mdin:
         self.pb_nml_defaults = {}    # dictionary with default pb namelist vars
         self.qmmm_nml = {}           # dictionary with qmmm namelist vars
         self.qmmm_nml_defaults = {}  # dictionary with default qmmm namelist vars
+        self.rism_nml = {}           # dictionary with rism namelist vars
+        self.rism_nml_defaults = {}  # dictionary with default rism namelist vars
+        self.gbnsr6_nml = {}           # dictionary with gbnsr6 namelist vars
+        self.gbnsr6_nml_defaults = {}  # dictionary with default gbnsr6 namelist vars
         self.valid_namelists = {}    # array with valid namelists for each program
         self.title = 'mdin prepared by ParmEd'   # title for the mdin file
 
@@ -55,7 +63,8 @@ class Mdin:
             self.ewald_nml = self.ewald_obj.sander
             self.pb_nml = self.pb_obj.sander
             self.qmmm_nml = self.qmmm_obj.sander
-            self.valid_namelists = {'cntrl', 'ewald', 'qmmm', 'pb'}
+            self.rism_nml = self.rism_obj.sander
+            self.valid_namelists = {'cntrl', 'ewald', 'qmmm', 'pb', 'rism'}
         elif self.program == "sander.APBS":
             self.cntrl_nml = self.cntrl_obj.sander
             self.pb_nml = self.pb_obj.sanderAPBS
@@ -64,6 +73,10 @@ class Mdin:
             self.cntrl_nml = self.cntrl_obj.pmemd
             self.ewald_nml = self.ewald_obj.pmemd
             self.valid_namelists = {'cntrl', 'ewald'}
+        elif self.program == "gbnsr6":
+            self.cntrl_nml = self.cntrl_obj.gbnsr6
+            self.gbnsr6_nml = self.gbnsr6_obj.gbnsr6
+            self.valid_namelists = ['cntrl', 'gb']
         else:
             raise InputError(f"Unrecognized program [{self.program}]")
 
@@ -71,10 +84,12 @@ class Mdin:
         self.ewald_nml_defaults = self.ewald_nml.copy()
         self.pb_nml_defaults = self.pb_nml.copy()
         self.qmmm_nml_defaults = self.qmmm_nml.copy()
+        self.rism_nml_defaults = self.rism_nml.copy()
+        self.gbnsr6_nml_defaults = self.gbnsr6_nml.copy()
 
     def write(self, filename: str = 'mdin'):
 
-        def write_nml(nml, defaults, file: TextIOBase, header) -> None:
+        def write_nml(nml, defaults, file: TextIOBase, header, print_header=False) -> None:
             # automatic indent of single space
             line = ' '
             header_printed = False
@@ -92,6 +107,12 @@ class Mdin:
             # flush any remaining items that haven't yet been printed to the mdin file
             if line.strip():
                 file.write(f"{line}\n")
+
+            # gbnsr6 requieres always print the cntrl header, so we check if was already printed
+            if not header_printed and print_header:
+                file.write(f"{header}\n")
+                header_printed = True
+
             # End namelist
             if header_printed:
                 file.write('/\n')
@@ -99,11 +120,13 @@ class Mdin:
         # open the file for writing and write the header and &cntrl namelist
         file = open(filename,'w')
         file.write(self.title + '\n')
-        write_nml(self.cntrl_nml, self.cntrl_nml_defaults, file, "&cntrl")
+        write_nml(self.cntrl_nml, self.cntrl_nml_defaults, file, "&cntrl", True)
         write_nml(self.ewald_nml, self.ewald_nml_defaults, file, "&ewald")
         pb_nml_name = "&apbs" if self.program == "sander.APBS" else "&pb"
         write_nml(self.pb_nml, self.pb_nml_defaults, file, pb_nml_name)
-        if self.cntrl_nml["ifqnt"] == 1:
+        write_nml(self.gbnsr6_nml, self.gbnsr6_nml_defaults, file, "&gb")
+        write_nml(self.rism_nml, self.rism_nml_defaults, file, "&rism")
+        if self.cntrl_nml.get("ifqnt") == 1:
             write_nml(self.qmmm_nml, self.qmmm_nml_defaults, file, "&qmmm")
 
         # Write the cards to the input file
@@ -190,6 +213,8 @@ class Mdin:
             pb=(self.pb_nml, self.pb_nml_defaults),
             apbs=(self.pb_nml, self.pb_nml_defaults),
             qmmm=(self.qmmm_nml, self.qmmm_nml_defaults),
+            rism=(self.rism_nml, self.rism_nml_defaults),
+            gb=(self.gbnsr6_nml, self.gbnsr6_nml_defaults)
         )
 
         variable = variable.lower()
@@ -198,7 +223,11 @@ class Mdin:
                 value = value[1:-1]
 
         if namelist in namelist_map:
+
             nml, nml_defaults = namelist_map[namelist]
+            if namelist == 'rism':
+                print(f"{nml}")
+                print(f"{nml_defaults}")
             if variable in nml:
                 mytype = type(nml_defaults[variable])
                 nml[variable] = mytype(value)
@@ -299,6 +328,12 @@ class Mdin:
         self.change('cntrl','maxcyc', maxcyc)
         self.change('cntrl','ncyc', ncyc)
         self.change('cntrl','ntmin', ntmin)
+
+    def rism(self, imin=5, irism=1):
+        self.change('cntrl', 'imin', imin)
+        self.change('cntrl', 'irism', irism)
+
+    #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 
     def AddCard(self, title='Residues in card', cardString='RES 1'):
         self.cards.append('%s\n%s\nEND' % (title, cardString))

--- a/parmed/amber/mdin/mdin.py
+++ b/parmed/amber/mdin/mdin.py
@@ -125,7 +125,8 @@ class Mdin:
         pb_nml_name = "&apbs" if self.program == "sander.APBS" else "&pb"
         write_nml(self.pb_nml, self.pb_nml_defaults, file, pb_nml_name)
         write_nml(self.gbnsr6_nml, self.gbnsr6_nml_defaults, file, "&gb")
-        write_nml(self.rism_nml, self.rism_nml_defaults, file, "&rism")
+        if self.cntrl_nml.get('irism'):
+            write_nml(self.rism_nml, self.rism_nml_defaults, file, "&rism", True)
         if self.cntrl_nml.get("ifqnt") == 1:
             write_nml(self.qmmm_nml, self.qmmm_nml_defaults, file, "&qmmm")
 

--- a/parmed/amber/mdin/rism.py
+++ b/parmed/amber/mdin/rism.py
@@ -1,0 +1,40 @@
+"""
+This module contains all of the rism namelist variables for the
+amber programs and automatically loads those dictionaries with the   
+default values found in that program (sander only).                  
+
+                           GPL LICENSE INFO                             
+
+Copyright (C) 2022 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.
+"""
+from typing import Dict
+
+from .typing import InputDataType
+
+class rism:
+
+    def __init__(self):
+        self.sander: Dict[str, InputDataType] = {
+            'closure': ["kh"], 'noasympcorr': 1, 'buffer': 14.0, 'solvcut': -1.0, 'grdspc': [0.5, 0.5, 0.5],
+            'ng3': [-1, -1, -1], 'solvbox': [-1, -1, -1], 'tolerance': [1e-05], 'ljtolerance': -1.0,
+            'asympkspacetolerance': -1.0, 'treedcf': 1, 'treetcf': 1, 'treecoulomb': 0, 'treedcfmac': 0.1,
+            'treetcfmac': 0.1, 'treecoulombmac': 0.1, 'treedcforder': 2, 'treetcforder': 2, 'treecoulomborder': 2,
+            'treedcfn0': 500, 'treetcfn0': 500, 'treecoulombn0': 500, 'mdiis_del': 0.7, 'mdiis_nvec': 5,
+            'mdiis_restart': 10.0, 'maxstep': 10000, 'npropagate': 5, 'polardecomp': 0, 'entropicdecomp': 0,
+            'verbose': 0, 'gfcorrection': 0, 'pcpluscorrection': 0
+        }

--- a/parmed/amber/mdin/rism.py
+++ b/parmed/amber/mdin/rism.py
@@ -5,7 +5,7 @@ default values found in that program (sander only).
 
                            GPL LICENSE INFO                             
 
-Copyright (C) 2022 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
+Copyright (C) 2023 Valdés-Tresanco MS, Valdés-Tresanco ME and Jason Swails
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/test/test_parmed_amber.py
+++ b/test/test_parmed_amber.py
@@ -2409,7 +2409,7 @@ class TestAmberMdin(FileIOTestCase):
         """ Tests the Mdin object basic features """
         fn = self.get_fn('test.mdin', written=True)
         mdin1 = mdin.Mdin('sander')
-        self.assertEqual(set(mdin1.valid_namelists), {'cntrl', 'ewald', 'qmmm', 'pb'})
+        self.assertEqual(set(mdin1.valid_namelists), {'cntrl', 'ewald', 'qmmm', 'pb', 'rism'})
         self.assertEqual(mdin1.title, 'mdin prepared by ParmEd')
         self.assertEqual(mdin1.verbosity, 0)
         # What the heck was this for?
@@ -2489,6 +2489,11 @@ class TestAmberMdin(FileIOTestCase):
         self.assertEqual(mdin1.cntrl_nml['maxcyc'], 1)
         self.assertEqual(mdin1.cntrl_nml['ncyc'], 10)
         self.assertEqual(mdin1.cntrl_nml['ntmin'], 1)
+        mdin1.rism()
+        self.assertEqual(mdin1.cntrl_nml['imin'], 5)
+        self.assertEqual(mdin1.cntrl_nml['irism'], 1)
+        self.assertEqual(mdin1.rism_nml['closure'], ['kh'])
+
         mdin1.change('cntrl', 'ifqnt', 1)
         mdin1.change('pb', 'istrng', 1.0)
         mdin1.change('qmmm', 'qmcharge', -1)
@@ -2505,12 +2510,28 @@ class TestAmberMdin(FileIOTestCase):
             self.assertEqual(mdin1.cntrl_nml[var], mdin2.cntrl_nml[var])
         for var in mdin1.qmmm_nml.keys():
             self.assertEqual(mdin1.qmmm_nml[var], mdin2.qmmm_nml[var])
+        for var in mdin1.rism_nml.keys():
+            self.assertEqual(mdin1.rism_nml[var], mdin2.rism_nml[var])
         mdin3 = mdin.Mdin(program='pmemd')
         self.assertRaises(InputError, lambda: mdin3.change('cntrl', 'ievb', 1))
         self.assertRaises(InputError, lambda: mdin.Mdin(program='charmm'))
         mdin4 = mdin.Mdin(program='sander.APBS')
         mdin4.change('cntrl', 'igb', 10)
         mdin4.change('pb', 'bcfl', 1)
+
+        fn2 = self.get_fn('test2.mdin', written=True)
+        mdin5 = mdin.Mdin(program='gbnsr6')
+        self.assertEqual(mdin5.cntrl_nml['inp'], 1)
+        self.assertEqual(mdin5.gbnsr6_nml['epsin'], 1.0)
+        self.assertEqual(mdin5.gbnsr6_nml['epsout'], 78.5)
+        mdin5.write(fn2)
+        mdin6 = mdin.Mdin(program='gbnsr6')
+        mdin6.read(fn2)
+        for var in mdin5.cntrl_nml.keys():
+            self.assertEqual(mdin5.cntrl_nml[var], mdin6.cntrl_nml[var])
+        for var in mdin5.gbnsr6_nml.keys():
+            self.assertEqual(mdin5.gbnsr6_nml[var], mdin6.gbnsr6_nml[var])
+
 
 class TestRst7Class(FileIOTestCase):
     """ Test the Rst7 class """


### PR DESCRIPTION
This was left unimplemented from the v3.4 branch. Like the last time, I have made the modifications so that the old and the new work and added the test. I wanted to have done it yesterday so it would go out in v4.1.0, but the remote on GitHub had problems, so I could not do anything. Let me know your comments.