### PR TITLE
Update dev environment and add testing for python 3.13

### DIFF
--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Optionally install AmberTools
-      if: ${{ matrix.python-version != 3.12 }}
+      if: ${{ matrix.python-version != 3.13 }}
       shell: bash -l {0}
       run: conda install "ambertools >=20.15" -c conda-forge -yq
 

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - name: Check out source code
@@ -42,7 +42,7 @@ jobs:
         bash -ex devtools/ci/install.sh
 
     - name: Upload Coverage Results
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       if: endsWith(github.ref, '/master')
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/devtools/environment-dev.yaml
+++ b/devtools/environment-dev.yaml
@@ -6,7 +6,7 @@ dependencies:
   - pandas
   - openmm >=7.6.0
   - netCDF4
-  - rdkit >=2020.09.4,<2024.03.1
+  - rdkit >=2020.09.4,<2024.09.5
   - nglview
   - networkx
   - lxml

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -68,7 +68,7 @@ class TestOpenMM(FileIOTestCase, EnergyTestCase):
         """ Tests automatic deserialization of an Integrator XML file """
         integrator = openmm.XmlFile.parse(get_fn('integrator.xml'))
         self.assertIsInstance(integrator, mm.Integrator)
-        self.assertIsInstance(integrator, mm.LangevinIntegrator)
+        self.assertIsInstance(integrator, mm.LangevinMiddleIntegrator)
 
     def test_deserialize_force_field(self):
         """ Tests automatic deserialization of an OpenMM ForceField XML file """


### PR DESCRIPTION
A project I'm working on is looking at adding testing and support for python 3.13. Parmed is one of the dependencies that can't be installed via conda-forge with python 3.13. I played around with installing from source along with python 3.13, and everything seems to work correctly after bumping up the version of `rdkit` in the `environment-dev.yaml` file. I figured it would be worth making a PR that includes this change and adds python 3.13 to the test matrix.


