### PR TITLE
Resolve issue/1386, fix `numpy.compat` deprecation warning

### DIFF
--- a/parmed/utils/netcdf.py
+++ b/parmed/utils/netcdf.py
@@ -39,14 +39,24 @@ import weakref
 from operator import mul
 from collections import OrderedDict
 from platform import python_implementation
+from typing import Any
 
 import mmap as mm
 
 import numpy as np
-from numpy.compat import asbytes, asstr
 from numpy import frombuffer, dtype, empty, array, asarray
 from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
+
+def asbytes(s: Any) -> bytes:
+    """Ensures input is in bytes format. Mimics numpy.compat.asbytes"""
+    return str(s).encode("latin1") if isinstance(s, str) else s
+
+
+def asstr(b: Any) -> str:
+    """Ensures input is in string format. Mimics numpy.compat.asstr"""
+    return b.decode("latin1") if isinstance(b, bytes) else str(b)
+
 
 
 IS_PYPY = python_implementation() == 'PyPy'

--- a/test/test_parmed_genopen.py
+++ b/test/test_parmed_genopen.py
@@ -71,7 +71,8 @@ class TestGenopen(FileIOTestCase):
         with closing(genopen(url, 'r')) as f:
             self.assertEqual(f.read(), genopen(get_fn('4lzt.pdb.gz')).read())
 
-    @unittest.skipUnless(is_local(), 'Cannot download files from PDB with CI systems')
+    # @unittest.skipUnless(is_local(), 'Cannot download files from PDB with CI systems')
+    @unittest.skip('RCSB deprecated FTP protocol https://www.rcsb.org/news/feature/65562f0ad78e004e766a96c1')
     def test_read_ftp_URL(self):
         """ Tests genopen reading a ftp remote file """
         url = 'ftp://ftp.wwpdb.org/pub/pdb/data/structures/divided/mmCIF/05/205l.cif.gz'


### PR DESCRIPTION
`numpy.compat` has been deprecated in numpy 2 and will be released in future versions. To prevent this from breaking ParmEd, `asbytes` and `asstr` have been implemented in place in the `parmed/utls/netcdf.py` file.