### PR TITLE
Flip guess strategy for atomic numbers

### DIFF
--- a/parmed/periodic_table.py
+++ b/parmed/periodic_table.py
@@ -289,15 +289,14 @@ def element_by_name(name):
     if len(name) == 0:
         return Element[0]
     try:
-        atomic_number = AtomicNum[name[0].upper()]
-    except KeyError:
         sym = name[:2]
+        sym = '%s%s' % (sym[0].upper(), sym[1].lower())
+        atomic_number = AtomicNum[sym]
+    except (KeyError, IndexError):
         try:
-            sym = '%s%s' % (sym[0].upper(), sym[1].lower())
-            atomic_number = AtomicNum[sym]
-        except (KeyError, IndexError):
+            atomic_number = AtomicNum[name[0].upper()]
+        except KeyError:
             atomic_number = 0 # give up
-
     return Element[atomic_number]
 
 # Add some mass aliases here. We need to do it *after* _sorted_masses is created above, since


### PR DESCRIPTION
Invert the order of guessing so that the first two letters are tried first instead of second -- maybe there's a good reason why this wasn't done this way originally?

This lead to a bug in my code when a mol2 from AmberTools Antechamber was generated with the name/type CL1 and ParmEd kept reading it as carbon. This change fixes my case at least, but maybe it breaks something else I'm not thinking about?