### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ if __name__ == '__main__':
           packages=packages,
           ext_modules=extensions,
           cmdclass=cmdclass,
-          package_data={'parmed.modeller': ['data/*.lib', 'data/*.json']},
+          package_data={'parmed.modeller': ['data/*.lib', 'data/*.json', 'data/*.json.gz']},
           python_requires='>=3.8',
           **kws
     )


### PR DESCRIPTION
The nonstandard residue file was not getting included in the distribution builds because it was compressed and the extension didn't match what was in the setup.py file.