### PR TITLE
fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/parmed/amber/parameters.py
+++ b/parmed/amber/parameters.py
@@ -25,13 +25,13 @@ subs = dict(FLOATRE=r'([+-]?(?:\d+(?:\.\d*)?|\.\d+))',
 _bondre = re.compile(r'(..?)-(..?)\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
 _anglere = re.compile(r'(..?)-(..?)-(..?)\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
 _dihedre = re.compile(r'(..?)-(..?)-(..?)-(..?)\s+%(FLOATRE)s\s+'
-                      '%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
+                      r'%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
 _dihed2re = re.compile(r'\s*%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s\s+'
                        '%(FLOATRE)s' % subs)
 _sceere = re.compile(r'SCEE=\s*%(FLOATRE)s' % subs)
 _scnbre = re.compile(r'SCNB=\s*%(FLOATRE)s' % subs)
 _impropre = re.compile(r'(..?)-(..?)-(..?)-(..?)\s+'
-                       '%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
+                       r'%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
 # Leaprc regexes
 _atomtypere = re.compile(r"""({\s*["']([\w\+\-]+)["']\s*["'](\w+)["']\s*"""
                          r"""["'](\w+)["']\s*})""")

--- a/parmed/formats/pdbx/PdbxReader.py
+++ b/parmed/formats/pdbx/PdbxReader.py
@@ -326,16 +326,16 @@ class PdbxReader(object):
         mmcifRe = re.compile(
             r"(?:"
 
-             "(?:_(.+?)[.](\S+))"               "|"  # _category.attribute
+            r"(?:_(.+?)[.](\S+))"              r"|"  # _category.attribute
 
-             "(?:['](.*?)(?:[']\s|[']$))"       "|"  # single quoted strings
-             "(?:[\"](.*?)(?:[\"]\s|[\"]$))"    "|"  # double quoted strings             
+            r"(?:['](.*?)(?:[']\s|[']$))"      r"|"  # single quoted strings
+            r"(?:[\"](.*?)(?:[\"]\s|[\"]$))"   r"|"  # double quoted strings             
 
-             "(?:\s*#.*$)"                      "|"  # comments (dumped)
+            r"(?:\s*#.*$)"                     r"|"  # comments (dumped)
 
-             "(\S+)"                                 # unquoted words
+            r"(\S+)"                                 # unquoted words
 
-             ")")
+            r")")
 
         fileIter = iter(ifh)
 
@@ -398,15 +398,15 @@ class PdbxReader(object):
         mmcifRe = re.compile(
             r"(?:"
 
-             "(?:_(.+?)[.](\S+))"               "|"  # _category.attribute
+            r"(?:_(.+?)[.](\S+))"               r"|"  # _category.attribute
 
-             "(?:['\"](.*?)(?:['\"]\s|['\"]$))" "|"  # quoted strings
+            r"(?:['\"](.*?)(?:['\"]\s|['\"]$))" r"|"  # quoted strings
 
-             "(?:\s*#.*$)"                      "|"  # comments (dumped)
+            r"(?:\s*#.*$)"                      r"|"  # comments (dumped)
 
-             "(\S+)"                                 # unquoted words
+            r"(\S+)"                                  # unquoted words
 
-             ")")
+            r")")
 
         fileIter = iter(ifh)
 


### PR DESCRIPTION
Fix the following warnings:

```
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:329: SyntaxWarning: invalid escape sequence '\S'
    "(?:_(.+?)[.](\S+))"               "|"  # _category.attribute
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:331: SyntaxWarning: invalid escape sequence '\s'
    "(?:['](.*?)(?:[']\s|[']$))"       "|"  # single quoted strings
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:332: SyntaxWarning: invalid escape sequence '\s'
    "(?:[\"](.*?)(?:[\"]\s|[\"]$))"    "|"  # double quoted strings
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:334: SyntaxWarning: invalid escape sequence '\s'
    "(?:\s*#.*$)"                      "|"  # comments (dumped)
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:336: SyntaxWarning: invalid escape sequence '\S'
    "(\S+)"                                 # unquoted words
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:401: SyntaxWarning: invalid escape sequence '\S'
    "(?:_(.+?)[.](\S+))"               "|"  # _category.attribute
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:403: SyntaxWarning: invalid escape sequence '\s'
    "(?:['\"](.*?)(?:['\"]\s|['\"]$))" "|"  # quoted strings
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:405: SyntaxWarning: invalid escape sequence '\s'
    "(?:\s*#.*$)"                      "|"  # comments (dumped)
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/formats/pdbx/PdbxReader.py:407: SyntaxWarning: invalid escape sequence '\S'
    "(\S+)"                                 # unquoted words
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/amber/parameters.py:28: SyntaxWarning: invalid escape sequence '\s'
    '%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/parmed/amber/parameters.py:34: SyntaxWarning: invalid escape sequence '\s'
    '%(FLOATRE)s\s+%(FLOATRE)s\s+%(FLOATRE)s' % subs)
```