### PR TITLE
Fixed deepcopy for Atom.

### DIFF
--- a/parmed/topologyobjects.py
+++ b/parmed/topologyobjects.py
@@ -570,6 +570,10 @@ class Atom(_ListItem):
         """ Returns a deep copy of this atom, but not attached to any list """
         return type(self)._copy(self)
 
+    def __deepcopy__(self):
+        """ Returns a deep copy of this atom, but not attached to any list """
+        return type(self)._copy(self)
+
     #===================================================
 
     @property


### PR DESCRIPTION
This PR is to fix a deepcopy-related bug that results in error for calls like `deepcopy(atom)` if Atom.__deepcopy__ is not defined.