### PR TITLE
Copy impropers when compressing

### DIFF
--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -497,7 +497,7 @@ class OpenMMParameterSet(ParameterSet, CharmmImproperMatchingMixin, metaclass=Fi
             else:
                 # Store this improper
                 unique_keys[unique_key] = atoms
-                improper_types[atoms] = improper
+                improper_types[atoms] = copy(improper)
 
         self.improper_types = improper_types
 


### PR DESCRIPTION
Single-line change to address #1383.  Prevents the same improper object from having its parameters incremented multiple times in cases when this should not occur.