### PR TITLE
Ignore TURN comments in PDBs

### DIFF
--- a/parmed/formats/pdb.py
+++ b/parmed/formats/pdb.py
@@ -192,7 +192,7 @@ class PDBFile(metaclass=FileFormatType):
                         'ANISOU', 'CISPEP', 'CONECT', 'DBREF ', 'HELIX ', 'HET   ', 'LINK  ', 'MODRES',
                         'REVDAT', 'SEQADV', 'SHEET ', 'SSBOND', 'FORMUL', 'HETNAM', 'HETSYN', 'SEQRES', 'SITE  ',
                         'ENDMDL', 'MODEL ', 'TER   ', 'JRNL  ', 'REMARK', 'TER', 'DBREF ', 'DBREF2', 'DBREF1',
-                        'DBREF', 'HET', 'LINKR '}:
+                        'DBREF', 'HET', 'LINKR ', 'TURN  '}:
                     continue
                 # Hack to support reduce-added flags
                 elif line[:6] == 'USER  ' and line[6:9] == 'MOD':


### PR DESCRIPTION
PDB files in the protein-ligand benchmarks have `TURN` in their header, which prevents ParmEd from reading the PDB files correctly. I'm not sure how these were prepared, but I think it comes from Maestro. I'm also not sure if this is within spec of the PDB format, but this change seems innocuous and allows processing of the benchmark set in ParmEd.